### PR TITLE
New terms 0.92.3

### DIFF
--- a/0.92/de.po
+++ b/0.92/de.po
@@ -22,7 +22,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: inkscape\n"
 "Report-Msgid-Bugs-To: inkscape-devel@lists.sourceforge.net\n"
-"POT-Creation-Date: 2017-07-24 23:11+0200\n"
+"POT-Creation-Date: 2018-02-03 23:41+0100\n"
 "PO-Revision-Date: 2017-08-05 00:39+0100\n"
 "Last-Translator: Eduard Braun <eduard.braun2@gmx.de>\n"
 "Language-Team: German <kde-i18n-de@kde.org>\n"
@@ -346,7 +346,7 @@ msgstr "Simuliere Ölgemälde"
 
 #. Pencil
 #: ../share/filters/filters.svg.h:78
-#: ../src/ui/dialog/inkscape-preferences.cpp:433
+#: ../src/ui/dialog/inkscape-preferences.cpp:451
 msgid "Pencil"
 msgstr "Malwerkzeug (Freihand)"
 
@@ -4471,7 +4471,7 @@ msgstr "Ohne Ebenen, leer"
 
 #. 3D box
 #: ../src/box3d.cpp:255 ../src/box3d.cpp:1309
-#: ../src/ui/dialog/inkscape-preferences.cpp:416
+#: ../src/ui/dialog/inkscape-preferences.cpp:434
 msgid "3D Box"
 msgstr "3D-Box"
 
@@ -4537,8 +4537,8 @@ msgid "_Origin X:"
 msgstr "_Ursprung X:"
 
 #: ../src/display/canvas-axonomgrid.cpp:359 ../src/display/canvas-grid.cpp:715
-#: ../src/ui/dialog/inkscape-preferences.cpp:786
-#: ../src/ui/dialog/inkscape-preferences.cpp:811
+#: ../src/ui/dialog/inkscape-preferences.cpp:804
+#: ../src/ui/dialog/inkscape-preferences.cpp:829
 msgid "X coordinate of grid origin"
 msgstr "X-Koordinate des Gitterursprungs"
 
@@ -4547,8 +4547,8 @@ msgid "O_rigin Y:"
 msgstr "U_rsprung Y:"
 
 #: ../src/display/canvas-axonomgrid.cpp:362 ../src/display/canvas-grid.cpp:718
-#: ../src/ui/dialog/inkscape-preferences.cpp:787
-#: ../src/ui/dialog/inkscape-preferences.cpp:812
+#: ../src/ui/dialog/inkscape-preferences.cpp:805
+#: ../src/ui/dialog/inkscape-preferences.cpp:830
 msgid "Y coordinate of grid origin"
 msgstr "Y-Koordinate des Gitterursprungs"
 
@@ -4557,29 +4557,29 @@ msgid "Spacing _Y:"
 msgstr "Abstand _Y:"
 
 #: ../src/display/canvas-axonomgrid.cpp:365
-#: ../src/ui/dialog/inkscape-preferences.cpp:815
+#: ../src/ui/dialog/inkscape-preferences.cpp:833
 msgid "Base length of z-axis"
 msgstr "Basislänge der Z-Achse"
 
 #: ../src/display/canvas-axonomgrid.cpp:368
-#: ../src/ui/dialog/inkscape-preferences.cpp:818
+#: ../src/ui/dialog/inkscape-preferences.cpp:836
 #: ../src/widgets/box3d-toolbar.cpp:302
 msgid "Angle X:"
 msgstr "Winkel X:"
 
 #: ../src/display/canvas-axonomgrid.cpp:368
-#: ../src/ui/dialog/inkscape-preferences.cpp:818
+#: ../src/ui/dialog/inkscape-preferences.cpp:836
 msgid "Angle of x-axis"
 msgstr "Winkel der X-Achse"
 
 #: ../src/display/canvas-axonomgrid.cpp:370
-#: ../src/ui/dialog/inkscape-preferences.cpp:819
+#: ../src/ui/dialog/inkscape-preferences.cpp:837
 #: ../src/widgets/box3d-toolbar.cpp:381
 msgid "Angle Z:"
 msgstr "Winkel Z:"
 
 #: ../src/display/canvas-axonomgrid.cpp:370
-#: ../src/ui/dialog/inkscape-preferences.cpp:819
+#: ../src/ui/dialog/inkscape-preferences.cpp:837
 msgid "Angle of z-axis"
 msgstr "Winkel der Z-Achse"
 
@@ -4588,7 +4588,7 @@ msgid "Minor grid line _color:"
 msgstr "Nebengitterlinienfarbe:"
 
 #: ../src/display/canvas-axonomgrid.cpp:374 ../src/display/canvas-grid.cpp:729
-#: ../src/ui/dialog/inkscape-preferences.cpp:770
+#: ../src/ui/dialog/inkscape-preferences.cpp:788
 msgid "Minor grid line color"
 msgstr "Nebengitterlinienfarbe:"
 
@@ -4601,7 +4601,7 @@ msgid "Ma_jor grid line color:"
 msgstr "Farbe der _dicken Gitterlinien:"
 
 #: ../src/display/canvas-axonomgrid.cpp:379 ../src/display/canvas-grid.cpp:734
-#: ../src/ui/dialog/inkscape-preferences.cpp:772
+#: ../src/ui/dialog/inkscape-preferences.cpp:790
 msgid "Major grid line color"
 msgstr "Farbe der dicken Gitterlinien"
 
@@ -4670,12 +4670,12 @@ msgid "Spacing _X:"
 msgstr "Abstand _X:"
 
 #: ../src/display/canvas-grid.cpp:721
-#: ../src/ui/dialog/inkscape-preferences.cpp:792
+#: ../src/ui/dialog/inkscape-preferences.cpp:810
 msgid "Distance between vertical grid lines"
 msgstr "Abstand der vertikalen Gitterlinien"
 
 #: ../src/display/canvas-grid.cpp:724
-#: ../src/ui/dialog/inkscape-preferences.cpp:793
+#: ../src/ui/dialog/inkscape-preferences.cpp:811
 msgid "Distance between horizontal grid lines"
 msgstr "Abstand der horizontalen Gitterlinien"
 
@@ -5069,7 +5069,7 @@ msgstr ""
 "Inkscape-Webseite oder wenden Sie sich an die Mailingliste, wenn Sie Fragen "
 "zu dieser Erweiterung haben."
 
-#: ../src/extension/implementation/script.cpp:1111
+#: ../src/extension/implementation/script.cpp:1119
 msgid ""
 "Inkscape has received additional data from the script executed.  The script "
 "did not return an error, but this may indicate the results will not be as "
@@ -5959,42 +5959,42 @@ msgid "EMF Output"
 msgstr "EMF-Ausgabe"
 
 #: ../src/extension/internal/emf-inout.cpp:3633
-#: ../src/extension/internal/wmf-inout.cpp:3212
+#: ../src/extension/internal/wmf-inout.cpp:3222
 msgid "Convert texts to paths"
 msgstr "Texte in Pfade umwandeln"
 
 #: ../src/extension/internal/emf-inout.cpp:3634
-#: ../src/extension/internal/wmf-inout.cpp:3213
+#: ../src/extension/internal/wmf-inout.cpp:3223
 msgid "Map Unicode to Symbol font"
 msgstr "Unicode-Zeichen mit „Symbol“-Schriftart darstellen"
 
 #: ../src/extension/internal/emf-inout.cpp:3635
-#: ../src/extension/internal/wmf-inout.cpp:3214
+#: ../src/extension/internal/wmf-inout.cpp:3224
 msgid "Map Unicode to Wingdings"
 msgstr "Unicode-Zeichen mit „Wingdings“-Schriftart darstellen"
 
 #: ../src/extension/internal/emf-inout.cpp:3636
-#: ../src/extension/internal/wmf-inout.cpp:3215
+#: ../src/extension/internal/wmf-inout.cpp:3225
 msgid "Map Unicode to Zapf Dingbats"
 msgstr "Unicode-Zeichen mit „Zapf Dingbats“-Schriftart darstellen"
 
 #: ../src/extension/internal/emf-inout.cpp:3637
-#: ../src/extension/internal/wmf-inout.cpp:3216
+#: ../src/extension/internal/wmf-inout.cpp:3226
 msgid "Use MS Unicode PUA (0xF020-0xF0FF) for converted characters"
 msgstr "„MS Unicode PUA“ (0xF020-0xF0FF) für umgewandelte Zeichen verwenden"
 
 #: ../src/extension/internal/emf-inout.cpp:3638
-#: ../src/extension/internal/wmf-inout.cpp:3217
+#: ../src/extension/internal/wmf-inout.cpp:3227
 msgid "Compensate for PPT font bug"
 msgstr "PPT-Schriftarten-Fehler kompensieren"
 
 #: ../src/extension/internal/emf-inout.cpp:3639
-#: ../src/extension/internal/wmf-inout.cpp:3218
+#: ../src/extension/internal/wmf-inout.cpp:3228
 msgid "Convert dashed/dotted lines to single lines"
 msgstr "Gestrichelte/gepunktete Linien in zusammenhängende Linien umwandeln"
 
 #: ../src/extension/internal/emf-inout.cpp:3640
-#: ../src/extension/internal/wmf-inout.cpp:3219
+#: ../src/extension/internal/wmf-inout.cpp:3229
 msgid "Convert gradients to colored polygon series"
 msgstr "Farbverläufe in mehrere farbige Polygone umwandeln"
 
@@ -6100,7 +6100,7 @@ msgstr "Hervorhebungsfarbe"
 #: ../src/extension/internal/filter/transparency.h:214
 #: ../src/extension/internal/filter/transparency.h:287
 #: ../src/extension/internal/filter/transparency.h:349
-#: ../src/ui/dialog/inkscape-preferences.cpp:1801
+#: ../src/ui/dialog/inkscape-preferences.cpp:1823
 #, c-format
 msgid "Filters"
 msgstr "Filter"
@@ -6311,7 +6311,7 @@ msgstr "Mischmodus:"
 #: ../src/extension/internal/filter/paint.h:702
 #: ../src/extension/internal/filter/textures.h:77
 #: ../src/extension/internal/filter/transparency.h:61
-#: ../src/filter-enums.cpp:52 ../src/ui/dialog/inkscape-preferences.cpp:693
+#: ../src/filter-enums.cpp:52 ../src/ui/dialog/inkscape-preferences.cpp:711
 msgid "Normal"
 msgstr "Normal"
 
@@ -6350,7 +6350,7 @@ msgstr "Stoß-Quelle"
 #: ../src/extension/internal/filter/transparency.h:132
 #: ../src/filter-enums.cpp:128 ../src/ui/tools/flood-tool.cpp:92
 #: ../src/ui/widget/color-icc-selector.cpp:176
-#: ../src/ui/widget/color-scales.cpp:385 ../src/ui/widget/color-scales.cpp:386
+#: ../src/ui/widget/color-scales.cpp:386 ../src/ui/widget/color-scales.cpp:387
 msgid "Red"
 msgstr "Rot"
 
@@ -6362,7 +6362,7 @@ msgstr "Rot"
 #: ../src/extension/internal/filter/transparency.h:133
 #: ../src/filter-enums.cpp:129 ../src/ui/tools/flood-tool.cpp:93
 #: ../src/ui/widget/color-icc-selector.cpp:177
-#: ../src/ui/widget/color-scales.cpp:388 ../src/ui/widget/color-scales.cpp:389
+#: ../src/ui/widget/color-scales.cpp:389 ../src/ui/widget/color-scales.cpp:390
 msgid "Green"
 msgstr "Grün"
 
@@ -6374,7 +6374,7 @@ msgstr "Grün"
 #: ../src/extension/internal/filter/transparency.h:134
 #: ../src/filter-enums.cpp:130 ../src/ui/tools/flood-tool.cpp:94
 #: ../src/ui/widget/color-icc-selector.cpp:178
-#: ../src/ui/widget/color-scales.cpp:391 ../src/ui/widget/color-scales.cpp:392
+#: ../src/ui/widget/color-scales.cpp:392 ../src/ui/widget/color-scales.cpp:393
 #: ../share/extensions/nicechart.inx.h:34
 msgid "Blue"
 msgstr "Blau"
@@ -6413,7 +6413,7 @@ msgstr "Höhe"
 #: ../src/extension/internal/filter/paint.h:707
 #: ../src/ui/tools/flood-tool.cpp:97
 #: ../src/ui/widget/color-icc-selector.cpp:187
-#: ../src/ui/widget/color-scales.cpp:417 ../src/ui/widget/color-scales.cpp:418
+#: ../src/ui/widget/color-scales.cpp:418 ../src/ui/widget/color-scales.cpp:419
 #: ../src/widgets/tweak-toolbar.cpp:318
 msgid "Lightness"
 msgstr "Helligkeit"
@@ -6437,7 +6437,7 @@ msgid "Distant"
 msgstr "Entfernt"
 
 #: ../src/extension/internal/filter/bumps.h:106
-#: ../src/ui/dialog/inkscape-preferences.cpp:470
+#: ../src/ui/dialog/inkscape-preferences.cpp:488
 msgid "Point"
 msgstr "Punkt"
 
@@ -6608,11 +6608,11 @@ msgstr "Kanalfarbe"
 #: ../src/extension/internal/filter/color.h:157
 #: ../src/extension/internal/filter/color.h:332
 #: ../src/extension/internal/filter/paint.h:87 ../src/filter-enums.cpp:66
-#: ../src/ui/dialog/inkscape-preferences.cpp:992
+#: ../src/ui/dialog/inkscape-preferences.cpp:1010
 #: ../src/ui/tools/flood-tool.cpp:96
 #: ../src/ui/widget/color-icc-selector.cpp:183
 #: ../src/ui/widget/color-icc-selector.cpp:188
-#: ../src/ui/widget/color-scales.cpp:414 ../src/ui/widget/color-scales.cpp:415
+#: ../src/ui/widget/color-scales.cpp:415 ../src/ui/widget/color-scales.cpp:416
 #: ../src/widgets/tweak-toolbar.cpp:302
 msgid "Saturation"
 msgstr "Sättigung"
@@ -6790,21 +6790,21 @@ msgstr "Kanal extrahieren"
 #: ../src/extension/internal/filter/color.h:715
 #: ../src/ui/widget/color-icc-selector.cpp:190
 #: ../src/ui/widget/color-icc-selector.cpp:195
-#: ../src/ui/widget/color-scales.cpp:439 ../src/ui/widget/color-scales.cpp:440
+#: ../src/ui/widget/color-scales.cpp:440 ../src/ui/widget/color-scales.cpp:441
 msgid "Cyan"
 msgstr "Zyan"
 
 #: ../src/extension/internal/filter/color.h:716
 #: ../src/ui/widget/color-icc-selector.cpp:191
 #: ../src/ui/widget/color-icc-selector.cpp:196
-#: ../src/ui/widget/color-scales.cpp:442 ../src/ui/widget/color-scales.cpp:443
+#: ../src/ui/widget/color-scales.cpp:443 ../src/ui/widget/color-scales.cpp:444
 msgid "Magenta"
 msgstr "Magenta"
 
 #: ../src/extension/internal/filter/color.h:717
 #: ../src/ui/widget/color-icc-selector.cpp:192
 #: ../src/ui/widget/color-icc-selector.cpp:197
-#: ../src/ui/widget/color-scales.cpp:445 ../src/ui/widget/color-scales.cpp:446
+#: ../src/ui/widget/color-scales.cpp:446 ../src/ui/widget/color-scales.cpp:447
 msgid "Yellow"
 msgstr "Gelb"
 
@@ -6830,7 +6830,7 @@ msgstr "Ausblenden zu:"
 
 #: ../src/extension/internal/filter/color.h:819
 #: ../src/ui/widget/color-icc-selector.cpp:193
-#: ../src/ui/widget/color-scales.cpp:448 ../src/ui/widget/color-scales.cpp:449
+#: ../src/ui/widget/color-scales.cpp:449 ../src/ui/widget/color-scales.cpp:450
 #: ../src/ui/widget/selected-style.cpp:275
 msgid "Black"
 msgstr "Schwarz"
@@ -7850,13 +7850,13 @@ msgstr ""
 "alle Dateien gemeinsam verschoben oder kopiert werden."
 
 #: ../src/extension/internal/gdkpixbuf-input.cpp:196
-#: ../src/ui/dialog/inkscape-preferences.cpp:1506
+#: ../src/ui/dialog/inkscape-preferences.cpp:1528
 #, c-format
 msgid "Embed"
 msgstr "Einbetten"
 
 #: ../src/extension/internal/gdkpixbuf-input.cpp:197 ../src/sp-anchor.cpp:105
-#: ../src/ui/dialog/inkscape-preferences.cpp:1506
+#: ../src/ui/dialog/inkscape-preferences.cpp:1528
 #, c-format
 msgid "Link"
 msgstr "Verknüpfen"
@@ -7900,19 +7900,19 @@ msgstr ""
 "(Funktioniert nicht in allen Browsern.)"
 
 #: ../src/extension/internal/gdkpixbuf-input.cpp:206
-#: ../src/ui/dialog/inkscape-preferences.cpp:1513
+#: ../src/ui/dialog/inkscape-preferences.cpp:1535
 #, c-format
 msgid "None (auto)"
 msgstr "Keine (automatisch)"
 
 #: ../src/extension/internal/gdkpixbuf-input.cpp:207
-#: ../src/ui/dialog/inkscape-preferences.cpp:1513
+#: ../src/ui/dialog/inkscape-preferences.cpp:1535
 #, c-format
 msgid "Smooth (optimizeQuality)"
 msgstr "Glätten (verbesserte Qualität)"
 
 #: ../src/extension/internal/gdkpixbuf-input.cpp:208
-#: ../src/ui/dialog/inkscape-preferences.cpp:1513
+#: ../src/ui/dialog/inkscape-preferences.cpp:1535
 #, c-format
 msgid "Blocky (optimizeSpeed)"
 msgstr "Pixelig (verbesserte Geschwindigkeit)"
@@ -7966,7 +7966,7 @@ msgid "Vertical Offset:"
 msgstr "Vertikaler Versatz:"
 
 #: ../src/extension/internal/grid.cpp:209
-#: ../src/ui/dialog/inkscape-preferences.cpp:1527
+#: ../src/ui/dialog/inkscape-preferences.cpp:1549
 #: ../share/extensions/draw_from_triangle.inx.h:58
 #: ../share/extensions/eqtexsvg.inx.h:4 ../share/extensions/foldablebox.inx.h:9
 #: ../share/extensions/funcplot.inx.h:38
@@ -7997,8 +7997,8 @@ msgstr "Rendern"
 
 #: ../src/extension/internal/grid.cpp:210
 #: ../src/ui/dialog/document-properties.cpp:163
-#: ../src/ui/dialog/inkscape-preferences.cpp:827
-#: ../src/widgets/toolbox.cpp:1902
+#: ../src/ui/dialog/inkscape-preferences.cpp:845
+#: ../src/widgets/toolbox.cpp:1901
 msgid "Grids"
 msgstr "Gitter"
 
@@ -8034,15 +8034,15 @@ msgstr "LaTeX-PSTricks-Datei"
 msgid "LaTeX Print"
 msgstr "LaTeX-Druck"
 
-#: ../src/extension/internal/odf.cpp:2138
+#: ../src/extension/internal/odf.cpp:2135
 msgid "OpenDocument Drawing Output"
 msgstr "OpenDocument-Zeichnungsausgabe"
 
-#: ../src/extension/internal/odf.cpp:2143
+#: ../src/extension/internal/odf.cpp:2140
 msgid "OpenDocument drawing (*.odg)"
 msgstr "OpenDocument-Zeichnung (*.odg)"
 
-#: ../src/extension/internal/odf.cpp:2144
+#: ../src/extension/internal/odf.cpp:2141
 msgid "OpenDocument drawing file"
 msgstr "OpenDocument-Zeichnungsdatei"
 
@@ -8170,27 +8170,27 @@ msgctxt "PDF input precision"
 msgid "very fine"
 msgstr "sehr fein"
 
-#: ../src/extension/internal/pdfinput/pdf-input.cpp:937
+#: ../src/extension/internal/pdfinput/pdf-input.cpp:943
 msgid "PDF Input"
 msgstr "PDF einlesen"
 
-#: ../src/extension/internal/pdfinput/pdf-input.cpp:942
+#: ../src/extension/internal/pdfinput/pdf-input.cpp:948
 msgid "Adobe PDF (*.pdf)"
 msgstr "Adobe PDF (*.pdf)"
 
-#: ../src/extension/internal/pdfinput/pdf-input.cpp:943
+#: ../src/extension/internal/pdfinput/pdf-input.cpp:949
 msgid "Adobe Portable Document Format"
 msgstr "Adobe Portable Document Format"
 
-#: ../src/extension/internal/pdfinput/pdf-input.cpp:950
+#: ../src/extension/internal/pdfinput/pdf-input.cpp:956
 msgid "AI Input"
 msgstr "AI einlesen"
 
-#: ../src/extension/internal/pdfinput/pdf-input.cpp:955
+#: ../src/extension/internal/pdfinput/pdf-input.cpp:961
 msgid "Adobe Illustrator 9.0 and above (*.ai)"
 msgstr "Adobe Illustrator 9.0 und neuer (*.ai)"
 
-#: ../src/extension/internal/pdfinput/pdf-input.cpp:956
+#: ../src/extension/internal/pdfinput/pdf-input.cpp:962
 msgid "Open files saved in Adobe Illustrator 9.0 and newer versions"
 msgstr "Mit Adobe Illustrator 9.0 oder neuer gespeicherte Dateien öffnen"
 
@@ -8315,32 +8315,32 @@ msgstr "VSDX einlesen"
 msgid "Microsoft Visio 2013 drawing (*.vsdx)"
 msgstr "Microsoft Visio 2013 Zeichnung (*´.vsdx)"
 
-#: ../src/extension/internal/wmf-inout.cpp:3196
+#: ../src/extension/internal/wmf-inout.cpp:3206
 msgid "WMF Input"
 msgstr "WMF einlesen"
 
-#: ../src/extension/internal/wmf-inout.cpp:3201
+#: ../src/extension/internal/wmf-inout.cpp:3211
 msgid "Windows Metafiles (*.wmf)"
 msgstr "Windows-Metadateien (*.wmf)"
 
-#: ../src/extension/internal/wmf-inout.cpp:3202
+#: ../src/extension/internal/wmf-inout.cpp:3212
 msgid "Windows Metafiles"
 msgstr "Windows-Metadateien"
 
-#: ../src/extension/internal/wmf-inout.cpp:3210
+#: ../src/extension/internal/wmf-inout.cpp:3220
 msgid "WMF Output"
 msgstr "WMF-Ausgabe"
 
-#: ../src/extension/internal/wmf-inout.cpp:3220
+#: ../src/extension/internal/wmf-inout.cpp:3230
 msgid "Map all fill patterns to standard WMF hatches"
 msgstr "Alle Füllmuster als Standard WMF-Muster verbinden"
 
-#: ../src/extension/internal/wmf-inout.cpp:3224
+#: ../src/extension/internal/wmf-inout.cpp:3234
 #: ../share/extensions/wmf_input.inx.h:2 ../share/extensions/wmf_output.inx.h:2
 msgid "Windows Metafile (*.wmf)"
 msgstr "Windows-Metadatei (*.wmf)"
 
-#: ../src/extension/internal/wmf-inout.cpp:3225
+#: ../src/extension/internal/wmf-inout.cpp:3235
 msgid "Windows Metafile"
 msgstr "Windows-Metadatei"
 
@@ -8374,7 +8374,7 @@ msgstr ""
 msgid "Convert legacy Inkscape file"
 msgstr "Ältere Inkscape-Datei aktualisieren"
 
-#: ../src/file-update.cpp:319
+#: ../src/file-update.cpp:320
 msgid ""
 "was created in an older version of Inkscape (90 DPI) and we need to make it "
 "compatible with newer versions (96 DPI). Tell us about this file:\n"
@@ -8383,7 +8383,7 @@ msgstr ""
 "erstellt, und wir müssen die Datei mit neueren Versionen (96 dpi) kompatibel "
 "machen. Bitte wähle eine Option:\n"
 
-#: ../src/file-update.cpp:327
+#: ../src/file-update.cpp:328
 msgid ""
 "This file contains digital artwork for screen display. <b>(Choose if "
 "unsure.)</b>"
@@ -8392,13 +8392,13 @@ msgstr ""
 "dargestellt werden soll. <b>(Wählen Sie dies aus, wenn Sie sich nicht sicher "
 "sind.)</b>"
 
-#: ../src/file-update.cpp:330
+#: ../src/file-update.cpp:331
 msgid "This file is intended for physical output, such as paper or 3D prints."
 msgstr ""
 "Diese Datei ist für die physikalische Ausgabe vorgesehen, z.B. als Ausdruck "
 "auf Papier oder in einem 3D-Drucker."
 
-#: ../src/file-update.cpp:332
+#: ../src/file-update.cpp:333
 msgid ""
 "The appearance of elements such as clips, masks, filters, and clones\n"
 "is most important. <b>(Choose if unsure.)</b>"
@@ -8407,7 +8407,7 @@ msgstr ""
 "maskierten Objekten, Filtern, Klonen,\n"
 "ist am wichtigsten. <b>(Auswählen, wenn unsicher.)</b>"
 
-#: ../src/file-update.cpp:336
+#: ../src/file-update.cpp:337
 msgid ""
 "The accuracy of the physical unit size and position values of objects\n"
 "in the file is most important. (Experimental.)"
@@ -8416,15 +8416,16 @@ msgstr ""
 "Objekten\n"
 "in der Datei sind besonders wichtig (experimentell)."
 
-#: ../src/file-update.cpp:338
+#: ../src/file-update.cpp:339
 msgid "Create a backup file in same directory."
 msgstr "Erstelle Sicherheitskopie im selben Verzeichnis."
 
-#: ../src/file-update.cpp:339
+#: ../src/file-update.cpp:340
 msgid "More details..."
 msgstr "Nähere Informationen..."
 
-#: ../src/file-update.cpp:342
+#: ../src/file-update.cpp:343
+#, fuzzy
 msgid ""
 "<small>We've updated Inkscape to follow the CSS standard of 96 DPI for "
 "better browser compatibility; we used to use 90 DPI. Digital artwork for "
@@ -8444,7 +8445,7 @@ msgid ""
 "printing.)\n"
 "\n"
 "More information about this change are available in the <a href='https://"
-"inkscape.org/en/learn/faq#todo-todo-todo'>Inkscape FAQ</a></small>"
+"inkscape.org/en/learn/faq#dpi_change'>Inkscape FAQ</a></small>"
 msgstr ""
 "<small>Wir haben Inkscape aktualisiert, um den CSS-Standard von 96 dpi "
 "Auflösung für bessere Kompatibilität mit Webbrowsern zu erfüllen. Früher "
@@ -8469,13 +8470,13 @@ msgstr ""
 "Mehr Informationen zu dieser Änderung gibt es in der <a href='https://"
 "inkscape.org/de/learn/faq#todo-todo-todo'>Inkscape-FAQ</a></small>"
 
-#: ../src/file-update.cpp:386
+#: ../src/file-update.cpp:387
 msgid "OK"
 msgstr "OK"
 
 #. Look for SPNamedView and SPDefs loop
 #. desktop->getDocument()->ensureUpToDate();  // Does not update box3d!
-#: ../src/file-update.cpp:569
+#: ../src/file-update.cpp:570
 msgid "Update Document"
 msgstr "Dokument aktualisieren"
 
@@ -8587,8 +8588,8 @@ msgstr "Es müssen keine Änderungen gespeichert werden."
 msgid "Saving document..."
 msgstr "Dokument wird gespeichert..."
 
-#: ../src/file.cpp:1280 ../src/ui/dialog/inkscape-preferences.cpp:1500
-#: ../src/ui/dialog/ocaldialogs.cpp:1244
+#: ../src/file.cpp:1280 ../src/ui/dialog/inkscape-preferences.cpp:1522
+#: ../src/ui/dialog/ocaldialogs.cpp:1245
 msgid "Import"
 msgstr "Importieren"
 
@@ -8696,7 +8697,7 @@ msgstr "Exklusiv-Oder (Ausschluss)"
 #: ../src/filter-enums.cpp:65 ../src/ui/tools/flood-tool.cpp:95
 #: ../src/ui/widget/color-icc-selector.cpp:182
 #: ../src/ui/widget/color-icc-selector.cpp:186
-#: ../src/ui/widget/color-scales.cpp:411 ../src/ui/widget/color-scales.cpp:412
+#: ../src/ui/widget/color-scales.cpp:412 ../src/ui/widget/color-scales.cpp:413
 #: ../src/widgets/tweak-toolbar.cpp:286
 msgid "Hue"
 msgstr "Farbton"
@@ -8764,7 +8765,7 @@ msgstr "Erhellen"
 msgid "Arithmetic"
 msgstr "Arithmetisch"
 
-#: ../src/filter-enums.cpp:120 ../src/selection-chemistry.cpp:545
+#: ../src/filter-enums.cpp:120 ../src/selection-chemistry.cpp:553
 #: ../src/ui/dialog/objects.cpp:1927
 msgid "Duplicate"
 msgstr "Duplizieren"
@@ -8978,17 +8979,17 @@ msgstr ""
 msgid "Autosave complete."
 msgstr "Automatisches Speichern abgeschlossen."
 
-#: ../src/inkscape.cpp:618
+#: ../src/inkscape.cpp:619
 msgid "Untitled document"
 msgstr "Unbenanntes Dokument"
 
 #. Show nice dialog box
-#: ../src/inkscape.cpp:650
+#: ../src/inkscape.cpp:651
 msgid "Inkscape encountered an internal error and will close now.\n"
 msgstr ""
 "Inkscape ist auf einen internen Fehler gestoßen und wird nun geschlossen.\n"
 
-#: ../src/inkscape.cpp:651
+#: ../src/inkscape.cpp:652
 msgid ""
 "Automatic backups of unsaved documents were done to the following "
 "locations:\n"
@@ -8996,7 +8997,7 @@ msgstr ""
 "Unter folgenden Speicherorten wurden automatische Sicherungskopien nicht "
 "gespeicherter Dokumente angelegt:\n"
 
-#: ../src/inkscape.cpp:652
+#: ../src/inkscape.cpp:653
 msgid "Automatic backup of the following documents failed:\n"
 msgstr ""
 "Anlegen von automatischen Sicherungskopien folgender Dokumente "
@@ -9224,8 +9225,8 @@ msgid "The index of the current page"
 msgstr "Aktuelle Seitennummer"
 
 #: ../src/libgdl/gdl-dock-object.c:125
-#: ../src/live_effects/parameter/originalpatharray.cpp:82
-#: ../src/ui/dialog/inkscape-preferences.cpp:1561
+#: ../src/live_effects/parameter/originalpatharray.cpp:87
+#: ../src/ui/dialog/inkscape-preferences.cpp:1583
 #: ../src/ui/widget/page-sizer.cpp:285 ../src/widgets/gradient-selector.cpp:150
 #: ../src/widgets/sp-xmlview-attr-list.cpp:49
 msgid "Name"
@@ -9396,8 +9397,8 @@ msgstr ""
 msgid "Dockitem which 'owns' this tablabel"
 msgstr "Dock-Objekt, dem dieser Tabbezeichner \"gehört\"."
 
-#: ../src/libgdl/gdl-dock.c:176 ../src/ui/dialog/inkscape-preferences.cpp:682
-#: ../src/ui/dialog/inkscape-preferences.cpp:725
+#: ../src/libgdl/gdl-dock.c:176 ../src/ui/dialog/inkscape-preferences.cpp:700
+#: ../src/ui/dialog/inkscape-preferences.cpp:743
 msgid "Floating"
 msgstr "Schwebend"
 
@@ -9623,7 +9624,7 @@ msgstr "Pfad anheften"
 msgid "Fill between strokes"
 msgstr "Zwischen Pfaden Füllen"
 
-#: ../src/live_effects/effect.cpp:152 ../src/selection-chemistry.cpp:2963
+#: ../src/live_effects/effect.cpp:152 ../src/selection-chemistry.cpp:2973
 msgid "Fill between many"
 msgstr "Zwischen Vielen Füllen"
 
@@ -9766,20 +9767,20 @@ msgid "Rotates the original 90 degrees, before bending it along the bend path"
 msgstr ""
 "Rotiert das Original um 90 Grad, bevor es entlang des Pfades gebogen wird"
 
-#: ../src/live_effects/lpe-bendpath.cpp:178
+#: ../src/live_effects/lpe-bendpath.cpp:179
 #: ../src/live_effects/lpe-patternalongpath.cpp:281
 msgid "Change the width"
 msgstr "Breite ändern"
 
 #: ../src/live_effects/lpe-bounding-box.cpp:24
-#: ../src/live_effects/lpe-clone-original.cpp:18
+#: ../src/live_effects/lpe-clone-original.cpp:24
 #: ../src/live_effects/lpe-fill-between-many.cpp:25
 #: ../src/live_effects/lpe-fill-between-strokes.cpp:23
 msgid "Linked path:"
 msgstr "Verknüpfter Pfad:"
 
 #: ../src/live_effects/lpe-bounding-box.cpp:24
-#: ../src/live_effects/lpe-clone-original.cpp:18
+#: ../src/live_effects/lpe-clone-original.cpp:24
 #: ../src/live_effects/lpe-fill-between-strokes.cpp:23
 msgid "Path from which to take the original path data"
 msgstr "Pfad, von dem die Orginal-Pfaddaten genommen werden"
@@ -10087,6 +10088,11 @@ msgstr "Definiert Richtung und Ausmaß der Extrusion"
 msgid "Paths from which to take the original path data"
 msgstr "Pfade, von denen die Orginal-Pfaddaten genommen werden"
 
+#: ../src/live_effects/lpe-fill-between-many.cpp:26
+#, fuzzy
+msgid "Allow transforms"
+msgstr "Transformationen"
+
 #: ../src/live_effects/lpe-fill-between-strokes.cpp:24
 msgid "Second path:"
 msgstr "Zweiter Pfad:"
@@ -10104,7 +10110,7 @@ msgid "Reverses the second path order"
 msgstr "Kehrt die Richtung des zweiten Pfads um"
 
 #: ../src/live_effects/lpe-fillet-chamfer.cpp:41
-#: ../src/widgets/text-toolbar.cpp:1905
+#: ../src/widgets/text-toolbar.cpp:1974
 #: ../share/extensions/render_barcode_qrcode.inx.h:5
 msgid "Auto"
 msgstr "Auto"
@@ -11372,13 +11378,13 @@ msgstr "Keine"
 
 #: ../src/live_effects/lpe-ruler.cpp:33
 #: ../src/live_effects/lpe-transform_2pts.cpp:37
-#: ../src/ui/tools/measure-tool.cpp:755 ../src/widgets/arc-toolbar.cpp:319
+#: ../src/ui/tools/measure-tool.cpp:755 ../src/widgets/arc-toolbar.cpp:473
 msgid "Start"
 msgstr "Anfang"
 
 #: ../src/live_effects/lpe-ruler.cpp:34
 #: ../src/live_effects/lpe-transform_2pts.cpp:38
-#: ../src/ui/tools/measure-tool.cpp:756 ../src/widgets/arc-toolbar.cpp:332
+#: ../src/ui/tools/measure-tool.cpp:756 ../src/widgets/arc-toolbar.cpp:486
 msgid "End"
 msgstr "Ende"
 
@@ -11783,7 +11789,7 @@ msgid "Change index of knot"
 msgstr "Knotenindex ändern"
 
 #: ../src/live_effects/lpe-transform_2pts.cpp:349
-#: ../src/ui/dialog/inkscape-preferences.cpp:1618
+#: ../src/ui/dialog/inkscape-preferences.cpp:1640
 #: ../src/ui/dialog/pixelartdialog.cpp:296
 #: ../src/ui/dialog/svg-fonts-dialog.cpp:697
 #: ../src/ui/dialog/tracedialog.cpp:813
@@ -11892,69 +11898,69 @@ msgstr ""
 "<b>Abrunden</b>: <b>Strg+Klick</b> Typ ändern, <b>Umschalt+Klick</b> Dialog "
 "öffnen, <b>Strg+Alt+Klick</b> zurücksetzen"
 
-#: ../src/live_effects/parameter/originalpath.cpp:67
-#: ../src/live_effects/parameter/originalpatharray.cpp:155
+#: ../src/live_effects/parameter/originalpath.cpp:68
+#: ../src/live_effects/parameter/originalpatharray.cpp:162
 msgid "Link to path"
 msgstr "Mit dem Pfad verknüpfen"
 
-#: ../src/live_effects/parameter/originalpath.cpp:79
+#: ../src/live_effects/parameter/originalpath.cpp:80
 msgid "Select original"
 msgstr "Original auswählen"
 
-#: ../src/live_effects/parameter/originalpatharray.cpp:90
+#: ../src/live_effects/parameter/originalpatharray.cpp:95
 #: ../src/widgets/gradient-toolbar.cpp:1205
 msgid "Reverse"
 msgstr "Umkehren"
 
-#: ../src/live_effects/parameter/originalpatharray.cpp:130
-#: ../src/live_effects/parameter/originalpatharray.cpp:315
-#: ../src/live_effects/parameter/path.cpp:509
+#: ../src/live_effects/parameter/originalpatharray.cpp:137
+#: ../src/live_effects/parameter/originalpatharray.cpp:322
+#: ../src/live_effects/parameter/path.cpp:516
 msgid "Link path parameter to path"
 msgstr "Pfadparameter mit Pfad verbinden"
 
-#: ../src/live_effects/parameter/originalpatharray.cpp:167
+#: ../src/live_effects/parameter/originalpatharray.cpp:174
 msgid "Remove Path"
 msgstr "Pfad entfernen"
 
-#: ../src/live_effects/parameter/originalpatharray.cpp:179
+#: ../src/live_effects/parameter/originalpatharray.cpp:186
 #: ../src/ui/dialog/objects.cpp:1888
 msgid "Move Down"
 msgstr "Nach unten"
 
-#: ../src/live_effects/parameter/originalpatharray.cpp:191
+#: ../src/live_effects/parameter/originalpatharray.cpp:198
 #: ../src/ui/dialog/objects.cpp:1896
 msgid "Move Up"
 msgstr "Nach oben"
 
-#: ../src/live_effects/parameter/originalpatharray.cpp:231
+#: ../src/live_effects/parameter/originalpatharray.cpp:238
 msgid "Move path up"
 msgstr "Pfad nach oben verschieben"
 
-#: ../src/live_effects/parameter/originalpatharray.cpp:261
+#: ../src/live_effects/parameter/originalpatharray.cpp:268
 msgid "Move path down"
 msgstr "Pfad nach unten verschieben"
 
-#: ../src/live_effects/parameter/originalpatharray.cpp:279
+#: ../src/live_effects/parameter/originalpatharray.cpp:286
 msgid "Remove path"
 msgstr "Pfad entfernen"
 
-#: ../src/live_effects/parameter/path.cpp:184
+#: ../src/live_effects/parameter/path.cpp:187
 msgid "Edit on-canvas"
 msgstr "Auf der Arbeitsfläche bearbeiten"
 
-#: ../src/live_effects/parameter/path.cpp:194
+#: ../src/live_effects/parameter/path.cpp:197
 msgid "Copy path"
 msgstr "Pfad kopieren"
 
-#: ../src/live_effects/parameter/path.cpp:204
+#: ../src/live_effects/parameter/path.cpp:207
 msgid "Paste path"
 msgstr "Pfad einfügen"
 
-#: ../src/live_effects/parameter/path.cpp:214
+#: ../src/live_effects/parameter/path.cpp:217
 msgid "Link to path on clipboard"
 msgstr "Mit Pfad aus der Zwischenablage verknüpfen"
 
-#: ../src/live_effects/parameter/path.cpp:477
+#: ../src/live_effects/parameter/path.cpp:484
 msgid "Paste path parameter"
 msgstr "Pfadparameter einfügen"
 
@@ -12007,42 +12013,42 @@ msgstr ""
 msgid "Unable to find node ID: '%s'\n"
 msgstr "Kann Knoten-Kennung „%s“ nicht finden.\n"
 
-#: ../src/main.cpp:304
+#: ../src/main.cpp:305
 msgid "Print the Inkscape version number"
 msgstr "Versionsnummer von Inkscape ausgeben"
 
-#: ../src/main.cpp:309
+#: ../src/main.cpp:310
 msgid "Do not use X server (only process files from console)"
 msgstr "X-Server nicht verwenden (Dateien nur mittels Konsole verarbeiten)"
 
-#: ../src/main.cpp:314
+#: ../src/main.cpp:315
 msgid "Try to use X server (even if $DISPLAY is not set)"
 msgstr ""
 "Versuche, den X-Server zu verwenden (auch wenn die Umgebungsvariable "
 "„$DISPLAY“ nicht gesetzt wurde)"
 
-#: ../src/main.cpp:319
+#: ../src/main.cpp:320
 msgid "Open specified document(s) (option string may be excluded)"
 msgstr ""
 "Angegebene Dokumente öffnen (Optionszeichenkette muss nicht übergeben werden)"
 
-#: ../src/main.cpp:320 ../src/main.cpp:325 ../src/main.cpp:330
-#: ../src/main.cpp:402 ../src/main.cpp:407 ../src/main.cpp:412
-#: ../src/main.cpp:423 ../src/main.cpp:439 ../src/main.cpp:444
+#: ../src/main.cpp:321 ../src/main.cpp:326 ../src/main.cpp:331
+#: ../src/main.cpp:403 ../src/main.cpp:408 ../src/main.cpp:413
+#: ../src/main.cpp:424 ../src/main.cpp:440 ../src/main.cpp:445
 msgid "FILENAME"
 msgstr "DATEINAME"
 
-#: ../src/main.cpp:324
+#: ../src/main.cpp:325
 msgid "Print document(s) to specified output file (use '| program' for pipe)"
 msgstr ""
 "Dokumente in angegebene Ausgabedatei drucken (verwenden Sie „| Programm“ zur "
 "Weiterleitung)"
 
-#: ../src/main.cpp:329
+#: ../src/main.cpp:330
 msgid "Export document to a PNG file"
 msgstr "Das Dokument in eine PNG-Datei exportieren"
 
-#: ../src/main.cpp:334
+#: ../src/main.cpp:335
 msgid ""
 "Resolution for exporting to bitmap and for rasterization of filters in PS/"
 "EPS/PDF (default 96)"
@@ -12050,11 +12056,11 @@ msgstr ""
 "Auflösung beim Exportieren von Bitmaps und für Rasterisierung von Filtern in "
 "PS/EPS/PDF (Standard ist 96)"
 
-#: ../src/main.cpp:335 ../src/ui/widget/rendering-options.cpp:37
+#: ../src/main.cpp:336 ../src/ui/widget/rendering-options.cpp:37
 msgid "DPI"
 msgstr "DPI"
 
-#: ../src/main.cpp:339
+#: ../src/main.cpp:340
 msgid ""
 "Exported area in SVG user units (default is the page; 0,0 is lower-left "
 "corner)"
@@ -12062,29 +12068,29 @@ msgstr ""
 "Exportierter Bereich in SVG-Benutzereinheiten (Standard: gesamte Seite, "
 "„0,0“ ist die untere linke Ecke)"
 
-#: ../src/main.cpp:340
+#: ../src/main.cpp:341
 msgid "x0:y0:x1:y1"
 msgstr "X0:Y0:X1:Y1"
 
-#: ../src/main.cpp:344
+#: ../src/main.cpp:345
 msgid "Exported area is the entire drawing (not page)"
 msgstr "Exportierter Bereich ist die gesamte Zeichnung (nicht die Seite)"
 
-#: ../src/main.cpp:349
+#: ../src/main.cpp:350
 msgid "Exported area is the entire page"
 msgstr "Exportierter Bereich ist die gesamte Seite"
 
-#: ../src/main.cpp:354
-msgid "Only for PS/EPS/PDF, sets margin in mm around exported area (default 0)"
+#: ../src/main.cpp:355
+msgid ""
+"Sets margin around exported area (default 0) in units of page size for SVG "
+"and mm for PS/EPS/PDF"
 msgstr ""
-"Nur für PS/EPS/PDF. Setzt einen Rand in mm um den exportierten Bereich "
-"(Standard 0)"
 
-#: ../src/main.cpp:355 ../src/main.cpp:397
+#: ../src/main.cpp:356 ../src/main.cpp:398
 msgid "VALUE"
 msgstr "WERT"
 
-#: ../src/main.cpp:359
+#: ../src/main.cpp:360
 msgid ""
 "Snap the bitmap export area outwards to the nearest integer values (in SVG "
 "user units)"
@@ -12092,78 +12098,78 @@ msgstr ""
 "Die Fläche für den Export einer Bitmap nach außen auf die nächsten "
 "Ganzzahlen aufrunden (in SVG-Benutzereinheiten)"
 
-#: ../src/main.cpp:364
+#: ../src/main.cpp:365
 msgid "The width of exported bitmap in pixels (overrides export-dpi)"
 msgstr "Breite der erzeugten Rastergrafik in Pixeln (überschreibt Export-dpi)"
 
-#: ../src/main.cpp:365
+#: ../src/main.cpp:366
 msgid "WIDTH"
 msgstr "BREITE"
 
-#: ../src/main.cpp:369
+#: ../src/main.cpp:370
 msgid "The height of exported bitmap in pixels (overrides export-dpi)"
 msgstr "Höhe der erzeugten Rastergrafik in Pixeln (überschreibt Export-dpi)"
 
-#: ../src/main.cpp:370
+#: ../src/main.cpp:371
 msgid "HEIGHT"
 msgstr "HÖHE"
 
 # Changed because this refers to object id in xml
-#: ../src/main.cpp:374
+#: ../src/main.cpp:375
 msgid "The ID of the object to export"
 msgstr "ID des zu exportierenden Objektes"
 
-#: ../src/main.cpp:375 ../src/main.cpp:488
-#: ../src/ui/dialog/inkscape-preferences.cpp:1564
+#: ../src/main.cpp:376 ../src/main.cpp:489
+#: ../src/ui/dialog/inkscape-preferences.cpp:1586
 msgid "ID"
 msgstr "ID"
 
 #. TRANSLATORS: this means: "Only export the object whose id is given in --export-id".
 #. See "man inkscape" for details.
-#: ../src/main.cpp:381
+#: ../src/main.cpp:382
 msgid ""
 "Export just the object with export-id, hide all others (only with export-id)"
 msgstr ""
 "Nur das Objekt mit der angegebenen Export-ID exportieren, alle anderen "
 "auslassen"
 
-#: ../src/main.cpp:386
+#: ../src/main.cpp:387
 msgid "Use stored filename and DPI hints when exporting (only with export-id)"
 msgstr ""
 "Verwende gespeicherten Dateinamen und DPI-Hinweise zum Exportieren (nur mit "
 "Export-ID)"
 
-#: ../src/main.cpp:391
+#: ../src/main.cpp:392
 msgid "Background color of exported bitmap (any SVG-supported color string)"
 msgstr ""
 "Hintergrundfarbe der exportierten Rastergrafik (jede von SVG unterstützte "
 "Farbzeichenkette)"
 
-#: ../src/main.cpp:392
+#: ../src/main.cpp:393
 msgid "COLOR"
 msgstr "FARBE"
 
-#: ../src/main.cpp:396
+#: ../src/main.cpp:397
 msgid "Background opacity of exported bitmap (either 0.0 to 1.0, or 1 to 255)"
 msgstr ""
 "Hintergrunddeckkraft der exportierten Rastergrafik (0,0 bis 1,0 oder 1 bis "
 "255)"
 
-#: ../src/main.cpp:401
+#: ../src/main.cpp:402
 msgid "Export document to plain SVG file (no sodipodi or inkscape namespaces)"
 msgstr ""
 "Dokument als reine SVG-Datei exportieren (ohne Sodipodi- oder Inkscape-"
 "Namensräume)"
 
-#: ../src/main.cpp:406
+#: ../src/main.cpp:407
 msgid "Export document to a PS file"
 msgstr "Das Dokument als PS-Datei exportieren"
 
-#: ../src/main.cpp:411
+#: ../src/main.cpp:412
 msgid "Export document to an EPS file"
 msgstr "Das Dokument als EPS-Datei exportieren"
 
-#: ../src/main.cpp:416
+#: ../src/main.cpp:417
 msgid ""
 "Choose the PostScript Level used to export. Possible choices are 2 and 3 "
 "(the default)"
@@ -12171,17 +12177,17 @@ msgstr ""
 "Wähle das PostScript-Level für den Export. Auswahlmöglichkeiten sind 2 und 3 "
 "(Standard)"
 
-#: ../src/main.cpp:418
+#: ../src/main.cpp:419
 msgid "PS Level"
 msgstr "PS-Level"
 
-#: ../src/main.cpp:422
+#: ../src/main.cpp:423
 msgid "Export document to a PDF file"
 msgstr "Das Dokument als PDF-Datei exportieren"
 
 # !!! would these quotes need to be kept as they are? Looks like it's explaining command line options.
 #. TRANSLATORS: "--export-pdf-version" is an Inkscape command line option; see "inkscape --help"
-#: ../src/main.cpp:428
+#: ../src/main.cpp:429
 msgid ""
 "Export PDF to given version. (hint: make sure to input the exact string "
 "found in the PDF export dialog, e.g. \"1.4\" which is PDF-a conformant)"
@@ -12190,11 +12196,11 @@ msgstr ""
 "dass die Version exakt wie im PDF-Export-Dialog angegeben wird, z. B. "
 "Beispiel \"1.4\", dieses ist PDF/A-konform)"
 
-#: ../src/main.cpp:429
+#: ../src/main.cpp:430
 msgid "PDF_VERSION"
 msgstr "PDF_VERSION"
 
-#: ../src/main.cpp:433
+#: ../src/main.cpp:434
 msgid ""
 "Export PDF/PS/EPS without text. Besides the PDF/PS/EPS, a LaTeX file is "
 "exported, putting the text on top of the PDF/PS/EPS file. Include the result "
@@ -12204,26 +12210,26 @@ msgstr ""
 "exportiert, die den Text über die PDF/PS/EPS-Datei legt. Einbinden des "
 "Ergebnisses in Latex mit: \\input{latexfile.tex}"
 
-#: ../src/main.cpp:438
+#: ../src/main.cpp:439
 msgid "Export document to an Enhanced Metafile (EMF) File"
 msgstr "Dokument als Erweiterte Metadatei (EMF) exportieren"
 
-#: ../src/main.cpp:443
+#: ../src/main.cpp:444
 msgid "Export document to a Windows Metafile (WMF) File"
 msgstr "Dokument als Windows-Metadatei (WMF) exportieren"
 
-#: ../src/main.cpp:448
+#: ../src/main.cpp:449
 msgid "Convert text object to paths on export (PS, EPS, PDF, SVG)"
 msgstr "Textelemente beim Export (PS, EPS, PDF, SVG) in Pfade umwandeln"
 
-#: ../src/main.cpp:453
+#: ../src/main.cpp:454
 msgid ""
 "Render filtered objects without filters, instead of rasterizing (PS, EPS, "
 "PDF)"
 msgstr "Objekte ohne Filter zeichnen, statt Rasterisierung (PS, EPS, PDF)"
 
 #. TRANSLATORS: "--query-id" is an Inkscape command line option; see "inkscape --help"
-#: ../src/main.cpp:459
+#: ../src/main.cpp:460
 msgid ""
 "Query the X coordinate of the drawing or, if specified, of the object with --"
 "query-id"
@@ -12232,7 +12238,7 @@ msgstr ""
 "Objektes"
 
 #. TRANSLATORS: "--query-id" is an Inkscape command line option; see "inkscape --help"
-#: ../src/main.cpp:465
+#: ../src/main.cpp:466
 msgid ""
 "Query the Y coordinate of the drawing or, if specified, of the object with --"
 "query-id"
@@ -12241,7 +12247,7 @@ msgstr ""
 "Objektes"
 
 #. TRANSLATORS: "--query-id" is an Inkscape command line option; see "inkscape --help"
-#: ../src/main.cpp:471
+#: ../src/main.cpp:472
 msgid ""
 "Query the width of the drawing or, if specified, of the object with --query-"
 "id"
@@ -12250,35 +12256,35 @@ msgstr ""
 "Objektes"
 
 #. TRANSLATORS: "--query-id" is an Inkscape command line option; see "inkscape --help"
-#: ../src/main.cpp:477
+#: ../src/main.cpp:478
 msgid ""
 "Query the height of the drawing or, if specified, of the object with --query-"
 "id"
 msgstr ""
 "Abfragen der Höhe der Zeichnung oder des mit --query-id angegebenen Objektes"
 
-#: ../src/main.cpp:482
+#: ../src/main.cpp:483
 msgid "List id,x,y,w,h for all objects"
 msgstr "id, x, y, w und h für alle Objekte auflisten"
 
-#: ../src/main.cpp:487
+#: ../src/main.cpp:488
 msgid "The ID of the object whose dimensions are queried"
 msgstr "ID des Objektes, dessen Abmessungen abgefragt werden"
 
 #. TRANSLATORS: this option makes Inkscape print the name (path) of the extension directory
-#: ../src/main.cpp:493
+#: ../src/main.cpp:494
 msgid "Print out the extension directory and exit"
 msgstr "Erweiterungsverzeichnis ausgeben und beenden"
 
-#: ../src/main.cpp:498
+#: ../src/main.cpp:499
 msgid "Remove unused definitions from the defs section(s) of the document"
 msgstr "Unbenutzte Elemente aus den <defs> des Dokuments entfernen"
 
-#: ../src/main.cpp:504
+#: ../src/main.cpp:505
 msgid "Enter a listening loop for D-Bus messages in console mode"
 msgstr "Warteschleife für D-Bus-Nachrichten im Konsolen-Modus eingeben"
 
-#: ../src/main.cpp:509
+#: ../src/main.cpp:510
 msgid ""
 "Specify the D-Bus bus name to listen for messages on (default is org."
 "inkscape)"
@@ -12286,45 +12292,48 @@ msgstr ""
 "D-Bus-Namen angeben, dessen Nachrichten angezeigt werden sollen (Standard "
 "ist org.inkscape)"
 
-#: ../src/main.cpp:510
+#: ../src/main.cpp:511
 msgid "BUS-NAME"
 msgstr "BUS-NAME"
 
-#: ../src/main.cpp:515
+#: ../src/main.cpp:516
 msgid "List the IDs of all the verbs in Inkscape"
 msgstr "Listet die ID aller Verben in Inkscape"
 
-#: ../src/main.cpp:520
+#: ../src/main.cpp:521
 msgid "Verb to call when Inkscape opens."
 msgstr "Aufzurufendes Verb wenn Inkscape startet"
 
-#: ../src/main.cpp:521
+#: ../src/main.cpp:522
 msgid "VERB-ID"
 msgstr "VERB-ID"
 
-#: ../src/main.cpp:525
+#: ../src/main.cpp:526
 msgid "Object ID to select when Inkscape opens."
 msgstr "ID des Objektes, das beim Start von Inkscape ausgewählt werden soll"
 
-#: ../src/main.cpp:526
+#: ../src/main.cpp:527
 msgid "OBJECT-ID"
 msgstr "OBJECT-ID"
 
-#: ../src/main.cpp:530
+#: ../src/main.cpp:531
 msgid "Start Inkscape in interactive shell mode."
 msgstr "Inkscape in interaktivem Konsolenmodus starten."
 
-#: ../src/main.cpp:535
+#: ../src/main.cpp:536
 msgid "Do not fix legacy (pre-0.92) files' text baseline spacing on opening."
 msgstr ""
 "Linienabstand von Dokumenten die in älteren Inkscape-Versionen (0.91 und "
 "früher) erstellt wurden beim Öffnen nicht automatisch korrigieren."
 
-#: ../src/main.cpp:540
-msgid "Method used to convert pre-.92 document dpi, if needed."
+#: ../src/main.cpp:541
+#, fuzzy
+msgid ""
+"Method used to convert pre-.92 document dpi, if needed. ([none|scale-viewbox|"
+"scale-document])"
 msgstr "Methode zur DPI-Konvertierung von pre-0.92-Dokumenten"
 
-#: ../src/main.cpp:890 ../src/main.cpp:1363
+#: ../src/main.cpp:891 ../src/main.cpp:1379
 msgid ""
 "[OPTIONS...] [FILE...]\n"
 "\n"
@@ -12619,7 +12628,7 @@ msgstr "Open-Font-Lizenz"
 
 #. Create the Title label and edit control
 #. TRANSLATORS: for info, see http://www.w3.org/TR/2000/CR-SVG-20000802/linking.html#AElementXLinkTitleAttribute
-#: ../src/rdf.cpp:235 ../src/ui/dialog/filedialogimpl-win32.cpp:1885
+#: ../src/rdf.cpp:235 ../src/ui/dialog/filedialogimpl-win32.cpp:1886
 #: ../src/ui/dialog/object-attributes.cpp:57
 msgid "Title:"
 msgstr "Titel:"
@@ -12700,7 +12709,7 @@ msgstr "Beziehung:"
 msgid "A related resource"
 msgstr "Zugehöriges Dokument"
 
-#: ../src/rdf.cpp:267 ../src/ui/dialog/inkscape-preferences.cpp:1924
+#: ../src/rdf.cpp:267 ../src/ui/dialog/inkscape-preferences.cpp:1946
 msgid "Language:"
 msgstr "Sprache:"
 
@@ -12785,7 +12794,7 @@ msgstr "Es wurde <b>nichts</b> gelöscht."
 
 #: ../src/selection-chemistry.cpp:426
 #: ../src/ui/dialog/calligraphic-profile-rename.cpp:75
-#: ../src/ui/dialog/swatches.cpp:277 ../src/ui/tools/text-tool.cpp:965
+#: ../src/ui/dialog/swatches.cpp:278 ../src/ui/tools/text-tool.cpp:965
 #: ../src/widgets/eraser-toolbar.cpp:120
 #: ../src/widgets/gradient-toolbar.cpp:1181
 #: ../src/widgets/gradient-toolbar.cpp:1195
@@ -12797,58 +12806,58 @@ msgstr "Löschen"
 msgid "Select <b>object(s)</b> to duplicate."
 msgstr "<b>Objekt(e)</b> zum Duplizieren auswählen."
 
-#: ../src/selection-chemistry.cpp:551
+#: ../src/selection-chemistry.cpp:559
 #, c-format
 msgid "%s copy"
 msgstr "%s Kopie"
 
-#: ../src/selection-chemistry.cpp:574
+#: ../src/selection-chemistry.cpp:582
 msgid "Delete all"
 msgstr "Alles löschen"
 
-#: ../src/selection-chemistry.cpp:762
+#: ../src/selection-chemistry.cpp:770
 msgid "Select <b>some objects</b> to group."
 msgstr "<b>Einige Objekte</b> zum Gruppieren auswählen."
 
-#: ../src/selection-chemistry.cpp:775
+#: ../src/selection-chemistry.cpp:783
 msgctxt "Verb"
 msgid "Group"
 msgstr "Gruppieren"
 
-#: ../src/selection-chemistry.cpp:798
+#: ../src/selection-chemistry.cpp:806
 msgid "<b>No objects selected</b> to pop out of group."
 msgstr ""
 "<b>Keine Objekte ausgewählt</b>, die aus der Gruppe herausgelöst werden "
 "könnten."
 
-#: ../src/selection-chemistry.cpp:808
+#: ../src/selection-chemistry.cpp:816
 msgid "Selection <b>not in a group</b>."
 msgstr "Auswahl ist <b>nicht in einer Gruppe</b>."
 
-#: ../src/selection-chemistry.cpp:822
+#: ../src/selection-chemistry.cpp:830
 msgid "Pop selection from group"
 msgstr "Auswahl aus Gruppe entfernen"
 
-#: ../src/selection-chemistry.cpp:830
+#: ../src/selection-chemistry.cpp:838
 msgid "Select a <b>group</b> to ungroup."
 msgstr ""
 "Eine <b>Gruppe</b> auswählen, deren Gruppierung aufgehoben werden soll."
 
-#: ../src/selection-chemistry.cpp:845
+#: ../src/selection-chemistry.cpp:853
 msgid "<b>No groups</b> to ungroup in the selection."
 msgstr "<b>Keine Gruppe</b> zum Aufheben in dieser Auswahl."
 
-#: ../src/selection-chemistry.cpp:901 ../src/sp-item-group.cpp:660
+#: ../src/selection-chemistry.cpp:909 ../src/sp-item-group.cpp:660
 #: ../src/ui/dialog/objects.cpp:1950
 msgid "Ungroup"
 msgstr "Gruppierung aufheben"
 
-#: ../src/selection-chemistry.cpp:988
+#: ../src/selection-chemistry.cpp:996
 msgid "Select <b>object(s)</b> to raise."
 msgstr "<b>Objekte</b> zum Anheben auswählen."
 
-#: ../src/selection-chemistry.cpp:994 ../src/selection-chemistry.cpp:1047
-#: ../src/selection-chemistry.cpp:1073 ../src/selection-chemistry.cpp:1188
+#: ../src/selection-chemistry.cpp:1002 ../src/selection-chemistry.cpp:1055
+#: ../src/selection-chemistry.cpp:1081 ../src/selection-chemistry.cpp:1196
 msgid ""
 "You cannot raise/lower objects from <b>different groups</b> or <b>layers</b>."
 msgstr ""
@@ -12856,254 +12865,254 @@ msgstr ""
 "gleichzeitig angehoben/abgesenkt werden."
 
 #. TRANSLATORS: "Raise" means "to raise an object" in the undo history
-#: ../src/selection-chemistry.cpp:1031
+#: ../src/selection-chemistry.cpp:1039
 msgctxt "Undo action"
 msgid "Raise"
 msgstr "Anheben"
 
-#: ../src/selection-chemistry.cpp:1039
+#: ../src/selection-chemistry.cpp:1047
 msgid "Select <b>object(s)</b> to raise to top."
 msgstr "<b>Objekt(e)</b> auswählen, die nach oben angehoben werden sollen."
 
-#: ../src/selection-chemistry.cpp:1060
+#: ../src/selection-chemistry.cpp:1068
 msgid "Raise to top"
 msgstr "Nach ganz oben anheben"
 
-#: ../src/selection-chemistry.cpp:1067
+#: ../src/selection-chemistry.cpp:1075
 msgid "Select <b>object(s)</b> to lower."
 msgstr "<b>Objekt(e)</b> zum Absenken auswählen."
 
 #. TRANSLATORS: "Lower" means "to lower an object" in the undo history
-#: ../src/selection-chemistry.cpp:1115
+#: ../src/selection-chemistry.cpp:1123
 msgctxt "Undo action"
 msgid "Lower"
 msgstr "Absenken"
 
-#: ../src/selection-chemistry.cpp:1124
+#: ../src/selection-chemistry.cpp:1132
 msgid "Select <b>object(s)</b> to stack down."
 msgstr "<b>Objekte</b> zum Absenken auswählen."
 
-#: ../src/selection-chemistry.cpp:1136
+#: ../src/selection-chemistry.cpp:1144
 msgid "We hit bottom."
 msgstr "Das Objekt ist bereits ganz unten."
 
 #. TRANSLATORS: "Lower" means "to lower an object" in the undo history
-#: ../src/selection-chemistry.cpp:1143
+#: ../src/selection-chemistry.cpp:1151
 msgctxt "Undo action"
 msgid "stack down"
 msgstr "Objekt absenken"
 
-#: ../src/selection-chemistry.cpp:1152
+#: ../src/selection-chemistry.cpp:1160
 msgid "Select <b>object(s)</b> to stack up."
 msgstr "<b>Objekt(e)</b> zum Anheben auswählen."
 
-#: ../src/selection-chemistry.cpp:1165
+#: ../src/selection-chemistry.cpp:1173
 msgid "We hit top."
 msgstr "Das Objekt ist bereits ganz oben."
 
 #. TRANSLATORS: "Lower" means "to lower an object" in the undo history
-#: ../src/selection-chemistry.cpp:1172
+#: ../src/selection-chemistry.cpp:1180
 msgctxt "Undo action"
 msgid "stack up"
 msgstr "Objekt anheben"
 
-#: ../src/selection-chemistry.cpp:1180
+#: ../src/selection-chemistry.cpp:1188
 msgid "Select <b>object(s)</b> to lower to bottom."
 msgstr ""
 "<b>Objekt(e)</b> auswählen, die nach ganz unten abgesenkt werden sollen."
 
-#: ../src/selection-chemistry.cpp:1211
+#: ../src/selection-chemistry.cpp:1219
 msgid "Lower to bottom"
 msgstr "Nach ganz unten absenken"
 
 # !!! just make the menu item insensitive
-#: ../src/selection-chemistry.cpp:1221
+#: ../src/selection-chemistry.cpp:1229
 msgid "Nothing to undo."
 msgstr "Es gibt nichts rückgängig zu machen."
 
 # # !!! just make the menu item insensitive
-#: ../src/selection-chemistry.cpp:1232
+#: ../src/selection-chemistry.cpp:1240
 msgid "Nothing to redo."
 msgstr "Es gibt nichts wiederherzustellen."
 
-#: ../src/selection-chemistry.cpp:1304
+#: ../src/selection-chemistry.cpp:1312
 msgid "Paste"
 msgstr "Einfügen"
 
-#: ../src/selection-chemistry.cpp:1312
+#: ../src/selection-chemistry.cpp:1320
 msgid "Paste style"
 msgstr "Stil übertragen"
 
-#: ../src/selection-chemistry.cpp:1322
+#: ../src/selection-chemistry.cpp:1330
 msgid "Paste live path effect"
 msgstr "Pfadeffekt einfügen"
 
-#: ../src/selection-chemistry.cpp:1344
+#: ../src/selection-chemistry.cpp:1352
 msgid "Select <b>object(s)</b> to remove live path effects from."
 msgstr "<b>Objekt(e)</b> auswählen, deren Pfadeffekte entfernt werden sollen."
 
-#: ../src/selection-chemistry.cpp:1356
+#: ../src/selection-chemistry.cpp:1364
 msgid "Remove live path effect"
 msgstr "Pfadeffekt entfernen"
 
-#: ../src/selection-chemistry.cpp:1367
+#: ../src/selection-chemistry.cpp:1375
 msgid "Select <b>object(s)</b> to remove filters from."
 msgstr "<b>Objekt(e)</b> auswählen, deren Filter entfernt werden sollen."
 
-#: ../src/selection-chemistry.cpp:1377
+#: ../src/selection-chemistry.cpp:1385
 #: ../src/ui/dialog/filter-effects-dialog.cpp:1695
 msgid "Remove filter"
 msgstr "Filter entfernen"
 
-#: ../src/selection-chemistry.cpp:1386
+#: ../src/selection-chemistry.cpp:1394
 msgid "Paste size"
 msgstr "Größe einfügen"
 
-#: ../src/selection-chemistry.cpp:1395
+#: ../src/selection-chemistry.cpp:1403
 msgid "Paste size separately"
 msgstr "Größe getrennt einfügen"
 
-#: ../src/selection-chemistry.cpp:1424
+#: ../src/selection-chemistry.cpp:1432
 msgid "Select <b>object(s)</b> to move to the layer above."
 msgstr ""
 "<b>Objekt(e)</b> auswählen, welche in die Ebene darüber verschoben werden "
 "sollen."
 
-#: ../src/selection-chemistry.cpp:1450
+#: ../src/selection-chemistry.cpp:1458
 msgid "Raise to next layer"
 msgstr "In darüberliegende Ebene anheben"
 
-#: ../src/selection-chemistry.cpp:1457
+#: ../src/selection-chemistry.cpp:1465
 msgid "No more layers above."
 msgstr "Keine weiteren Ebenen über dieser."
 
-#: ../src/selection-chemistry.cpp:1468
+#: ../src/selection-chemistry.cpp:1476
 msgid "Select <b>object(s)</b> to move to the layer below."
 msgstr ""
 "<b>Objekt(e)</b> auswählen, welche in die Ebene darunter verschoben werden "
 "sollen."
 
-#: ../src/selection-chemistry.cpp:1494
+#: ../src/selection-chemistry.cpp:1502
 msgid "Lower to previous layer"
 msgstr "Zur darunterliegenden Ebene absenken"
 
-#: ../src/selection-chemistry.cpp:1501
+#: ../src/selection-chemistry.cpp:1509
 msgid "No more layers below."
 msgstr "Keine weiteren Ebenen unter dieser."
 
-#: ../src/selection-chemistry.cpp:1511
+#: ../src/selection-chemistry.cpp:1519
 msgid "Select <b>object(s)</b> to move."
 msgstr "<b>Objekt(e)</b> zum Verschieben auswählen."
 
-#: ../src/selection-chemistry.cpp:1529 ../src/verbs.cpp:2672
+#: ../src/selection-chemistry.cpp:1537 ../src/verbs.cpp:2672
 msgid "Move selection to layer"
 msgstr "Auswahl zur Ebene verschieben"
 
 #. An SVG element cannot have a transform. We could change 'x' and 'y' in response
 #. to a translation... but leave that for another day.
-#: ../src/selection-chemistry.cpp:1618 ../src/seltrans.cpp:391
+#: ../src/selection-chemistry.cpp:1626 ../src/seltrans.cpp:391
 msgid "Cannot transform an embedded SVG."
 msgstr "Kann ein eingebettetes SVG nicht transformieren."
 
-#: ../src/selection-chemistry.cpp:1788
+#: ../src/selection-chemistry.cpp:1796
 msgid "Remove transform"
 msgstr "Transformationen zurücksetzen"
 
-#: ../src/selection-chemistry.cpp:1895
+#: ../src/selection-chemistry.cpp:1903
 msgid "Rotate 90° CCW"
 msgstr "90° gegen den Uhrzeigersinn drehen"
 
-#: ../src/selection-chemistry.cpp:1895
+#: ../src/selection-chemistry.cpp:1903
 msgid "Rotate 90° CW"
 msgstr "90° im Uhrzeigersinn drehen"
 
-#: ../src/selection-chemistry.cpp:1916 ../src/seltrans.cpp:484
+#: ../src/selection-chemistry.cpp:1924 ../src/seltrans.cpp:484
 #: ../src/ui/dialog/transformation.cpp:890
 msgid "Rotate"
 msgstr "Drehen"
 
-#: ../src/selection-chemistry.cpp:2265
+#: ../src/selection-chemistry.cpp:2273
 msgid "Rotate by pixels"
 msgstr "Pixelweise drehen"
 
-#: ../src/selection-chemistry.cpp:2295 ../src/seltrans.cpp:481
+#: ../src/selection-chemistry.cpp:2303 ../src/seltrans.cpp:481
 #: ../src/ui/dialog/transformation.cpp:864 ../src/ui/widget/page-sizer.cpp:450
 #: ../share/extensions/interp_att_g.inx.h:14
 msgid "Scale"
 msgstr "Skalieren"
 
-#: ../src/selection-chemistry.cpp:2320
+#: ../src/selection-chemistry.cpp:2328
 msgid "Scale by whole factor"
 msgstr "Um einen ganzzahligen Faktor skalieren"
 
-#: ../src/selection-chemistry.cpp:2335
+#: ../src/selection-chemistry.cpp:2343
 msgid "Move vertically"
 msgstr "Vertikal verschieben"
 
-#: ../src/selection-chemistry.cpp:2338
+#: ../src/selection-chemistry.cpp:2346
 msgid "Move horizontally"
 msgstr "Horizontal verschieben"
 
-#: ../src/selection-chemistry.cpp:2341 ../src/selection-chemistry.cpp:2367
+#: ../src/selection-chemistry.cpp:2349 ../src/selection-chemistry.cpp:2375
 #: ../src/seltrans.cpp:478 ../src/ui/dialog/transformation.cpp:801
 msgid "Move"
 msgstr "Verschieben"
 
-#: ../src/selection-chemistry.cpp:2361
+#: ../src/selection-chemistry.cpp:2369
 msgid "Move vertically by pixels"
 msgstr "Vertikal um einzelne Pixel verschieben"
 
-#: ../src/selection-chemistry.cpp:2364
+#: ../src/selection-chemistry.cpp:2372
 msgid "Move horizontally by pixels"
 msgstr "Horizontal um einzelne Pixel verschieben"
 
-#: ../src/selection-chemistry.cpp:2567
+#: ../src/selection-chemistry.cpp:2575
 msgid "The selection has no applied path effect."
 msgstr "Die Auswahl enthält keine Objekte mit Pfadeffekt."
 
-#: ../src/selection-chemistry.cpp:2659 ../src/ui/dialog/clonetiler.cpp:2238
+#: ../src/selection-chemistry.cpp:2667 ../src/ui/dialog/clonetiler.cpp:2238
 msgid "Select an <b>object</b> to clone."
 msgstr "Zu klonendes <b>Objekt</b> auswählen."
 
-#: ../src/selection-chemistry.cpp:2694
+#: ../src/selection-chemistry.cpp:2702
 msgctxt "Action"
 msgid "Clone"
 msgstr "Klonen"
 
-#: ../src/selection-chemistry.cpp:2708
+#: ../src/selection-chemistry.cpp:2716
 msgid "Select <b>clones</b> to relink."
 msgstr "<b>Klone</b> auswählen, die neu verknüpft werden sollen"
 
-#: ../src/selection-chemistry.cpp:2715
+#: ../src/selection-chemistry.cpp:2723
 msgid "Copy an <b>object</b> to clipboard to relink clones to."
 msgstr ""
 "<b>Objekt</b>, mit dem die Klone neu verknüpft werden sollen, in die "
 "Zwischenablage kopieren."
 
-#: ../src/selection-chemistry.cpp:2736
+#: ../src/selection-chemistry.cpp:2744
 msgid "<b>No clones to relink</b> in the selection."
 msgstr ""
 "<b>Keine Klone</b> in der Auswahl, deren Verknüpfung erneut gesetzt werden "
 "kann."
 
-#: ../src/selection-chemistry.cpp:2739
+#: ../src/selection-chemistry.cpp:2747
 msgid "Relink clone"
 msgstr "Klon neu verknüpfen"
 
-#: ../src/selection-chemistry.cpp:2753
+#: ../src/selection-chemistry.cpp:2761
 msgid "Select <b>clones</b> to unlink."
 msgstr "<b>Klon</b> auswählen, dessen Verknüpfung aufgehoben werden soll."
 
-#: ../src/selection-chemistry.cpp:2806
+#: ../src/selection-chemistry.cpp:2814
 msgid "<b>No clones to unlink</b> in the selection."
 msgstr ""
 "<b>Keine Klone</b> in der Auswahl, deren Verknüpfung aufgehoben werden kann."
 
-#: ../src/selection-chemistry.cpp:2810
+#: ../src/selection-chemistry.cpp:2818
 msgid "Unlink clone"
 msgstr "Klonverbindung auftrennen"
 
-#: ../src/selection-chemistry.cpp:2823
+#: ../src/selection-chemistry.cpp:2831
 msgid ""
 "Select a <b>clone</b> to go to its original. Select a <b>linked offset</b> "
 "to go to its source. Select a <b>text on path</b> to go to the path. Select "
@@ -13114,7 +13123,7 @@ msgstr ""
 "den Ausgangspfad zu finden. <b>Fließtextpfad</b> auswählen, um seinen Rahmen "
 "zu finden."
 
-#: ../src/selection-chemistry.cpp:2873
+#: ../src/selection-chemistry.cpp:2881
 msgid ""
 "<b>Cannot find</b> the object to select (orphaned clone, offset, textpath, "
 "flowed text?)"
@@ -13122,7 +13131,7 @@ msgstr ""
 "Gesuchtes Objekt <b>nicht gefunden</b> - vielleicht ist der Klon, der "
 "verbundene Versatz, der Textpfad oder der Fließtext verwaist?"
 
-#: ../src/selection-chemistry.cpp:2879
+#: ../src/selection-chemistry.cpp:2887
 msgid ""
 "The object you're trying to select is <b>not visible</b> (it is in &lt;"
 "defs&gt;)"
@@ -13130,137 +13139,137 @@ msgstr ""
 "Dieses Objekt kann nicht ausgewählt werden - es ist <b>unsichtbar</b> und "
 "befindet sich in &lt;defs&gt;."
 
-#: ../src/selection-chemistry.cpp:2969
+#: ../src/selection-chemistry.cpp:2979
 msgid "Select path(s) to fill."
 msgstr "Pfad(e) zum Füllen auswählen."
 
-#: ../src/selection-chemistry.cpp:2987
+#: ../src/selection-chemistry.cpp:2997
 msgid "Select <b>object(s)</b> to convert to marker."
 msgstr ""
 "<b>Objekt(e)</b> auswählen, die in eine Knotenmarkierung umgewandelt werden "
 "sollen."
 
-#: ../src/selection-chemistry.cpp:3061
+#: ../src/selection-chemistry.cpp:3071
 msgid "Objects to marker"
 msgstr "Objekte zu Knotenmarkierung"
 
-#: ../src/selection-chemistry.cpp:3087
+#: ../src/selection-chemistry.cpp:3097
 msgid "Select <b>object(s)</b> to convert to guides."
 msgstr ""
 "<b>Objekt(e)</b> auswählen, die in Hilfslinien umgewandelt werden sollen."
 
-#: ../src/selection-chemistry.cpp:3108
+#: ../src/selection-chemistry.cpp:3118
 msgid "Objects to guides"
 msgstr "Objekte zu Hilfslinien"
 
-#: ../src/selection-chemistry.cpp:3144
+#: ../src/selection-chemistry.cpp:3154
 msgid "Select <b>objects</b> to convert to symbol."
 msgstr "Wählen Sie <b>Objekte</b> zum Konvertieren in ein Symbol aus."
 
-#: ../src/selection-chemistry.cpp:3248
+#: ../src/selection-chemistry.cpp:3258
 msgid "Group to symbol"
 msgstr "Gruppe zu Symbol"
 
-#: ../src/selection-chemistry.cpp:3267
+#: ../src/selection-chemistry.cpp:3277
 msgid "Select a <b>symbol</b> to extract objects from."
 msgstr "Wählen Sie ein <b>Symbol</b>, um Objekte daraus zu entnehmen."
 
-#: ../src/selection-chemistry.cpp:3276
+#: ../src/selection-chemistry.cpp:3286
 msgid "Select only one <b>symbol</b> in Symbol dialog to convert to group."
 msgstr ""
 "Wählen Sie nur ein<b>Symbol</b> aus, um es in eine Gruppe zu konvertieren."
 
-#: ../src/selection-chemistry.cpp:3332
+#: ../src/selection-chemistry.cpp:3342
 msgid "Group from symbol"
 msgstr "Symbol zu Gruppe"
 
-#: ../src/selection-chemistry.cpp:3350
+#: ../src/selection-chemistry.cpp:3360
 msgid "Select <b>object(s)</b> to convert to pattern."
 msgstr ""
 "<b>Objekt(e)</b> auswählen, die in ein Füllmuster umgewandelt werden sollen."
 
-#: ../src/selection-chemistry.cpp:3446
+#: ../src/selection-chemistry.cpp:3456
 msgid "Objects to pattern"
 msgstr "Objekte in Füllmuster umwandeln"
 
-#: ../src/selection-chemistry.cpp:3462
+#: ../src/selection-chemistry.cpp:3472
 msgid "Select an <b>object with pattern fill</b> to extract objects from."
 msgstr ""
 "Ein <b>Objekt mit Musterfüllung</b> auswählen, um die Füllung zu extrahieren."
 
-#: ../src/selection-chemistry.cpp:3521
+#: ../src/selection-chemistry.cpp:3531
 msgid "<b>No pattern fills</b> in the selection."
 msgstr "Die Auswahl enthält <b>keine Musterfüllung</b>."
 
-#: ../src/selection-chemistry.cpp:3524
+#: ../src/selection-chemistry.cpp:3534
 msgid "Pattern to objects"
 msgstr "Füllmuster in Objekte umwandeln"
 
-#: ../src/selection-chemistry.cpp:3610
+#: ../src/selection-chemistry.cpp:3620
 msgid "Select <b>object(s)</b> to make a bitmap copy."
 msgstr "<b>Objekt(e) auswählen</b>, um eine Bitmap-Kopie zu erstellen."
 
-#: ../src/selection-chemistry.cpp:3614
+#: ../src/selection-chemistry.cpp:3624
 msgid "Rendering bitmap..."
 msgstr "Bitmap wird gerendert..."
 
-#: ../src/selection-chemistry.cpp:3799
+#: ../src/selection-chemistry.cpp:3809
 msgid "Create bitmap"
 msgstr "Bitmap erstellen"
 
-#: ../src/selection-chemistry.cpp:3824 ../src/selection-chemistry.cpp:3936
+#: ../src/selection-chemistry.cpp:3834 ../src/selection-chemistry.cpp:3946
 msgid "Select <b>object(s)</b> to create clippath or mask from."
 msgstr ""
 "<b>Objekt(e)</b> auswählen, um Ausschneidepfad oder Maske daraus zu erzeugen."
 
-#: ../src/selection-chemistry.cpp:3910 ../src/ui/dialog/objects.cpp:1956
+#: ../src/selection-chemistry.cpp:3920 ../src/ui/dialog/objects.cpp:1956
 msgid "Create Clip Group"
 msgstr "Ausschneidemaske erzeugen"
 
-#: ../src/selection-chemistry.cpp:3939
+#: ../src/selection-chemistry.cpp:3949
 msgid "Select mask object and <b>object(s)</b> to apply clippath or mask to."
 msgstr ""
 "Maskenobjekt und <b>Objekt(e)</b> zur Anwendung von Ausschneidepfad oder "
 "Maske auswählen."
 
-#: ../src/selection-chemistry.cpp:4086
+#: ../src/selection-chemistry.cpp:4096
 msgid "Set clipping path"
 msgstr "Ausschneidepfad setzen"
 
-#: ../src/selection-chemistry.cpp:4088
+#: ../src/selection-chemistry.cpp:4098
 msgid "Set mask"
 msgstr "Maske setzen"
 
-#: ../src/selection-chemistry.cpp:4103
+#: ../src/selection-chemistry.cpp:4113
 msgid "Select <b>object(s)</b> to remove clippath or mask from."
 msgstr ""
 "<b>Objekt(e)</b> auswählen, deren Ausschneidepfad oder Maske entfernt werden "
 "soll."
 
-#: ../src/selection-chemistry.cpp:4219
+#: ../src/selection-chemistry.cpp:4229
 msgid "Release clipping path"
 msgstr "Ausschneidepfad freigeben"
 
-#: ../src/selection-chemistry.cpp:4221
+#: ../src/selection-chemistry.cpp:4231
 msgid "Release mask"
 msgstr "Maske freigeben"
 
 # While it's canvas in English, the page size is what is intended (according to cpp file).
-#: ../src/selection-chemistry.cpp:4240
+#: ../src/selection-chemistry.cpp:4250
 msgid "Select <b>object(s)</b> to fit canvas to."
 msgstr ""
 "<b>Objekt(e)</b> auswählen, an die die Seitengröße angepasst werden soll."
 
 #. Fit Page
-#: ../src/selection-chemistry.cpp:4260 ../src/verbs.cpp:3018
+#: ../src/selection-chemistry.cpp:4270 ../src/verbs.cpp:3018
 msgid "Fit Page to Selection"
 msgstr "Seite in Auswahl einpassen"
 
-#: ../src/selection-chemistry.cpp:4289 ../src/verbs.cpp:3020
+#: ../src/selection-chemistry.cpp:4299 ../src/verbs.cpp:3020
 msgid "Fit Page to Drawing"
 msgstr "Seite in Zeichnungsgröße einpassen"
 
-#: ../src/selection-chemistry.cpp:4310
+#: ../src/selection-chemistry.cpp:4320
 msgid "Fit Page to Selection or Drawing"
 msgstr "Seite in Auswahl oder ganze Zeichnung einpassen"
 
@@ -13453,8 +13462,8 @@ msgstr ""
 msgid "Keyboard directory (%s) is unavailable."
 msgstr "Tastaturkürzelverzeichnis (%s) nicht verfügbar."
 
-#: ../src/shortcuts.cpp:343 ../src/ui/dialog/export.cpp:1305
-#: ../src/ui/dialog/export.cpp:1339
+#: ../src/shortcuts.cpp:343 ../src/ui/dialog/export.cpp:1306
+#: ../src/ui/dialog/export.cpp:1340
 msgid "Select a filename for exporting"
 msgstr "Wählen Sie einen Namen für die zu exportierende Datei"
 
@@ -13485,7 +13494,7 @@ msgstr "Bogen"
 
 #. Ellipse
 #: ../src/sp-ellipse.cpp:362 ../src/sp-ellipse.cpp:369
-#: ../src/ui/dialog/inkscape-preferences.cpp:421
+#: ../src/ui/dialog/inkscape-preferences.cpp:439
 #: ../src/widgets/pencil-toolbar.cpp:178
 msgid "Ellipse"
 msgstr "Ellipse"
@@ -13676,12 +13685,12 @@ msgid "<b>Polyline</b>"
 msgstr "<b>Linienzug</b>"
 
 #. Rectangle
-#: ../src/sp-rect.cpp:197 ../src/ui/dialog/inkscape-preferences.cpp:411
+#: ../src/sp-rect.cpp:197 ../src/ui/dialog/inkscape-preferences.cpp:429
 msgid "Rectangle"
 msgstr "Rechteck"
 
 #. Spiral
-#: ../src/sp-spiral.cpp:220 ../src/ui/dialog/inkscape-preferences.cpp:429
+#: ../src/sp-spiral.cpp:220 ../src/ui/dialog/inkscape-preferences.cpp:447
 #: ../share/extensions/gcodetools_area.inx.h:16
 msgid "Spiral"
 msgstr "Spirale"
@@ -13694,7 +13703,7 @@ msgid "with %3f turns"
 msgstr "mit %3f Windungen"
 
 #. Star
-#: ../src/sp-star.cpp:247 ../src/ui/dialog/inkscape-preferences.cpp:425
+#: ../src/sp-star.cpp:247 ../src/ui/dialog/inkscape-preferences.cpp:443
 #: ../src/widgets/star-toolbar.cpp:469
 msgid "Star"
 msgstr "Stern"
@@ -14051,37 +14060,37 @@ msgstr "Nachzeichnen: Abgeschlossen. %ld Knoten erstellt"
 msgid "Nothing was copied."
 msgstr "Es wurde nichts kopiert."
 
-#: ../src/ui/clipboard.cpp:393 ../src/ui/clipboard.cpp:607
-#: ../src/ui/clipboard.cpp:636
+#: ../src/ui/clipboard.cpp:393 ../src/ui/clipboard.cpp:608
+#: ../src/ui/clipboard.cpp:637
 msgid "Nothing on the clipboard."
 msgstr "Es ist nichts in der Zwischenablage."
 
-#: ../src/ui/clipboard.cpp:451
+#: ../src/ui/clipboard.cpp:452
 msgid "Select <b>object(s)</b> to paste style to."
 msgstr "Objekt(e) auswählen, um Stil darauf anzuwenden."
 
-#: ../src/ui/clipboard.cpp:462 ../src/ui/clipboard.cpp:479
+#: ../src/ui/clipboard.cpp:463 ../src/ui/clipboard.cpp:480
 msgid "No style on the clipboard."
 msgstr "Kein Stil in der Zwischenablage."
 
-#: ../src/ui/clipboard.cpp:504
+#: ../src/ui/clipboard.cpp:505
 msgid "Select <b>object(s)</b> to paste size to."
 msgstr "<b>Objekt(e)</b> auswählen, um Größe einzufügen."
 
-#: ../src/ui/clipboard.cpp:511
+#: ../src/ui/clipboard.cpp:512
 msgid "No size on the clipboard."
 msgstr "Keine Größe in der Zwischenablage."
 
-#: ../src/ui/clipboard.cpp:568
+#: ../src/ui/clipboard.cpp:569
 msgid "Select <b>object(s)</b> to paste live path effect to."
 msgstr "<b>Objekt(e)</b> auswählen, um den Pfadeffekt einzufügen."
 
 #. no_effect:
-#: ../src/ui/clipboard.cpp:594
+#: ../src/ui/clipboard.cpp:595
 msgid "No effect on the clipboard."
 msgstr "Kein Effekt in der Zwischenablage."
 
-#: ../src/ui/clipboard.cpp:613 ../src/ui/clipboard.cpp:650
+#: ../src/ui/clipboard.cpp:614 ../src/ui/clipboard.cpp:651
 msgid "Clipboard does not contain a path."
 msgstr "Die Zwischenablage enthält keinen Pfad."
 
@@ -14208,7 +14217,7 @@ msgid "Rearrange"
 msgstr "Anordnen"
 
 #: ../src/ui/dialog/align-and-distribute.cpp:941
-#: ../src/widgets/toolbox.cpp:1804
+#: ../src/widgets/toolbox.cpp:1803
 msgid "Nodes"
 msgstr "Knoten"
 
@@ -15219,12 +15228,12 @@ msgstr "Nutzungsbedingungen - Lizenz"
 
 # !!!
 #: ../src/ui/dialog/document-metadata.cpp:126
-#: ../src/ui/dialog/document-properties.cpp:1037
+#: ../src/ui/dialog/document-properties.cpp:1054
 msgid "<b>Dublin Core Entities</b>"
 msgstr "<b>Dublin-Core-Entities</b>"
 
 #: ../src/ui/dialog/document-metadata.cpp:168
-#: ../src/ui/dialog/document-properties.cpp:1099
+#: ../src/ui/dialog/document-properties.cpp:1116
 msgid "<b>License</b>"
 msgstr "<b>Lizenz</b>"
 
@@ -15483,7 +15492,7 @@ msgstr "_Entfernen"
 msgid "Remove selected grid."
 msgstr "Ausgewähltes Gitter entfernen."
 
-#: ../src/ui/dialog/document-properties.cpp:162 ../src/widgets/toolbox.cpp:1911
+#: ../src/ui/dialog/document-properties.cpp:162 ../src/widgets/toolbox.cpp:1910
 msgid "Guides"
 msgstr "Hilfslinien"
 
@@ -15515,23 +15524,23 @@ msgstr "<b>Rand</b>"
 msgid "<b>Display</b>"
 msgstr "<b>Anzeige</b>"
 
-#: ../src/ui/dialog/document-properties.cpp:381
+#: ../src/ui/dialog/document-properties.cpp:398
 msgid "<b>Guides</b>"
 msgstr "<b>Hilfslinien</b>"
 
-#: ../src/ui/dialog/document-properties.cpp:399
+#: ../src/ui/dialog/document-properties.cpp:416
 msgid "<b>Snap to objects</b>"
 msgstr "<b>An Objekten einrasten</b>"
 
-#: ../src/ui/dialog/document-properties.cpp:401
+#: ../src/ui/dialog/document-properties.cpp:418
 msgid "<b>Snap to grids</b>"
 msgstr "<b>Am Gitter einrasten</b>"
 
-#: ../src/ui/dialog/document-properties.cpp:403
+#: ../src/ui/dialog/document-properties.cpp:420
 msgid "<b>Snap to guides</b>"
 msgstr "<b>An Hilfslinien einrasten</b>"
 
-#: ../src/ui/dialog/document-properties.cpp:405
+#: ../src/ui/dialog/document-properties.cpp:422
 msgid "<b>Miscellaneous</b>"
 msgstr "<b>Verschiedenes</b>"
 
@@ -15539,137 +15548,137 @@ msgstr "<b>Verschiedenes</b>"
 #. Inkscape::GC::release(defsRepr);
 #. inform the document, so we can undo
 #. Color Management
-#: ../src/ui/dialog/document-properties.cpp:542 ../src/verbs.cpp:3034
+#: ../src/ui/dialog/document-properties.cpp:559 ../src/verbs.cpp:3034
 msgid "Link Color Profile"
 msgstr "Farbprofil verknüpfen"
 
-#: ../src/ui/dialog/document-properties.cpp:654
+#: ../src/ui/dialog/document-properties.cpp:671
 msgid "Remove linked color profile"
 msgstr "Verknüpftes Farbprofil entfernen"
 
-#: ../src/ui/dialog/document-properties.cpp:673
+#: ../src/ui/dialog/document-properties.cpp:690
 msgid "<b>Linked Color Profiles:</b>"
 msgstr "<b>Verknüpfte Farbprofile:</b>"
 
-#: ../src/ui/dialog/document-properties.cpp:675
+#: ../src/ui/dialog/document-properties.cpp:692
 msgid "<b>Available Color Profiles:</b>"
 msgstr "<b>Verfügbare Farbprofile:</b>"
 
-#: ../src/ui/dialog/document-properties.cpp:677
+#: ../src/ui/dialog/document-properties.cpp:694
 msgid "Link Profile"
 msgstr "Profil verknüpfen"
 
-#: ../src/ui/dialog/document-properties.cpp:680
+#: ../src/ui/dialog/document-properties.cpp:697
 msgid "Unlink Profile"
 msgstr "Profil entknüpfen"
 
-#: ../src/ui/dialog/document-properties.cpp:764
+#: ../src/ui/dialog/document-properties.cpp:781
 msgid "Profile Name"
 msgstr "Profilname"
 
-#: ../src/ui/dialog/document-properties.cpp:800
+#: ../src/ui/dialog/document-properties.cpp:817
 msgid "External scripts"
 msgstr "Externe Skripte"
 
-#: ../src/ui/dialog/document-properties.cpp:801
+#: ../src/ui/dialog/document-properties.cpp:818
 msgid "Embedded scripts"
 msgstr "Eingebettete Skripte"
 
-#: ../src/ui/dialog/document-properties.cpp:806
+#: ../src/ui/dialog/document-properties.cpp:823
 msgid "<b>External script files:</b>"
 msgstr "<b>Externe Skriptdateien:</b>"
 
-#: ../src/ui/dialog/document-properties.cpp:808
+#: ../src/ui/dialog/document-properties.cpp:825
 msgid "Add the current file name or browse for a file"
 msgstr ""
 "Fügen Sie den aktuellen Dateinamen hinzu oder suchen Sie nach einer Datei"
 
-#: ../src/ui/dialog/document-properties.cpp:811
-#: ../src/ui/dialog/document-properties.cpp:888
+#: ../src/ui/dialog/document-properties.cpp:828
+#: ../src/ui/dialog/document-properties.cpp:905
 #: ../src/ui/widget/selected-style.cpp:357
 msgid "Remove"
 msgstr "Entfernen"
 
-#: ../src/ui/dialog/document-properties.cpp:875
+#: ../src/ui/dialog/document-properties.cpp:892
 msgid "Filename"
 msgstr "Dateiname"
 
-#: ../src/ui/dialog/document-properties.cpp:883
+#: ../src/ui/dialog/document-properties.cpp:900
 msgid "<b>Embedded script files:</b>"
 msgstr "<b>Eingebettete Skriptdateien:</b>"
 
-#: ../src/ui/dialog/document-properties.cpp:885
+#: ../src/ui/dialog/document-properties.cpp:902
 #: ../src/ui/dialog/objects.cpp:1928
 msgid "New"
 msgstr "Neu"
 
-#: ../src/ui/dialog/document-properties.cpp:952
+#: ../src/ui/dialog/document-properties.cpp:969
 msgid "Script id"
 msgstr "Skript-ID"
 
-#: ../src/ui/dialog/document-properties.cpp:958
+#: ../src/ui/dialog/document-properties.cpp:975
 msgid "<b>Content:</b>"
 msgstr "<b>Inhalt:</b>"
 
-#: ../src/ui/dialog/document-properties.cpp:1075
+#: ../src/ui/dialog/document-properties.cpp:1092
 msgid "_Save as default"
 msgstr "Als Standardeinstellung _speichern"
 
-#: ../src/ui/dialog/document-properties.cpp:1076
+#: ../src/ui/dialog/document-properties.cpp:1093
 msgid "Save this metadata as the default metadata"
 msgstr "Aktuelle Metadaten als Standard abspeichern"
 
-#: ../src/ui/dialog/document-properties.cpp:1077
+#: ../src/ui/dialog/document-properties.cpp:1094
 msgid "Use _default"
 msgstr "Standardeinstellungen _benutzen"
 
-#: ../src/ui/dialog/document-properties.cpp:1078
+#: ../src/ui/dialog/document-properties.cpp:1095
 msgid "Use the previously saved default metadata here"
 msgstr "Die zuvor gespeicherten Standardmetadaten verwenden"
 
 #. inform the document, so we can undo
-#: ../src/ui/dialog/document-properties.cpp:1151
+#: ../src/ui/dialog/document-properties.cpp:1168
 msgid "Add external script..."
 msgstr "Füge externes Skript hinzu..."
 
-#: ../src/ui/dialog/document-properties.cpp:1190
+#: ../src/ui/dialog/document-properties.cpp:1207
 msgid "Select a script to load"
 msgstr "Skript zum Laden auswählen"
 
 #. inform the document, so we can undo
-#: ../src/ui/dialog/document-properties.cpp:1218
+#: ../src/ui/dialog/document-properties.cpp:1235
 msgid "Add embedded script..."
 msgstr "Füge eingebettetes Skript hinzu..."
 
 #. inform the document, so we can undo
-#: ../src/ui/dialog/document-properties.cpp:1249
+#: ../src/ui/dialog/document-properties.cpp:1266
 msgid "Remove external script"
 msgstr "Lösche externes Skript"
 
 #. inform the document, so we can undo
-#: ../src/ui/dialog/document-properties.cpp:1278
+#: ../src/ui/dialog/document-properties.cpp:1295
 msgid "Remove embedded script"
 msgstr "Eingebettetes Skript entfernen"
 
 #. TODO repr->set_content(_EmbeddedContent.get_buffer()->get_text());
 #. inform the document, so we can undo
-#: ../src/ui/dialog/document-properties.cpp:1374
+#: ../src/ui/dialog/document-properties.cpp:1391
 msgid "Edit embedded script"
 msgstr "Eingebettetes Skript bearbeiten"
 
-#: ../src/ui/dialog/document-properties.cpp:1458
+#: ../src/ui/dialog/document-properties.cpp:1475
 msgid "<b>Creation</b>"
 msgstr "<b>Erzeugen</b>"
 
-#: ../src/ui/dialog/document-properties.cpp:1459
+#: ../src/ui/dialog/document-properties.cpp:1476
 msgid "<b>Defined grids</b>"
 msgstr "<b>Definierte Gitter</b>"
 
-#: ../src/ui/dialog/document-properties.cpp:1703
+#: ../src/ui/dialog/document-properties.cpp:1720
 msgid "Remove grid"
 msgstr "Gitter entfernen"
 
-#: ../src/ui/dialog/document-properties.cpp:1795
+#: ../src/ui/dialog/document-properties.cpp:1812
 msgid "Changed default display unit"
 msgstr "Änderung der Anzeigeeinheit"
 
@@ -15779,9 +15788,9 @@ msgid "_Height:"
 msgstr "_Höhe:"
 
 #: ../src/ui/dialog/export.cpp:304
-#: ../src/ui/dialog/inkscape-preferences.cpp:1493
-#: ../src/ui/dialog/inkscape-preferences.cpp:1497
-#: ../src/ui/dialog/inkscape-preferences.cpp:1521
+#: ../src/ui/dialog/inkscape-preferences.cpp:1515
+#: ../src/ui/dialog/inkscape-preferences.cpp:1519
+#: ../src/ui/dialog/inkscape-preferences.cpp:1543
 msgid "dpi"
 msgstr "dpi"
 
@@ -15809,77 +15818,77 @@ msgstr[1] "B_atch-Export von %d gewählten Objekten"
 msgid "Export in progress"
 msgstr "Exportieren läuft"
 
-#: ../src/ui/dialog/export.cpp:1022
+#: ../src/ui/dialog/export.cpp:1023
 msgid "No items selected."
 msgstr "Kein Element gewählt."
 
-#: ../src/ui/dialog/export.cpp:1026 ../src/ui/dialog/export.cpp:1028
+#: ../src/ui/dialog/export.cpp:1027 ../src/ui/dialog/export.cpp:1029
 msgid "Exporting %1 files"
 msgstr "Exportiere %1 Dateien"
 
-#: ../src/ui/dialog/export.cpp:1069 ../src/ui/dialog/export.cpp:1071
+#: ../src/ui/dialog/export.cpp:1070 ../src/ui/dialog/export.cpp:1072
 #, c-format
 msgid "Exporting file <b>%s</b>..."
 msgstr "Exportiere Datei <b>%s</b>..."
 
-#: ../src/ui/dialog/export.cpp:1080 ../src/ui/dialog/export.cpp:1172
+#: ../src/ui/dialog/export.cpp:1081 ../src/ui/dialog/export.cpp:1173
 #, c-format
 msgid "Could not export to filename %s.\n"
 msgstr "Konnte nicht als Datei %s exportieren.\n"
 
-#: ../src/ui/dialog/export.cpp:1083
+#: ../src/ui/dialog/export.cpp:1084
 #, c-format
 msgid "Could not export to filename <b>%s</b>."
 msgstr "Konnte nicht als Datei <b>%s</b> exportieren."
 
-#: ../src/ui/dialog/export.cpp:1098
+#: ../src/ui/dialog/export.cpp:1099
 #, c-format
 msgid "Successfully exported <b>%d</b> files from <b>%d</b> selected items."
 msgstr ""
 "Erfolgreich <b>%d</b> Dateien aus <b>%d</b> ausgewählten Objekten exportiert."
 
-#: ../src/ui/dialog/export.cpp:1109
+#: ../src/ui/dialog/export.cpp:1110
 msgid "You have to enter a filename."
 msgstr "Sie müssen einen Dateinamen angeben"
 
-#: ../src/ui/dialog/export.cpp:1110
+#: ../src/ui/dialog/export.cpp:1111
 msgid "You have to enter a filename"
 msgstr "Sie müssen einen Dateinamen angeben"
 
-#: ../src/ui/dialog/export.cpp:1124
+#: ../src/ui/dialog/export.cpp:1125
 msgid "The chosen area to be exported is invalid."
 msgstr "Der zum Exportieren gewählte Bereich ist ungültig."
 
-#: ../src/ui/dialog/export.cpp:1125
+#: ../src/ui/dialog/export.cpp:1126
 msgid "The chosen area to be exported is invalid"
 msgstr "Der zum Exportieren gewählte Bereich ist ungültig"
 
-#: ../src/ui/dialog/export.cpp:1140
+#: ../src/ui/dialog/export.cpp:1141
 #, c-format
 msgid "Directory %s does not exist or is not a directory.\n"
 msgstr "Das Verzeichnis %s existiert nicht oder ist kein Verzeichnis.\n"
 
 #. TRANSLATORS: %1 will be the filename, %2 the width, and %3 the height of the image
-#: ../src/ui/dialog/export.cpp:1154 ../src/ui/dialog/export.cpp:1156
+#: ../src/ui/dialog/export.cpp:1155 ../src/ui/dialog/export.cpp:1157
 msgid "Exporting %1 (%2 x %3)"
 msgstr "Exportiere %1 (%2 x %3)"
 
-#: ../src/ui/dialog/export.cpp:1183
+#: ../src/ui/dialog/export.cpp:1184
 #, c-format
 msgid "Drawing exported to <b>%s</b>."
 msgstr "Zeichnung exportiert als <b>%s</b>."
 
-#: ../src/ui/dialog/export.cpp:1187
+#: ../src/ui/dialog/export.cpp:1188
 msgid "Export aborted."
 msgstr "Export abgebrochen."
 
-#: ../src/ui/dialog/export.cpp:1308 ../src/ui/interface.cpp:1401
+#: ../src/ui/dialog/export.cpp:1309 ../src/ui/interface.cpp:1401
 #: ../src/widgets/desktop-widget.cpp:1201
 #: ../src/widgets/desktop-widget.cpp:1263
 msgid "_Cancel"
 msgstr "_Abbrechen"
 
-#: ../src/ui/dialog/export.cpp:1309 ../src/ui/dialog/input.cpp:1082
+#: ../src/ui/dialog/export.cpp:1310 ../src/ui/dialog/input.cpp:1082
 #: ../src/verbs.cpp:2438 ../src/widgets/desktop-widget.cpp:1202
 msgid "_Save"
 msgstr "_Speichern"
@@ -17008,7 +17017,7 @@ msgstr "Spiralen"
 msgid "Search spirals"
 msgstr "Spiralen suchen"
 
-#: ../src/ui/dialog/find.cpp:103 ../src/widgets/toolbox.cpp:1812
+#: ../src/ui/dialog/find.cpp:103 ../src/widgets/toolbox.cpp:1811
 msgid "Paths"
 msgstr "Pfade"
 
@@ -18045,31 +18054,31 @@ msgstr "Auswahl"
 msgid "Selection only or whole document"
 msgstr "Nur Auswahl oder ganzes Dokument"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:183
+#: ../src/ui/dialog/inkscape-preferences.cpp:201
 msgid "Show selection cue"
 msgstr "Auswahlmarkierung anzeigen"
 
 # !!! Frage? Passiv formulieren?
-#: ../src/ui/dialog/inkscape-preferences.cpp:184
+#: ../src/ui/dialog/inkscape-preferences.cpp:202
 msgid ""
 "Whether selected objects display a selection cue (the same as in selector)"
 msgstr ""
 "Ob ausgewählte Objekte optisch hervorgehoben werden sollen (wie beim "
 "Auswahlwerkzeug)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:190
+#: ../src/ui/dialog/inkscape-preferences.cpp:208
 msgid "Enable gradient editing"
 msgstr "Farbverlaufsbearbeitung aktiviert"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:191
+#: ../src/ui/dialog/inkscape-preferences.cpp:209
 msgid "Whether selected objects display gradient editing controls"
 msgstr "Ausgewählte Objekte zeigen Farbverlaufs-Anfasser an"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:196
+#: ../src/ui/dialog/inkscape-preferences.cpp:214
 msgid "Conversion to guides uses edges instead of bounding box"
 msgstr "Umwandlung zu Hilfslinien nutzt Objektkanten anstelle von Objektrahmen"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:197
+#: ../src/ui/dialog/inkscape-preferences.cpp:215
 msgid ""
 "Converting an object to guides places these along the object's true edges "
 "(imitating the object's shape), not along the bounding box"
@@ -18077,39 +18086,39 @@ msgstr ""
 "Wird ein Objekt zu Hilfslinien umgewandelt, so gelten die tatsächlichen "
 "Umrisse des Objekts, nicht der Objektrahmen."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:204
+#: ../src/ui/dialog/inkscape-preferences.cpp:222
 msgid "Ctrl+click _dot size:"
 msgstr "Punktgröße bei Strg+Klick:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:204
+#: ../src/ui/dialog/inkscape-preferences.cpp:222
 msgid "times current stroke width"
 msgstr "mal Konturbreite"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:205
+#: ../src/ui/dialog/inkscape-preferences.cpp:223
 msgid "Size of dots created with Ctrl+click (relative to current stroke width)"
 msgstr ""
 "Größe der Punkte, die durch Strg+Klick erzeugt werden (relativ zur aktuellen "
 "Konturbreite)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:213
+#: ../src/ui/dialog/inkscape-preferences.cpp:231
 msgid "Base simplify:"
 msgstr "Basisvereinfachung:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:213
+#: ../src/ui/dialog/inkscape-preferences.cpp:231
 msgid "on dynamic LPE simplify"
 msgstr "beim Vereinfachen über Pfadeffekt"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:214
+#: ../src/ui/dialog/inkscape-preferences.cpp:232
 msgid "Base simplify of dynamic LPE based simplify"
 msgstr ""
 "Basisvereinfachung beim Vereinfachen mit der Pfadeffekt basierten "
 "Vereinfachung"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:229
+#: ../src/ui/dialog/inkscape-preferences.cpp:247
 msgid "<b>No objects selected</b> to take the style from."
 msgstr "<b>Objekte auswählen</b>, um Stil zu übernehmen."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:238
+#: ../src/ui/dialog/inkscape-preferences.cpp:256
 msgid ""
 "<b>More than one object selected.</b>  Cannot take style from multiple "
 "objects."
@@ -18117,23 +18126,23 @@ msgstr ""
 "<b>Mehr als ein Objekt ausgewählt.</b> Ein Stil kann nicht von mehreren "
 "Objekten übernommen werden."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:274
+#: ../src/ui/dialog/inkscape-preferences.cpp:292
 msgid "Style of new objects"
 msgstr "Stil von neuen Objekten"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:276
+#: ../src/ui/dialog/inkscape-preferences.cpp:294
 msgid "Last used style"
 msgstr "Zuletzt benutzter Stil"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:278
+#: ../src/ui/dialog/inkscape-preferences.cpp:296
 msgid "Apply the style you last set on an object"
 msgstr "Stil anwenden, der zuletzt für ein Objekt gesetzt wurde"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:283
+#: ../src/ui/dialog/inkscape-preferences.cpp:301
 msgid "This tool's own style:"
 msgstr "Stilvorgaben für dieses Werkzeug:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:287
+#: ../src/ui/dialog/inkscape-preferences.cpp:305
 msgid ""
 "Each tool may store its own style to apply to the newly created objects. Use "
 "the button below to set it."
@@ -18142,174 +18151,174 @@ msgstr ""
 "Objekte nutzen. Stilvorgabe mit der unteren Schaltfläche festlegen."
 
 #. style swatch
-#: ../src/ui/dialog/inkscape-preferences.cpp:291
+#: ../src/ui/dialog/inkscape-preferences.cpp:309
 msgid "Take from selection"
 msgstr "Aus Auswahl übernehmen"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:300
+#: ../src/ui/dialog/inkscape-preferences.cpp:318
 msgid "This tool's style of new objects"
 msgstr "Stilvorgaben für dieses Werkzeug für neue Objekte"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:307
+#: ../src/ui/dialog/inkscape-preferences.cpp:325
 msgid "Remember the style of the (first) selected object as this tool's style"
 msgstr ""
 "Stil des (ersten) ausgewählten Objektes zur Stilvorgabe für dieses Werkzeug "
 "machen"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:312
+#: ../src/ui/dialog/inkscape-preferences.cpp:330
 msgid "Tools"
 msgstr "Werkzeuge"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:315
+#: ../src/ui/dialog/inkscape-preferences.cpp:333
 msgid "Bounding box to use"
 msgstr "Zu verwendender Objektrahmen"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:316
+#: ../src/ui/dialog/inkscape-preferences.cpp:334
 msgid "Visual bounding box"
 msgstr "Visueller Objektrahmen"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:318
+#: ../src/ui/dialog/inkscape-preferences.cpp:336
 msgid "This bounding box includes stroke width, markers, filter margins, etc."
 msgstr ""
 "Dieser Objektrahmen berücksichtigt Strichbreiten, Knotenmarkierungen, "
 "Filterränder usw."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:319
+#: ../src/ui/dialog/inkscape-preferences.cpp:337
 msgid "Geometric bounding box"
 msgstr "Geometrischer Objektrahmen"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:321
+#: ../src/ui/dialog/inkscape-preferences.cpp:339
 msgid "This bounding box includes only the bare path"
 msgstr "Dieser Objektrahmen berücksichtigt nur den reinen Pfad"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:323
+#: ../src/ui/dialog/inkscape-preferences.cpp:341
 msgid "Conversion to guides"
 msgstr "Umwandlung in Hilfslinien"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:324
+#: ../src/ui/dialog/inkscape-preferences.cpp:342
 msgid "Keep objects after conversion to guides"
 msgstr "Behalte Objekte nach Umwandlung in Hilfslinien"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:326
+#: ../src/ui/dialog/inkscape-preferences.cpp:344
 msgid ""
 "When converting an object to guides, don't delete the object after the "
 "conversion"
 msgstr "Objekt bleibt erhalten, wenn es in Hilfslinien umgewandelt wird."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:327
+#: ../src/ui/dialog/inkscape-preferences.cpp:345
 msgid "Treat groups as a single object"
 msgstr "Behandle Gruppen als Einzelobjekte"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:329
+#: ../src/ui/dialog/inkscape-preferences.cpp:347
 msgid ""
 "Treat groups as a single object during conversion to guides rather than "
 "converting each child separately"
 msgstr ""
 "Gruppen werden als Ganzes (statt der Einzelteile) zu Hilfslinien umgewandelt."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:331
+#: ../src/ui/dialog/inkscape-preferences.cpp:349
 msgid "Average all sketches"
 msgstr "Aus allen Skizzenlinien mitteln"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:332
+#: ../src/ui/dialog/inkscape-preferences.cpp:350
 msgid "Width is in absolute units"
 msgstr "Breitenangabe in absoluten Einheiten"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:333
+#: ../src/ui/dialog/inkscape-preferences.cpp:351
 msgid "Select new path"
 msgstr "Neuen Pfad auswählen"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:334
+#: ../src/ui/dialog/inkscape-preferences.cpp:352
 msgid "Don't attach connectors to text objects"
 msgstr "Objektverbinder nicht mit Textobjekten verbinden"
 
 #. Selector
-#: ../src/ui/dialog/inkscape-preferences.cpp:337
+#: ../src/ui/dialog/inkscape-preferences.cpp:355
 msgid "Selector"
 msgstr "Auswahlwerkzeug"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:342
+#: ../src/ui/dialog/inkscape-preferences.cpp:360
 msgid "When transforming, show"
 msgstr "Zeige beim Transformieren"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:343
+#: ../src/ui/dialog/inkscape-preferences.cpp:361
 msgid "Objects"
 msgstr "Objekte"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:345
+#: ../src/ui/dialog/inkscape-preferences.cpp:363
 msgid "Show the actual objects when moving or transforming"
 msgstr "Zeige Objekte mit Inhalt beim Verschieben oder Verändern"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:346
+#: ../src/ui/dialog/inkscape-preferences.cpp:364
 msgid "Box outline"
 msgstr "Objektumriss"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:348
+#: ../src/ui/dialog/inkscape-preferences.cpp:366
 msgid "Show only a box outline of the objects when moving or transforming"
 msgstr "Nur einen Objektumriss beim Verschieben oder Verändern anzeigen"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:349
+#: ../src/ui/dialog/inkscape-preferences.cpp:367
 msgid "Per-object selection cue"
 msgstr "Pro Objekt-Auswahl"
 
 # CHECK
-#: ../src/ui/dialog/inkscape-preferences.cpp:350
+#: ../src/ui/dialog/inkscape-preferences.cpp:368
 msgctxt "Selection cue"
 msgid "None"
 msgstr "Keine"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:352
+#: ../src/ui/dialog/inkscape-preferences.cpp:370
 msgid "No per-object selection indication"
 msgstr "Keine Auswahlmarkierung für Objekte"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:353
+#: ../src/ui/dialog/inkscape-preferences.cpp:371
 msgid "Mark"
 msgstr "Markierung"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:355
+#: ../src/ui/dialog/inkscape-preferences.cpp:373
 msgid "Each selected object has a diamond mark in the top left corner"
 msgstr ""
 "Jedes ausgewählte Objekt hat eine diamantförmige Markierung in der linken "
 "oberen Ecke"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:356
+#: ../src/ui/dialog/inkscape-preferences.cpp:374
 msgid "Box"
 msgstr "Objektrahmen"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:358
+#: ../src/ui/dialog/inkscape-preferences.cpp:376
 msgid "Each selected object displays its bounding box"
 msgstr "Jedes gewählte Objekt zeigt seinen Objektrahmen"
 
 #. Node
-#: ../src/ui/dialog/inkscape-preferences.cpp:361
+#: ../src/ui/dialog/inkscape-preferences.cpp:379
 msgid "Node"
 msgstr "Knoten"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:364
+#: ../src/ui/dialog/inkscape-preferences.cpp:382
 msgid "Path outline"
 msgstr "Pfadumriss"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:365
+#: ../src/ui/dialog/inkscape-preferences.cpp:383
 msgid "Path outline color"
 msgstr "Entwurfspfad Farbe"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:366
+#: ../src/ui/dialog/inkscape-preferences.cpp:384
 msgid "Selects the color used for showing the path outline"
 msgstr "Die Farbe in der der Entwurfspfad angezeigt wird."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:367
+#: ../src/ui/dialog/inkscape-preferences.cpp:385
 msgid "Always show outline"
 msgstr "Umriss zeigen"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:368
+#: ../src/ui/dialog/inkscape-preferences.cpp:386
 msgid "Show outlines for all paths, not only invisible paths"
 msgstr "Zeigt Umrandung aller Pfade an, nicht nur von unsichtbaren Pfaden"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:369
+#: ../src/ui/dialog/inkscape-preferences.cpp:387
 msgid "Update outline when dragging nodes"
 msgstr "Umriss beim Ziehen von Knoten aktualisieren"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:370
+#: ../src/ui/dialog/inkscape-preferences.cpp:388
 msgid ""
 "Update the outline when dragging or transforming nodes; if this is off, the "
 "outline will only update when completing a drag"
@@ -18318,11 +18327,11 @@ msgstr ""
 "es deaktiviert ist, wird die Umrandung erst wieder aktualisiert, wenn die "
 "Aktion abgeschlossen ist."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:371
+#: ../src/ui/dialog/inkscape-preferences.cpp:389
 msgid "Update paths when dragging nodes"
 msgstr "Pfad beim Ziehen von Knoten aktualisieren"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:372
+#: ../src/ui/dialog/inkscape-preferences.cpp:390
 msgid ""
 "Update paths when dragging or transforming nodes; if this is off, paths will "
 "only be updated when completing a drag"
@@ -18331,11 +18340,11 @@ msgstr ""
 "deaktiviert ist, wird der Pfad erst aktualisiert, wenn die Aktion "
 "abgeschlossen ist."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:373
+#: ../src/ui/dialog/inkscape-preferences.cpp:391
 msgid "Show path direction on outlines"
 msgstr "Zeige die Pfadrichtung an Außenlinine"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:374
+#: ../src/ui/dialog/inkscape-preferences.cpp:392
 msgid ""
 "Visualize the direction of selected paths by drawing small arrows in the "
 "middle of each outline segment"
@@ -18343,30 +18352,30 @@ msgstr ""
 "Veranschaulichen Sie die Richtung der ausgewählten Pfade, in dem Sie kleine "
 "Pfeile in die Mitte jedes Rand-Segments zeichnen."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:375
+#: ../src/ui/dialog/inkscape-preferences.cpp:393
 msgid "Show temporary path outline"
 msgstr "Zeige temporär Pfadumrandung"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:376
+#: ../src/ui/dialog/inkscape-preferences.cpp:394
 msgid "When hovering over a path, briefly flash its outline"
 msgstr ""
 "Wenn die Maus über den Pfad bewegt wird, wird dessen Entwurfspfad kurz "
 "angezeigt."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:377
+#: ../src/ui/dialog/inkscape-preferences.cpp:395
 msgid "Show temporary outline for selected paths"
 msgstr "Zeige temporär Umrandung für ausgewählte Pfade"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:378
+#: ../src/ui/dialog/inkscape-preferences.cpp:396
 msgid "Show temporary outline even when a path is selected for editing"
 msgstr ""
 "Zeigt temporäre Umrandung an, wenn der Pfad zum Bearbeiten ausgewählt wurde."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:380
+#: ../src/ui/dialog/inkscape-preferences.cpp:398
 msgid "_Flash time:"
 msgstr "_Anzeigedauer:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:380
+#: ../src/ui/dialog/inkscape-preferences.cpp:398
 msgid ""
 "Specifies how long the path outline will be visible after a mouse-over (in "
 "milliseconds); specify 0 to have the outline shown until mouse leaves the "
@@ -18375,23 +18384,23 @@ msgstr ""
 "Bestimmt die Dauer der Pfadanzeige (in Millisekunden). Bei 0 wird der "
 "Entwurfspfad angezeigt bis die Maus den Bereich verlassen hat."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:381
+#: ../src/ui/dialog/inkscape-preferences.cpp:399
 msgid "Editing preferences"
 msgstr "Einstellungen bearbeiten"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:382
+#: ../src/ui/dialog/inkscape-preferences.cpp:400
 msgid "Show transform handles for single nodes"
 msgstr "Zeige Anfasser für einzelne Knoten"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:383
+#: ../src/ui/dialog/inkscape-preferences.cpp:401
 msgid "Show transform handles even when only a single node is selected"
 msgstr "Anfasser anzeigen, wenn nur ein einzelner Knoten ausgewählt ist."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:384
+#: ../src/ui/dialog/inkscape-preferences.cpp:402
 msgid "Deleting nodes preserves shape"
 msgstr "Knoten löschen, Form beibehalten"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:385
+#: ../src/ui/dialog/inkscape-preferences.cpp:403
 msgid ""
 "Move handles next to deleted nodes to resemble original shape; hold Ctrl to "
 "get the other behavior"
@@ -18400,31 +18409,31 @@ msgstr ""
 "Origianlform ähnelt; halten Sie für das andere Verhalten Strg gedrückt"
 
 #. Tweak
-#: ../src/ui/dialog/inkscape-preferences.cpp:388
+#: ../src/ui/dialog/inkscape-preferences.cpp:406
 msgid "Tweak"
 msgstr "Modellieren"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:389
+#: ../src/ui/dialog/inkscape-preferences.cpp:407
 msgid "Object paint style"
 msgstr "Objekt-Farbstil"
 
 #. Zoom
-#: ../src/ui/dialog/inkscape-preferences.cpp:394
+#: ../src/ui/dialog/inkscape-preferences.cpp:412
 #: ../src/widgets/desktop-widget.cpp:709
 msgid "Zoom"
 msgstr "Zoomfaktor"
 
 #. Measure
-#: ../src/ui/dialog/inkscape-preferences.cpp:399 ../src/verbs.cpp:2777
+#: ../src/ui/dialog/inkscape-preferences.cpp:417 ../src/verbs.cpp:2777
 msgctxt "ContextVerb"
 msgid "Measure"
 msgstr "Messen"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:401
+#: ../src/ui/dialog/inkscape-preferences.cpp:419
 msgid "Ignore first and last points"
 msgstr "Anfangs- und Endpunkt ignorieren"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:402
+#: ../src/ui/dialog/inkscape-preferences.cpp:420
 msgid ""
 "The start and end of the measurement tool's control line will not be "
 "considered for calculating lengths. Only lengths between actual curve "
@@ -18435,15 +18444,15 @@ msgstr ""
 "werden angezeigt."
 
 #. Shapes
-#: ../src/ui/dialog/inkscape-preferences.cpp:405
+#: ../src/ui/dialog/inkscape-preferences.cpp:423
 msgid "Shapes"
 msgstr "Formen"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:438
+#: ../src/ui/dialog/inkscape-preferences.cpp:456
 msgid "Sketch mode"
 msgstr "Skizziermodus"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:440
+#: ../src/ui/dialog/inkscape-preferences.cpp:458
 msgid ""
 "If on, the sketch result will be the normal average of all sketches made, "
 "instead of averaging the old result with the new sketch"
@@ -18452,17 +18461,17 @@ msgstr ""
 "statt das alte Ergebnis mit der neuen Linie zu mitteln."
 
 #. Pen
-#: ../src/ui/dialog/inkscape-preferences.cpp:443
+#: ../src/ui/dialog/inkscape-preferences.cpp:461
 #: ../src/ui/dialog/input.cpp:1485
 msgid "Pen"
 msgstr "Füller (Linien & Bézierkurven)"
 
 #. Calligraphy
-#: ../src/ui/dialog/inkscape-preferences.cpp:449
+#: ../src/ui/dialog/inkscape-preferences.cpp:467
 msgid "Calligraphy"
 msgstr "Kalligrafie"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:453
+#: ../src/ui/dialog/inkscape-preferences.cpp:471
 msgid ""
 "If on, pen width is in absolute units (px) independent of zoom; otherwise "
 "pen width depends on zoom so that it looks the same at any zoom"
@@ -18471,7 +18480,7 @@ msgstr ""
 "unabhängig vom Zoom; ansonsten hängt die Stiftbreite vom Zoom ab, so dass "
 "sie bei jeder Zoomeinstellung gleich aussieht"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:455
+#: ../src/ui/dialog/inkscape-preferences.cpp:473
 msgid ""
 "If on, each newly created object will be selected (deselecting previous "
 "selection)"
@@ -18480,27 +18489,27 @@ msgstr ""
 "Auswahl ist nicht mehr aktiv)"
 
 #. Text
-#: ../src/ui/dialog/inkscape-preferences.cpp:458 ../src/verbs.cpp:2769
+#: ../src/ui/dialog/inkscape-preferences.cpp:476 ../src/verbs.cpp:2769
 msgctxt "ContextVerb"
 msgid "Text"
 msgstr "Text"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:463
+#: ../src/ui/dialog/inkscape-preferences.cpp:481
 msgid "Show font samples in the drop-down list"
 msgstr "Zeigt Schriftart-Beispiele in der Auswahlliste"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:464
+#: ../src/ui/dialog/inkscape-preferences.cpp:482
 msgid ""
 "Show font samples alongside font names in the drop-down list in Text bar"
 msgstr ""
 "Zeigt Schriftart-Beispiele neben den Schriftartnamen in der Auswahlliste in "
 "der Textwerkzeugleiste"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:466
+#: ../src/ui/dialog/inkscape-preferences.cpp:484
 msgid "Show font substitution warning dialog"
 msgstr "Zeige Warndialog für Schriftersetzung"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:467
+#: ../src/ui/dialog/inkscape-preferences.cpp:485
 msgid ""
 "Show font substitution warning dialog when requested fonts are not available "
 "on the system"
@@ -18508,77 +18517,77 @@ msgstr ""
 "Zeigt Schriftartenersetzungs-Warnmeldung, wenn angeforderte Schriftarten auf "
 "dem System nicht verfügbar sind"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:470
+#: ../src/ui/dialog/inkscape-preferences.cpp:488
 msgid "Pixel"
 msgstr "Pixel"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:470
+#: ../src/ui/dialog/inkscape-preferences.cpp:488
 msgid "Pica"
 msgstr "Pica"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:470
+#: ../src/ui/dialog/inkscape-preferences.cpp:488
 msgid "Millimeter"
 msgstr "Millimeter"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:470
+#: ../src/ui/dialog/inkscape-preferences.cpp:488
 msgid "Centimeter"
 msgstr "Zentimeter"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:470
+#: ../src/ui/dialog/inkscape-preferences.cpp:488
 msgid "Inch"
 msgstr "Zoll"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:470
+#: ../src/ui/dialog/inkscape-preferences.cpp:488
 msgid "Em square"
 msgstr "Em-Quadrat"
 
 #. , _("Ex square"), _("Percent")
 #. , SP_CSS_UNIT_EX, SP_CSS_UNIT_PERCENT
-#: ../src/ui/dialog/inkscape-preferences.cpp:473
+#: ../src/ui/dialog/inkscape-preferences.cpp:491
 msgid "Text units"
 msgstr "Texteinheiten"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:475
+#: ../src/ui/dialog/inkscape-preferences.cpp:493
 msgid "Text size unit type:"
 msgstr "Textgrößen-Einheitstyp:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:476
+#: ../src/ui/dialog/inkscape-preferences.cpp:494
 msgid "Set the type of unit used in the text toolbar and text dialogs"
 msgstr ""
 "Setzt den Typ der Einheit, die in der Text-Werkzeugleiste und in "
 "Textdialogen verwendet wird"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:477
+#: ../src/ui/dialog/inkscape-preferences.cpp:495
 msgid "Always output text size in pixels (px)"
 msgstr "Ausgabe-Textgröße immer in Pixeln (px)"
 
 #. Spray
-#: ../src/ui/dialog/inkscape-preferences.cpp:483
+#: ../src/ui/dialog/inkscape-preferences.cpp:501
 msgid "Spray"
 msgstr "Spray"
 
 #. Eraser
-#: ../src/ui/dialog/inkscape-preferences.cpp:488
+#: ../src/ui/dialog/inkscape-preferences.cpp:506
 msgid "Eraser"
 msgstr "Radierer"
 
 #. Paint Bucket
-#: ../src/ui/dialog/inkscape-preferences.cpp:493
+#: ../src/ui/dialog/inkscape-preferences.cpp:511
 msgid "Paint Bucket"
 msgstr "Farbeimer"
 
 #. Gradient
-#: ../src/ui/dialog/inkscape-preferences.cpp:499
+#: ../src/ui/dialog/inkscape-preferences.cpp:517
 #: ../src/widgets/gradient-selector.cpp:144
 #: ../src/widgets/gradient-selector.cpp:295
 msgid "Gradient"
 msgstr "Farbverlauf"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:501
+#: ../src/ui/dialog/inkscape-preferences.cpp:519
 msgid "Prevent sharing of gradient definitions"
 msgstr "Keine gemeinsamen Verlaufsdefinitionen"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:503
+#: ../src/ui/dialog/inkscape-preferences.cpp:521
 msgid ""
 "When on, shared gradient definitions are automatically forked on change; "
 "uncheck to allow sharing of gradient definitions so that editing one object "
@@ -18588,11 +18597,11 @@ msgstr ""
 "sobald einer geändert wird. Andernfalls werden bei der Änderung eines "
 "Verlaufes sämtliche Objekte mit dem gleichen Verlauf ebenfalls geändert."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:504
+#: ../src/ui/dialog/inkscape-preferences.cpp:522
 msgid "Use legacy Gradient Editor"
 msgstr "Alten Farbverlaufseditor benutzen"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:506
+#: ../src/ui/dialog/inkscape-preferences.cpp:524
 msgid ""
 "When on, the Gradient Edit button in the Fill & Stroke dialog will show the "
 "legacy Gradient Editor dialog, when off the Gradient Tool will be used"
@@ -18601,11 +18610,11 @@ msgstr ""
 "Kontur Dialog den alten Verlaufs-Editor Dialog, wenn ausgeschaltet, wird das "
 "Verlaufswerkzeug verwendet."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:509
+#: ../src/ui/dialog/inkscape-preferences.cpp:527
 msgid "Linear gradient _angle:"
 msgstr "Winkel des linearen Farbverlaufs"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:510
+#: ../src/ui/dialog/inkscape-preferences.cpp:528
 msgid ""
 "Default angle of new linear gradients in degrees (clockwise from horizontal)"
 msgstr ""
@@ -18613,16 +18622,16 @@ msgstr ""
 "im Uhrzeigersinn)"
 
 #. Dropper
-#: ../src/ui/dialog/inkscape-preferences.cpp:514
+#: ../src/ui/dialog/inkscape-preferences.cpp:532
 msgid "Dropper"
 msgstr "Farbpipette"
 
 #. Connector
-#: ../src/ui/dialog/inkscape-preferences.cpp:519
+#: ../src/ui/dialog/inkscape-preferences.cpp:537
 msgid "Connector"
 msgstr "Objektverbinder"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:522
+#: ../src/ui/dialog/inkscape-preferences.cpp:540
 msgid "If on, connector attachment points will not be shown for text objects"
 msgstr ""
 "Wenn eingeschaltet, dann werden die Einrastpunkte nicht für Textobjekte "
@@ -18630,424 +18639,424 @@ msgstr ""
 
 #. LPETool
 #. disabled, because the LPETool is not finished yet.
-#: ../src/ui/dialog/inkscape-preferences.cpp:527
+#: ../src/ui/dialog/inkscape-preferences.cpp:545
 msgid "LPE Tool"
 msgstr "LPE-Werkzeug"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:534
+#: ../src/ui/dialog/inkscape-preferences.cpp:552
 msgid "Interface"
 msgstr "Benutzeroberfläche"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:537
+#: ../src/ui/dialog/inkscape-preferences.cpp:555
 msgid "System default"
 msgstr "Standardeinstellungen"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:538
+#: ../src/ui/dialog/inkscape-preferences.cpp:556
 msgid "Albanian (sq)"
 msgstr "Albanisch (sq)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:538
+#: ../src/ui/dialog/inkscape-preferences.cpp:556
 msgid "Amharic (am)"
 msgstr "Amharisch (am)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:538
+#: ../src/ui/dialog/inkscape-preferences.cpp:556
 msgid "Arabic (ar)"
 msgstr "Arabisch (ar)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:538
+#: ../src/ui/dialog/inkscape-preferences.cpp:556
 msgid "Armenian (hy)"
 msgstr "Armenisch (hy)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:538
+#: ../src/ui/dialog/inkscape-preferences.cpp:556
 msgid "Assamese (as)"
 msgstr "Assamesisch (as)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:538
+#: ../src/ui/dialog/inkscape-preferences.cpp:556
 msgid "Azerbaijani (az)"
 msgstr "Aserbeidschanisch (az)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:539
+#: ../src/ui/dialog/inkscape-preferences.cpp:557
 msgid "Basque (eu)"
 msgstr "Baskisch (eu)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:539
+#: ../src/ui/dialog/inkscape-preferences.cpp:557
 msgid "Belarusian (be)"
 msgstr "Belorussisch (be)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:539
+#: ../src/ui/dialog/inkscape-preferences.cpp:557
 msgid "Bulgarian (bg)"
 msgstr "Bulgarisch (bg)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:539
+#: ../src/ui/dialog/inkscape-preferences.cpp:557
 msgid "Bengali (bn)"
 msgstr "Bengalesisch (bn)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:539
+#: ../src/ui/dialog/inkscape-preferences.cpp:557
 msgid "Bengali/Bangladesh (bn_BD)"
 msgstr "Bengalesisch (bn_BD)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:539
+#: ../src/ui/dialog/inkscape-preferences.cpp:557
 msgid "Bodo (brx)"
 msgstr "Bodo (brx)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:539
+#: ../src/ui/dialog/inkscape-preferences.cpp:557
 msgid "Breton (br)"
 msgstr "Bretonisch (br)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:540
+#: ../src/ui/dialog/inkscape-preferences.cpp:558
 msgid "Catalan (ca)"
 msgstr "Katalanisch (ca)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:540
+#: ../src/ui/dialog/inkscape-preferences.cpp:558
 msgid "Valencian Catalan (ca@valencia)"
 msgstr "Valencianisches Katalan (ca@valencia)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:540
+#: ../src/ui/dialog/inkscape-preferences.cpp:558
 msgid "Chinese/China (zh_CN)"
 msgstr "Chinesisch/China (zh_CN)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:540
+#: ../src/ui/dialog/inkscape-preferences.cpp:558
 msgid "Chinese/Taiwan (zh_TW)"
 msgstr "Chinesisch/Taiwan (zh_TW)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:540
+#: ../src/ui/dialog/inkscape-preferences.cpp:558
 msgid "Croatian (hr)"
 msgstr "Kroatisch (hr)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:540
+#: ../src/ui/dialog/inkscape-preferences.cpp:558
 msgid "Czech (cs)"
 msgstr "Tschechisch (cs)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:541
+#: ../src/ui/dialog/inkscape-preferences.cpp:559
 msgid "Danish (da)"
 msgstr "Dänisch (da)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:541
+#: ../src/ui/dialog/inkscape-preferences.cpp:559
 msgid "Dogri (doi)"
 msgstr "Dogri (doi)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:541
+#: ../src/ui/dialog/inkscape-preferences.cpp:559
 msgid "Dutch (nl)"
 msgstr "Niderländisch (nl)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:541
+#: ../src/ui/dialog/inkscape-preferences.cpp:559
 msgid "Dzongkha (dz)"
 msgstr "Dzongkha (dz)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:542
+#: ../src/ui/dialog/inkscape-preferences.cpp:560
 msgid "German (de)"
 msgstr "Deutsch (de)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:542
+#: ../src/ui/dialog/inkscape-preferences.cpp:560
 msgid "Greek (el)"
 msgstr "Griechisch (el)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:543
+#: ../src/ui/dialog/inkscape-preferences.cpp:561
 msgid "English (en)"
 msgstr "Englisch (en)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:543
+#: ../src/ui/dialog/inkscape-preferences.cpp:561
 msgid "English/Australia (en_AU)"
 msgstr "Englisch/Australien (en_AU)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:543
+#: ../src/ui/dialog/inkscape-preferences.cpp:561
 msgid "English/Canada (en_CA)"
 msgstr "Englisch/Kanada (en_CA)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:543
+#: ../src/ui/dialog/inkscape-preferences.cpp:561
 msgid "English/Great Britain (en_GB)"
 msgstr "Englisch/Großbritannien (en_GB)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:543
+#: ../src/ui/dialog/inkscape-preferences.cpp:561
 msgid "Pig Latin (en_US@piglatin)"
 msgstr "Pig Latin (en_US@piglatin)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:543
+#: ../src/ui/dialog/inkscape-preferences.cpp:561
 msgid "Esperanto (eo)"
 msgstr "Esperanto (eo)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:543
+#: ../src/ui/dialog/inkscape-preferences.cpp:561
 msgid "Estonian (et)"
 msgstr "Estnisch (et)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:544
+#: ../src/ui/dialog/inkscape-preferences.cpp:562
 msgid "Farsi (fa)"
 msgstr "Farsi (fa)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:544
+#: ../src/ui/dialog/inkscape-preferences.cpp:562
 msgid "Finnish (fi)"
 msgstr "Finnisch (fi)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:544
+#: ../src/ui/dialog/inkscape-preferences.cpp:562
 msgid "French (fr)"
 msgstr "Französisch (fr)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:545
+#: ../src/ui/dialog/inkscape-preferences.cpp:563
 msgid "Galician (gl)"
 msgstr "Galizisch (gl)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:545
+#: ../src/ui/dialog/inkscape-preferences.cpp:563
 msgid "Gujarati (gu)"
 msgstr "Gujarati (gu)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:546
+#: ../src/ui/dialog/inkscape-preferences.cpp:564
 msgid "Hebrew (he)"
 msgstr "Hebräisch (he)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:546
+#: ../src/ui/dialog/inkscape-preferences.cpp:564
 msgid "Hindi (hi)"
 msgstr "Hindi (hi)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:546
+#: ../src/ui/dialog/inkscape-preferences.cpp:564
 msgid "Hungarian (hu)"
 msgstr "Ungarisch (hu)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:547
+#: ../src/ui/dialog/inkscape-preferences.cpp:565
 msgid "Icelandic (is)"
 msgstr "Isländisch (is)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:547
+#: ../src/ui/dialog/inkscape-preferences.cpp:565
 msgid "Indonesian (id)"
 msgstr "Indonesisch (id)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:547
+#: ../src/ui/dialog/inkscape-preferences.cpp:565
 msgid "Irish (ga)"
 msgstr "Irisch (ga)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:547
+#: ../src/ui/dialog/inkscape-preferences.cpp:565
 msgid "Italian (it)"
 msgstr "Italienisch (it)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:548
+#: ../src/ui/dialog/inkscape-preferences.cpp:566
 msgid "Japanese (ja)"
 msgstr "Japanisch (ja)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:549
+#: ../src/ui/dialog/inkscape-preferences.cpp:567
 msgid "Kannada (kn)"
 msgstr "Kannada (kn)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:549
+#: ../src/ui/dialog/inkscape-preferences.cpp:567
 msgid "Kashmiri in Perso-Arabic script (ks@aran)"
 msgstr "Kashmiri in erweiterter arabischer Schrift (ks@aran)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:549
+#: ../src/ui/dialog/inkscape-preferences.cpp:567
 msgid "Kashmiri in Devanagari script (ks@deva)"
 msgstr "Kashmiri in Devanagari-Schrift (ks@deva)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:549
+#: ../src/ui/dialog/inkscape-preferences.cpp:567
 msgid "Khmer (km)"
 msgstr "Khmer (km)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:549
+#: ../src/ui/dialog/inkscape-preferences.cpp:567
 msgid "Kinyarwanda (rw)"
 msgstr "Kinyarwanda (rw)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:549
+#: ../src/ui/dialog/inkscape-preferences.cpp:567
 msgid "Konkani (kok)"
 msgstr "Konkani (kok)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:549
+#: ../src/ui/dialog/inkscape-preferences.cpp:567
 msgid "Konkani in Latin script (kok@latin)"
 msgstr "Konkani in lateinischer Schrift (sr@latin)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:549
+#: ../src/ui/dialog/inkscape-preferences.cpp:567
 msgid "Korean (ko)"
 msgstr "Koreanisch (ko)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:550
+#: ../src/ui/dialog/inkscape-preferences.cpp:568
 msgid "Latvian (lv)"
 msgstr "Lettisch (lv)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:550
+#: ../src/ui/dialog/inkscape-preferences.cpp:568
 msgid "Lithuanian (lt)"
 msgstr "Litauisch (lt)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:551
+#: ../src/ui/dialog/inkscape-preferences.cpp:569
 msgid "Macedonian (mk)"
 msgstr "Mazedonisch (mk)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:551
+#: ../src/ui/dialog/inkscape-preferences.cpp:569
 msgid "Maithili (mai)"
 msgstr "Maithili (mai)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:551
+#: ../src/ui/dialog/inkscape-preferences.cpp:569
 msgid "Malayalam (ml)"
 msgstr "Malayalam (ml)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:551
+#: ../src/ui/dialog/inkscape-preferences.cpp:569
 msgid "Manipuri (mni)"
 msgstr "Meitei (mni)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:551
+#: ../src/ui/dialog/inkscape-preferences.cpp:569
 msgid "Manipuri in Bengali script (mni@beng)"
 msgstr "Manipuri in bengalischer Schrift (mni@beng)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:551
+#: ../src/ui/dialog/inkscape-preferences.cpp:569
 msgid "Marathi (mr)"
 msgstr "Marathi (mr)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:551
+#: ../src/ui/dialog/inkscape-preferences.cpp:569
 msgid "Mongolian (mn)"
 msgstr "Mongolisch (mn)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:552
+#: ../src/ui/dialog/inkscape-preferences.cpp:570
 msgid "Nepali (ne)"
 msgstr "Nepalesisch (ne)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:552
+#: ../src/ui/dialog/inkscape-preferences.cpp:570
 msgid "Norwegian Bokmål (nb)"
 msgstr "Norwegisch/Bokmål (nb)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:552
+#: ../src/ui/dialog/inkscape-preferences.cpp:570
 msgid "Norwegian Nynorsk (nn)"
 msgstr "Norwegisch/Nynorsk (nn)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:553
+#: ../src/ui/dialog/inkscape-preferences.cpp:571
 msgid "Odia (or)"
 msgstr "Orya (or)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:554
+#: ../src/ui/dialog/inkscape-preferences.cpp:572
 msgid "Panjabi (pa)"
 msgstr "Panjabi (pa)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:554
+#: ../src/ui/dialog/inkscape-preferences.cpp:572
 msgid "Polish (pl)"
 msgstr "Polnisch (pl)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:554
+#: ../src/ui/dialog/inkscape-preferences.cpp:572
 msgid "Portuguese (pt)"
 msgstr "Portugisisch(pt)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:554
+#: ../src/ui/dialog/inkscape-preferences.cpp:572
 msgid "Portuguese/Brazil (pt_BR)"
 msgstr "Portugisisch/Brasilien (pt_BR)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:555
+#: ../src/ui/dialog/inkscape-preferences.cpp:573
 msgid "Romanian (ro)"
 msgstr "Rumänisch (ro)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:555
+#: ../src/ui/dialog/inkscape-preferences.cpp:573
 msgid "Russian (ru)"
 msgstr "Russisch (ru)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:556
+#: ../src/ui/dialog/inkscape-preferences.cpp:574
 msgid "Sanskrit (sa)"
 msgstr "Sanskrit (sa)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:556
+#: ../src/ui/dialog/inkscape-preferences.cpp:574
 msgid "Santali (sat)"
 msgstr "Santali (sat)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:556
+#: ../src/ui/dialog/inkscape-preferences.cpp:574
 msgid "Santali in Devanagari script (sat@deva)"
 msgstr "Santali in Devanagari-Schrift (sat@deva)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:556
+#: ../src/ui/dialog/inkscape-preferences.cpp:574
 msgid "Serbian (sr)"
 msgstr "Serbisch (sr)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:556
+#: ../src/ui/dialog/inkscape-preferences.cpp:574
 msgid "Serbian in Latin script (sr@latin)"
 msgstr "Serbisch in lateinischer Schrift (sr@latin)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:557
+#: ../src/ui/dialog/inkscape-preferences.cpp:575
 msgid "Sindhi (sd)"
 msgstr "Sindhi (sd)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:557
+#: ../src/ui/dialog/inkscape-preferences.cpp:575
 msgid "Sindhi in Devanagari script (sd@deva)"
 msgstr "Sindhi in Devanagari-Schrift (sd@deva)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:557
+#: ../src/ui/dialog/inkscape-preferences.cpp:575
 msgid "Slovak (sk)"
 msgstr "Slovakisch (sk)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:557
+#: ../src/ui/dialog/inkscape-preferences.cpp:575
 msgid "Slovenian (sl)"
 msgstr "Slovenisch (sl)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:557
+#: ../src/ui/dialog/inkscape-preferences.cpp:575
 msgid "Spanish (es)"
 msgstr "Spanisch (es)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:557
+#: ../src/ui/dialog/inkscape-preferences.cpp:575
 msgid "Spanish/Mexico (es_MX)"
 msgstr "Spanisch/Mexico (es_MX)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:557
+#: ../src/ui/dialog/inkscape-preferences.cpp:575
 msgid "Swedish (sv)"
 msgstr "Schwedisch (sv)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:558
+#: ../src/ui/dialog/inkscape-preferences.cpp:576
 msgid "Tamil (ta)"
 msgstr "Tamilisch (ta)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:558
+#: ../src/ui/dialog/inkscape-preferences.cpp:576
 msgid "Telugu (te)"
 msgstr "Telugu (te)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:558
+#: ../src/ui/dialog/inkscape-preferences.cpp:576
 msgid "Thai (th)"
 msgstr "Thai (th)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:558
+#: ../src/ui/dialog/inkscape-preferences.cpp:576
 msgid "Turkish (tr)"
 msgstr "Türkisch (tr)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:559
+#: ../src/ui/dialog/inkscape-preferences.cpp:577
 msgid "Ukrainian (uk)"
 msgstr "Ukrainisch (uk)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:559
+#: ../src/ui/dialog/inkscape-preferences.cpp:577
 msgid "Urdu (ur)"
 msgstr "Urdu (ur)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:560
+#: ../src/ui/dialog/inkscape-preferences.cpp:578
 msgid "Vietnamese (vi)"
 msgstr "Vietnamesisch (vi)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:612
+#: ../src/ui/dialog/inkscape-preferences.cpp:630
 msgid "Language (requires restart):"
 msgstr "Sprache (erfordert Neustart)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:613
+#: ../src/ui/dialog/inkscape-preferences.cpp:631
 msgid "Set the language for menus and number formats"
 msgstr "Sprache für Menüs und Zahlenformate setzen"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:616
+#: ../src/ui/dialog/inkscape-preferences.cpp:634
 msgctxt "Icon size"
 msgid "Larger"
 msgstr "Größer"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:616
+#: ../src/ui/dialog/inkscape-preferences.cpp:634
 msgctxt "Icon size"
 msgid "Large"
 msgstr "Groß"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:616
+#: ../src/ui/dialog/inkscape-preferences.cpp:634
 msgctxt "Icon size"
 msgid "Small"
 msgstr "Klein"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:616
+#: ../src/ui/dialog/inkscape-preferences.cpp:634
 msgctxt "Icon size"
 msgid "Smaller"
 msgstr "Kleiner"
 
 # !!! called "Commands Bar" in other places
-#: ../src/ui/dialog/inkscape-preferences.cpp:621
+#: ../src/ui/dialog/inkscape-preferences.cpp:639
 msgid "Toolbox icon size:"
 msgstr "Symbolgröße in der Werkzeugleiste"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:622
+#: ../src/ui/dialog/inkscape-preferences.cpp:640
 msgid "Set the size for the tool icons (requires restart)"
 msgstr "Größe der Werkzeugsymbole verändern (erfordert Neustart)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:625
+#: ../src/ui/dialog/inkscape-preferences.cpp:643
 msgid "Control bar icon size:"
 msgstr "Symbolgröße in Einstellungsleiste"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:626
+#: ../src/ui/dialog/inkscape-preferences.cpp:644
 msgid ""
 "Set the size for the icons in tools' control bars to use (requires restart)"
 msgstr ""
@@ -19055,22 +19064,22 @@ msgstr ""
 "Neustart)"
 
 # !!! called "Commands Bar" in other places
-#: ../src/ui/dialog/inkscape-preferences.cpp:629
+#: ../src/ui/dialog/inkscape-preferences.cpp:647
 msgid "Secondary toolbar icon size:"
 msgstr "Symbolgröße in zweiter Werkzeugleiste"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:630
+#: ../src/ui/dialog/inkscape-preferences.cpp:648
 msgid ""
 "Set the size for the icons in secondary toolbars to use (requires restart)"
 msgstr ""
 "Bestimmt die Größe der Piktogramme in untergeordneten Werkzeugleisten "
 "(erfordert Neustart)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:633
+#: ../src/ui/dialog/inkscape-preferences.cpp:651
 msgid "Work-around color sliders not drawing"
 msgstr "Abhilfe für nicht gezeichnete Farb-Schieberegler"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:635
+#: ../src/ui/dialog/inkscape-preferences.cpp:653
 msgid ""
 "When on, will attempt to work around bugs in certain GTK themes drawing "
 "color sliders"
@@ -19078,26 +19087,26 @@ msgstr ""
 "Wenn gewählt, wird versucht, den Fehler bzgl. nicht gezeichneter Farb-"
 "Schieberegler in manchen GTK-Themen zu umgehen."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:640
+#: ../src/ui/dialog/inkscape-preferences.cpp:658
 msgid "Clear list"
 msgstr "Liste löschen"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:643
+#: ../src/ui/dialog/inkscape-preferences.cpp:661
 msgid "Maximum documents in Open _Recent:"
 msgstr "Länge der \"letzte Dokumente\"-Liste:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:644
+#: ../src/ui/dialog/inkscape-preferences.cpp:662
 msgid ""
 "Set the maximum length of the Open Recent list in the File menu, or clear "
 "the list"
 msgstr ""
 "Die maximale Länge der Liste zuletzt geöffneter Dokumente im Menü „Datei“"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:647
+#: ../src/ui/dialog/inkscape-preferences.cpp:665
 msgid "_Zoom correction factor (in %):"
 msgstr "_Zoom Korrektur (in %)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:648
+#: ../src/ui/dialog/inkscape-preferences.cpp:666
 msgid ""
 "Adjust the slider until the length of the ruler on your screen matches its "
 "real length. This information is used when zooming to 1:1, 1:2, etc., to "
@@ -19108,11 +19117,11 @@ msgstr ""
 "beim Zoom auf 1:1, 1:2, usw. das Objekt in realistischen Größen darzustellen."
 
 #. show infobox
-#: ../src/ui/dialog/inkscape-preferences.cpp:651
+#: ../src/ui/dialog/inkscape-preferences.cpp:669
 msgid "Show filter primitives infobox (requires restart)"
 msgstr "Zeigt Informationen zu den Filterbausteinen (erfordert Neustart)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:653
+#: ../src/ui/dialog/inkscape-preferences.cpp:671
 msgid ""
 "Show icons and descriptions for the filter primitives available at the "
 "filter effects dialog"
@@ -19120,26 +19129,26 @@ msgstr ""
 "Symbole und Beschreibungen für die verfügbaren Filterbausteine im "
 "Filtereffektdialog anzeigen"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:656
-#: ../src/ui/dialog/inkscape-preferences.cpp:664
+#: ../src/ui/dialog/inkscape-preferences.cpp:674
+#: ../src/ui/dialog/inkscape-preferences.cpp:682
 msgid "Icons only"
 msgstr "nur Symbole"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:656
-#: ../src/ui/dialog/inkscape-preferences.cpp:664
+#: ../src/ui/dialog/inkscape-preferences.cpp:674
+#: ../src/ui/dialog/inkscape-preferences.cpp:682
 msgid "Text only"
 msgstr "nur Text"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:656
-#: ../src/ui/dialog/inkscape-preferences.cpp:664
+#: ../src/ui/dialog/inkscape-preferences.cpp:674
+#: ../src/ui/dialog/inkscape-preferences.cpp:682
 msgid "Icons and text"
 msgstr "Symbole und Text"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:661
+#: ../src/ui/dialog/inkscape-preferences.cpp:679
 msgid "Dockbar style (requires restart):"
 msgstr "Dockleistenstil (erfordert Neustart)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:662
+#: ../src/ui/dialog/inkscape-preferences.cpp:680
 msgid ""
 "Selects whether the vertical bars on the dockbar will show text labels, "
 "icons, or both"
@@ -19147,11 +19156,11 @@ msgstr ""
 "Wählt, ob vertikale Leisten auf der Dockleiste Beschriftungen, Symbole oder "
 "beides angezeigen"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:669
+#: ../src/ui/dialog/inkscape-preferences.cpp:687
 msgid "Switcher style (requires restart):"
 msgstr "Stil des Umschalters (erfordert Neustart):"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:670
+#: ../src/ui/dialog/inkscape-preferences.cpp:688
 msgid ""
 "Selects whether the dockbar switcher will show text labels, icons, or both"
 msgstr ""
@@ -19159,97 +19168,97 @@ msgstr ""
 "zeigt"
 
 #. Windows
-#: ../src/ui/dialog/inkscape-preferences.cpp:674
+#: ../src/ui/dialog/inkscape-preferences.cpp:692
 msgid "Save and restore window geometry for each document"
 msgstr "Fenstergeometrie für jedes Dokument speichern und wiederherstellen"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:675
+#: ../src/ui/dialog/inkscape-preferences.cpp:693
 msgid "Remember and use last window's geometry"
 msgstr "Geometrie des letzten Fensters merken und verwenden"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:676
+#: ../src/ui/dialog/inkscape-preferences.cpp:694
 msgid "Don't save window geometry"
 msgstr "Fenstergeometrie nicht speichern"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:678
+#: ../src/ui/dialog/inkscape-preferences.cpp:696
 msgid "Save and restore dialogs status"
 msgstr "Speichern und Wiederherstellen von Dialog-Status"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:679
-#: ../src/ui/dialog/inkscape-preferences.cpp:715
+#: ../src/ui/dialog/inkscape-preferences.cpp:697
+#: ../src/ui/dialog/inkscape-preferences.cpp:733
 msgid "Don't save dialogs status"
 msgstr "Dialogstatus nicht speichern"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:681
-#: ../src/ui/dialog/inkscape-preferences.cpp:723
+#: ../src/ui/dialog/inkscape-preferences.cpp:699
+#: ../src/ui/dialog/inkscape-preferences.cpp:741
 msgid "Dockable"
 msgstr "Andockbar"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:685
+#: ../src/ui/dialog/inkscape-preferences.cpp:703
 msgid "Native open/save dialogs"
 msgstr "Native Dialoge für Öffnen/Speichern"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:686
+#: ../src/ui/dialog/inkscape-preferences.cpp:704
 msgid "GTK open/save dialogs"
 msgstr "GTK Dialoge für Öffnen/Speichern"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:688
+#: ../src/ui/dialog/inkscape-preferences.cpp:706
 msgid "Dialogs are hidden in taskbar"
 msgstr "Dialoge werden in der Fensterliste nicht angezeigt"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:689
+#: ../src/ui/dialog/inkscape-preferences.cpp:707
 msgid "Save and restore documents viewport"
 msgstr "Fenstergeometrie für jedes Dokument speichern und wiederherstellen"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:690
+#: ../src/ui/dialog/inkscape-preferences.cpp:708
 msgid "Zoom when window is resized"
 msgstr "Zeichnungsgröße ändern, wenn die Fenstergröße verändert wird"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:691
+#: ../src/ui/dialog/inkscape-preferences.cpp:709
 msgid "Show close button on dialogs"
 msgstr "Schaltflächen zum Schließen von Dialogen zeigen"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:692
+#: ../src/ui/dialog/inkscape-preferences.cpp:710
 msgctxt "Dialog on top"
 msgid "None"
 msgstr "Nein"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:694
+#: ../src/ui/dialog/inkscape-preferences.cpp:712
 msgid "Aggressive"
 msgstr "Aggressiv"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:697
+#: ../src/ui/dialog/inkscape-preferences.cpp:715
 msgctxt "Window size"
 msgid "Small"
 msgstr "Klein"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:697
+#: ../src/ui/dialog/inkscape-preferences.cpp:715
 msgctxt "Window size"
 msgid "Large"
 msgstr "Groß"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:697
+#: ../src/ui/dialog/inkscape-preferences.cpp:715
 msgctxt "Window size"
 msgid "Maximized"
 msgstr "Maximiert"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:701
+#: ../src/ui/dialog/inkscape-preferences.cpp:719
 msgid "Default window size:"
 msgstr "Standard Fenstergröße:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:702
+#: ../src/ui/dialog/inkscape-preferences.cpp:720
 msgid "Set the default window size"
 msgstr "Standard Fenstergröße setzen:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:705
+#: ../src/ui/dialog/inkscape-preferences.cpp:723
 msgid "Saving window geometry (size and position)"
 msgstr "Fenstergeometrie speichern (Größe und Position):"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:707
+#: ../src/ui/dialog/inkscape-preferences.cpp:725
 msgid "Let the window manager determine placement of all windows"
 msgstr "Dem Fenstermanager die Platzierung aller Fenster entscheiden lassen"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:709
+#: ../src/ui/dialog/inkscape-preferences.cpp:727
 msgid ""
 "Remember and use the last window's geometry (saves geometry to user "
 "preferences)"
@@ -19257,7 +19266,7 @@ msgstr ""
 "Geometrie des letzten Fensters merken und verwenden (speichert Geometrie in "
 "Benutzereinstellungen)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:711
+#: ../src/ui/dialog/inkscape-preferences.cpp:729
 msgid ""
 "Save and restore window geometry for each document (saves geometry in the "
 "document)"
@@ -19265,11 +19274,11 @@ msgstr ""
 "Fenstergeometrie für jedes Dokument speichern und wiederherstellen "
 "(speichert Geometrie im Dokument)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:713
+#: ../src/ui/dialog/inkscape-preferences.cpp:731
 msgid "Saving dialogs status"
 msgstr "Dialogstatus speichern"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:717
+#: ../src/ui/dialog/inkscape-preferences.cpp:735
 msgid ""
 "Save and restore dialogs status (the last open windows dialogs are saved "
 "when it closes)"
@@ -19277,66 +19286,66 @@ msgstr ""
 "Speichern und Wiederherstellen von Dialog-Status (die letzten offenen "
 "Fenster Dialoge werden gespeichert, wenn sie geschlossen werden)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:721
+#: ../src/ui/dialog/inkscape-preferences.cpp:739
 msgid "Dialog behavior (requires restart)"
 msgstr "Dialogfensterverhalten (erfordert Neustart)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:727
+#: ../src/ui/dialog/inkscape-preferences.cpp:745
 msgid "Desktop integration"
 msgstr "Desktopintegration"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:729
+#: ../src/ui/dialog/inkscape-preferences.cpp:747
 msgid "Use Windows like open and save dialogs"
 msgstr ""
 "Ans Windows-Design angelehnte Dialoge für Öffnen und Speichern benutzen"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:731
+#: ../src/ui/dialog/inkscape-preferences.cpp:749
 msgid "Use GTK open and save dialogs "
 msgstr ""
 "Dialoge der Komponentenbibliothek GTK für Öffnen und Speichern benutzen"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:735
+#: ../src/ui/dialog/inkscape-preferences.cpp:753
 msgid "Dialogs on top:"
 msgstr "Dialoge immer im Vordergrund:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:738
+#: ../src/ui/dialog/inkscape-preferences.cpp:756
 msgid "Dialogs are treated as regular windows"
 msgstr "Dialoge werden wie normale Fenster behandelt"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:740
+#: ../src/ui/dialog/inkscape-preferences.cpp:758
 msgid "Dialogs stay on top of document windows"
 msgstr "Dialoge bleiben vor Dokumentenfenstern"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:742
+#: ../src/ui/dialog/inkscape-preferences.cpp:760
 msgid "Same as Normal but may work better with some window managers"
 msgstr ""
 "Wie „Normal“, aber funktioniert evtl. besser mit manchen Fenstermanagern"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:745
+#: ../src/ui/dialog/inkscape-preferences.cpp:763
 msgid "Dialog Transparency"
 msgstr "Dialog Transparenz"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:747
+#: ../src/ui/dialog/inkscape-preferences.cpp:765
 msgid "_Opacity when focused:"
 msgstr "Deckkraft wenn fokussiert:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:749
+#: ../src/ui/dialog/inkscape-preferences.cpp:767
 msgid "Opacity when _unfocused:"
 msgstr "Deckkraft wenn nicht fokussiert:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:751
+#: ../src/ui/dialog/inkscape-preferences.cpp:769
 msgid "_Time of opacity change animation:"
 msgstr "Zeit der Animation beim Ändern der Deckkraft:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:754
+#: ../src/ui/dialog/inkscape-preferences.cpp:772
 msgid "Miscellaneous"
 msgstr "Verschiedenes"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:757
+#: ../src/ui/dialog/inkscape-preferences.cpp:775
 msgid "Whether dialog windows are to be hidden in the window manager taskbar"
 msgstr "Sollen Dialogfenster in der Fensterliste nicht angezeigt werden?"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:760
+#: ../src/ui/dialog/inkscape-preferences.cpp:778
 msgid ""
 "Zoom drawing when document window is resized, to keep the same area visible "
 "(this is the default which can be changed in any window using the button "
@@ -19347,7 +19356,7 @@ msgstr ""
 "Fenster mit der Schaltfläche über dem rechten Rollbalken geändert werden "
 "kann)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:762
+#: ../src/ui/dialog/inkscape-preferences.cpp:780
 msgid ""
 "Save documents viewport (zoom and panning position). Useful to turn off when "
 "sharing version controlled files."
@@ -19356,101 +19365,101 @@ msgstr ""
 "Nützlich abzuschalten, wenn gemeinsame Versionskontrolle von Dateien "
 "verwendet wird."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:764
+#: ../src/ui/dialog/inkscape-preferences.cpp:782
 msgid "Whether dialog windows have a close button (requires restart)"
 msgstr "Dialogfenster haben Schaltflächen zum Schließen (erfordert Neustart)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:765
+#: ../src/ui/dialog/inkscape-preferences.cpp:783
 msgid "Windows"
 msgstr "Fenster"
 
 #. Grids
-#: ../src/ui/dialog/inkscape-preferences.cpp:768
+#: ../src/ui/dialog/inkscape-preferences.cpp:786
 msgid "Line color when zooming out"
 msgstr "Linienfarbe beim Herauszoomen"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:771
+#: ../src/ui/dialog/inkscape-preferences.cpp:789
 msgid "The gridlines will be shown in minor grid line color"
 msgstr "Die Gitterlinien werden in der Nebengitterlinienfarbe angezeigt"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:773
+#: ../src/ui/dialog/inkscape-preferences.cpp:791
 msgid "The gridlines will be shown in major grid line color"
 msgstr "Die Gitterlinien werden in der Hauptgitterlinienfarbe angezeigt"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:775
+#: ../src/ui/dialog/inkscape-preferences.cpp:793
 msgid "Default grid settings"
 msgstr "Standard-Gittereinstellungen"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:781
-#: ../src/ui/dialog/inkscape-preferences.cpp:806
+#: ../src/ui/dialog/inkscape-preferences.cpp:799
+#: ../src/ui/dialog/inkscape-preferences.cpp:824
 msgid "Grid units:"
 msgstr "Gitter Einheiten:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:786
-#: ../src/ui/dialog/inkscape-preferences.cpp:811
+#: ../src/ui/dialog/inkscape-preferences.cpp:804
+#: ../src/ui/dialog/inkscape-preferences.cpp:829
 msgid "Origin X:"
 msgstr "Ursprung X:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:787
-#: ../src/ui/dialog/inkscape-preferences.cpp:812
+#: ../src/ui/dialog/inkscape-preferences.cpp:805
+#: ../src/ui/dialog/inkscape-preferences.cpp:830
 msgid "Origin Y:"
 msgstr "Ursprung Y:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:792
+#: ../src/ui/dialog/inkscape-preferences.cpp:810
 msgid "Spacing X:"
 msgstr "Abstand X:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:793
-#: ../src/ui/dialog/inkscape-preferences.cpp:815
+#: ../src/ui/dialog/inkscape-preferences.cpp:811
+#: ../src/ui/dialog/inkscape-preferences.cpp:833
 msgid "Spacing Y:"
 msgstr "Abstand Y:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:795
-#: ../src/ui/dialog/inkscape-preferences.cpp:796
-#: ../src/ui/dialog/inkscape-preferences.cpp:820
-#: ../src/ui/dialog/inkscape-preferences.cpp:821
+#: ../src/ui/dialog/inkscape-preferences.cpp:813
+#: ../src/ui/dialog/inkscape-preferences.cpp:814
+#: ../src/ui/dialog/inkscape-preferences.cpp:838
+#: ../src/ui/dialog/inkscape-preferences.cpp:839
 msgid "Minor grid line color:"
 msgstr "Farbe der Nebengitterlinien:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:796
-#: ../src/ui/dialog/inkscape-preferences.cpp:821
+#: ../src/ui/dialog/inkscape-preferences.cpp:814
+#: ../src/ui/dialog/inkscape-preferences.cpp:839
 msgid "Color used for normal grid lines"
 msgstr "Farbe der normalen Gitterlinien"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:797
-#: ../src/ui/dialog/inkscape-preferences.cpp:798
-#: ../src/ui/dialog/inkscape-preferences.cpp:822
-#: ../src/ui/dialog/inkscape-preferences.cpp:823
+#: ../src/ui/dialog/inkscape-preferences.cpp:815
+#: ../src/ui/dialog/inkscape-preferences.cpp:816
+#: ../src/ui/dialog/inkscape-preferences.cpp:840
+#: ../src/ui/dialog/inkscape-preferences.cpp:841
 msgid "Major grid line color:"
 msgstr "Farbe der Hauptgitterlinien:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:798
-#: ../src/ui/dialog/inkscape-preferences.cpp:823
+#: ../src/ui/dialog/inkscape-preferences.cpp:816
+#: ../src/ui/dialog/inkscape-preferences.cpp:841
 msgid "Color used for major (highlighted) grid lines"
 msgstr "Farbe der dicken (hervorgehobenen) Gitterlinien"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:800
-#: ../src/ui/dialog/inkscape-preferences.cpp:825
+#: ../src/ui/dialog/inkscape-preferences.cpp:818
+#: ../src/ui/dialog/inkscape-preferences.cpp:843
 msgid "Major grid line every:"
 msgstr "Hauptgitterlinien alle:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:801
+#: ../src/ui/dialog/inkscape-preferences.cpp:819
 msgid "Show dots instead of lines"
 msgstr "Zeige Punkte anstelle von Linien"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:802
+#: ../src/ui/dialog/inkscape-preferences.cpp:820
 msgid "If set, display dots at gridpoints instead of gridlines"
 msgstr "Punkte anstelle von Gitterlinien verwenden"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:883
+#: ../src/ui/dialog/inkscape-preferences.cpp:901
 msgid "Input/Output"
 msgstr "Eingabe/Ausgabe"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:886
+#: ../src/ui/dialog/inkscape-preferences.cpp:904
 msgid "Use current directory for \"Save As ...\""
 msgstr "Verwende aktuelles Verzeichnis für \"Speichern unter...\""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:888
+#: ../src/ui/dialog/inkscape-preferences.cpp:906
 msgid ""
 "When this option is on, the \"Save as...\" and \"Save a Copy...\" dialogs "
 "will always open in the directory where the currently open document is; when "
@@ -19462,11 +19471,11 @@ msgstr ""
 "Dokuments öffnen. Ist sie deaktiviert, wird das Verzeichnis geöffnet in "
 "welchem die letzte Datei gespeichert wurde."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:890
+#: ../src/ui/dialog/inkscape-preferences.cpp:908
 msgid "Add label comments to printing output"
 msgstr "Beim Ausdruck Bezeichnerkommentare mitdrucken"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:892
+#: ../src/ui/dialog/inkscape-preferences.cpp:910
 msgid ""
 "When on, a comment will be added to the raw print output, marking the "
 "rendered output for an object with its label"
@@ -19474,11 +19483,11 @@ msgstr ""
 "Diese Option fügt der unbehandelten Druckausgabe einen Kommentar hinzu.\n"
 "Das zu druckende Objekt wird mit einem Bezeichner markiert."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:894
+#: ../src/ui/dialog/inkscape-preferences.cpp:912
 msgid "Add default metadata to new documents"
 msgstr "Fügt Standard Metadaten neuen Dokumenten hinzu"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:896
+#: ../src/ui/dialog/inkscape-preferences.cpp:914
 msgid ""
 "Add default metadata to new documents. Default metadata can be set from "
 "Document Properties->Metadata."
@@ -19486,15 +19495,15 @@ msgstr ""
 "Fügt Standardmetadaten in neue Dokumente ein. Standard-Metadaten können über "
 "Dokument-Eigenschaften-> Metadaten gesetzt werden."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:900
+#: ../src/ui/dialog/inkscape-preferences.cpp:918
 msgid "_Grab sensitivity:"
 msgstr "Anfass-Empfindlichkeit:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:900
+#: ../src/ui/dialog/inkscape-preferences.cpp:918
 msgid "pixels (requires restart)"
 msgstr "Pixel (erfordert Neustart)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:901
+#: ../src/ui/dialog/inkscape-preferences.cpp:919
 msgid ""
 "How close on the screen you need to be to an object to be able to grab it "
 "with mouse (in screen pixels)"
@@ -19502,37 +19511,37 @@ msgstr ""
 "Mindestentfernung des Mauszeigers zu einem Objekt, um es zu erfassen (in "
 "Pixeln)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:903
+#: ../src/ui/dialog/inkscape-preferences.cpp:921
 msgid "_Click/drag threshold:"
 msgstr "Schwellwert für Klicken/Ziehen:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:903
-#: ../src/ui/dialog/inkscape-preferences.cpp:1245
-#: ../src/ui/dialog/inkscape-preferences.cpp:1249
-#: ../src/ui/dialog/inkscape-preferences.cpp:1259
+#: ../src/ui/dialog/inkscape-preferences.cpp:921
+#: ../src/ui/dialog/inkscape-preferences.cpp:1263
+#: ../src/ui/dialog/inkscape-preferences.cpp:1267
+#: ../src/ui/dialog/inkscape-preferences.cpp:1277
 msgid "pixels"
 msgstr "Pixel"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:904
+#: ../src/ui/dialog/inkscape-preferences.cpp:922
 msgid ""
 "Maximum mouse drag (in screen pixels) which is considered a click, not a drag"
 msgstr ""
 "Maximale Bewegung des Zeigers (in Pixeln), bei der noch Klicken statt Ziehen "
 "interpretiert wird"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:907
+#: ../src/ui/dialog/inkscape-preferences.cpp:925
 msgid "_Handle size:"
 msgstr "Anfassergröße:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:908
+#: ../src/ui/dialog/inkscape-preferences.cpp:926
 msgid "Set the relative size of node handles"
 msgstr "Relative Größe der Knotenanfasser setzen"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:910
+#: ../src/ui/dialog/inkscape-preferences.cpp:928
 msgid "Use pressure-sensitive tablet (requires restart)"
 msgstr "Druckempfindliches Grafiktablett verwenden (erfordert Neustart)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:912
+#: ../src/ui/dialog/inkscape-preferences.cpp:930
 msgid ""
 "Use the capabilities of a tablet or other pressure-sensitive device. Disable "
 "this only if you have problems with the tablet (you can still use it as a "
@@ -19542,27 +19551,27 @@ msgstr ""
 "Geräts verwenden. Schalten Sie dies nur aus, wenn Sie Probleme mit dem Gerät "
 "haben (Sie können es immer noch als Maus verwenden)."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:914
+#: ../src/ui/dialog/inkscape-preferences.cpp:932
 msgid "Switch tool based on tablet device (requires restart)"
 msgstr "Wechsel Werkzeug abhängig von Tablett-Werkzeug (erfordert Neustart)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:916
+#: ../src/ui/dialog/inkscape-preferences.cpp:934
 msgid ""
 "Change tool as different devices are used on the tablet (pen, eraser, mouse)"
 msgstr ""
 "Wechselt das Werkzeug, wenn auf dem Grafiktablett ein anderes Gerät "
 "verwendet wird (Stift, Radierer, Maus)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:917
+#: ../src/ui/dialog/inkscape-preferences.cpp:935
 msgid "Input devices"
 msgstr "Eingabegeräte"
 
 #. SVG output options
-#: ../src/ui/dialog/inkscape-preferences.cpp:920
+#: ../src/ui/dialog/inkscape-preferences.cpp:938
 msgid "Use named colors"
 msgstr "Farbnamen benutzen"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:921
+#: ../src/ui/dialog/inkscape-preferences.cpp:939
 msgid ""
 "If set, write the CSS name of the color when available (e.g. 'red' or "
 "'magenta') instead of the numeric value"
@@ -19570,23 +19579,23 @@ msgstr ""
 "Benutzt, wenn möglich, die CSS-Farbnamen (z.B. 'red', 'magenta') anstelle "
 "von nummerischen Werten."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:923
+#: ../src/ui/dialog/inkscape-preferences.cpp:941
 msgid "XML formatting"
 msgstr "XML-Format"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:925
+#: ../src/ui/dialog/inkscape-preferences.cpp:943
 msgid "Inline attributes"
 msgstr "Attribute kürzen"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:926
+#: ../src/ui/dialog/inkscape-preferences.cpp:944
 msgid "Put attributes on the same line as the element tag"
 msgstr "Schreibt Attribute in die gleiche Zeile wie das Element-Tag."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:929
+#: ../src/ui/dialog/inkscape-preferences.cpp:947
 msgid "_Indent, spaces:"
 msgstr "E_inzug, Leerzeichen:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:929
+#: ../src/ui/dialog/inkscape-preferences.cpp:947
 msgid ""
 "The number of spaces to use for indenting nested elements; set to 0 for no "
 "indentation"
@@ -19594,28 +19603,28 @@ msgstr ""
 "Die Anzahl an Leerstellen die zum einrücken untergeordneter Elemente genutzt "
 "werden soll. Mit 0 werden keine Leerstellen eingefügt."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:931
+#: ../src/ui/dialog/inkscape-preferences.cpp:949
 msgid "Path data"
 msgstr "Pfaddaten"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:934
+#: ../src/ui/dialog/inkscape-preferences.cpp:952
 msgid "Absolute"
 msgstr "Absolut"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:934
+#: ../src/ui/dialog/inkscape-preferences.cpp:952
 msgid "Relative"
 msgstr "Relativ"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:934
-#: ../src/ui/dialog/inkscape-preferences.cpp:1224
+#: ../src/ui/dialog/inkscape-preferences.cpp:952
+#: ../src/ui/dialog/inkscape-preferences.cpp:1242
 msgid "Optimized"
 msgstr "Optimiert"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:938
+#: ../src/ui/dialog/inkscape-preferences.cpp:956
 msgid "Path string format:"
 msgstr "Pfad-Zeichenkettenformat:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:938
+#: ../src/ui/dialog/inkscape-preferences.cpp:956
 msgid ""
 "Path data should be written: only with absolute coordinates, only with "
 "relative coordinates, or optimized for string length (mixed absolute and "
@@ -19625,11 +19634,11 @@ msgstr ""
 "relativen Koordinaten oder optimiert für die Textlänge (Mischung absoluter "
 "und relativer Koordinaten)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:940
+#: ../src/ui/dialog/inkscape-preferences.cpp:958
 msgid "Force repeat commands"
 msgstr "Erzwinge Kommandowiederholung"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:941
+#: ../src/ui/dialog/inkscape-preferences.cpp:959
 msgid ""
 "Force repeating of the same path command (for example, 'L 1,2 L 3,4' instead "
 "of 'L 1,2 3,4')"
@@ -19637,23 +19646,23 @@ msgstr ""
 "Erzwingt die Wiederholung von Pfad-Kommandos (z.B. 'L 1,2 L 3,4' anstatt 'L "
 "1,2 3,4')"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:943
+#: ../src/ui/dialog/inkscape-preferences.cpp:961
 msgid "Numbers"
 msgstr "Zahlen"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:946
+#: ../src/ui/dialog/inkscape-preferences.cpp:964
 msgid "_Numeric precision:"
 msgstr "Genauigkeit:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:946
+#: ../src/ui/dialog/inkscape-preferences.cpp:964
 msgid "Significant figures of the values written to the SVG file"
 msgstr "Maßgebliche Zahlen der Werte, die in die SVG-Datei geschrieben werden"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:949
+#: ../src/ui/dialog/inkscape-preferences.cpp:967
 msgid "Minimum _exponent:"
 msgstr "Minimal _Exponent:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:949
+#: ../src/ui/dialog/inkscape-preferences.cpp:967
 msgid ""
 "The smallest number written to SVG is 10 to the power of this exponent; "
 "anything smaller is written as zero"
@@ -19663,17 +19672,17 @@ msgstr ""
 
 #. Code to add controls for attribute checking options
 #. Add incorrect style properties options
-#: ../src/ui/dialog/inkscape-preferences.cpp:954
+#: ../src/ui/dialog/inkscape-preferences.cpp:972
 msgid "Improper Attributes Actions"
 msgstr "Unsachgemäße Attribut-Aktionen"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:956
-#: ../src/ui/dialog/inkscape-preferences.cpp:964
-#: ../src/ui/dialog/inkscape-preferences.cpp:972
+#: ../src/ui/dialog/inkscape-preferences.cpp:974
+#: ../src/ui/dialog/inkscape-preferences.cpp:982
+#: ../src/ui/dialog/inkscape-preferences.cpp:990
 msgid "Print warnings"
 msgstr "Drucke Warnungen"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:957
+#: ../src/ui/dialog/inkscape-preferences.cpp:975
 msgid ""
 "Print warning if invalid or non-useful attributes found. Database files "
 "located in inkscape_data_dir/attributes."
@@ -19681,20 +19690,20 @@ msgstr ""
 "Gebe Warnung aus, wenn ungültige oder nicht-nützliche Attribute gefunden "
 "werden. Datenbank-Dateien liegen in inkscape_data_dir/Attribute."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:958
+#: ../src/ui/dialog/inkscape-preferences.cpp:976
 msgid "Remove attributes"
 msgstr "Attribute löschen"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:959
+#: ../src/ui/dialog/inkscape-preferences.cpp:977
 msgid "Delete invalid or non-useful attributes from element tag"
 msgstr "Löscht ungültige oder nicht-nützliche Attribute vom Element-Tag"
 
 #. Add incorrect style properties options
-#: ../src/ui/dialog/inkscape-preferences.cpp:962
+#: ../src/ui/dialog/inkscape-preferences.cpp:980
 msgid "Inappropriate Style Properties Actions"
 msgstr "Unangemessene Stileigenschaften-Aktionen"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:965
+#: ../src/ui/dialog/inkscape-preferences.cpp:983
 msgid ""
 "Print warning if inappropriate style properties found (i.e. 'font-family' "
 "set on a <rect>). Database files located in inkscape_data_dir/attributes."
@@ -19703,21 +19712,21 @@ msgstr ""
 "'Schrift-Familie' auf einem <rect> gesetzt). Datenbank-Dateien liegen in "
 "inkscape_data_dir/Attribute."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:966
-#: ../src/ui/dialog/inkscape-preferences.cpp:974
+#: ../src/ui/dialog/inkscape-preferences.cpp:984
+#: ../src/ui/dialog/inkscape-preferences.cpp:992
 msgid "Remove style properties"
 msgstr "Stileigenschaften löschen"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:967
+#: ../src/ui/dialog/inkscape-preferences.cpp:985
 msgid "Delete inappropriate style properties"
 msgstr "Unpassende Stileigenschaften löschen"
 
 #. Add default or inherited style properties options
-#: ../src/ui/dialog/inkscape-preferences.cpp:970
+#: ../src/ui/dialog/inkscape-preferences.cpp:988
 msgid "Non-useful Style Properties Actions"
 msgstr "Nicht-nützliche Stileigenschafts-Aktionen"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:973
+#: ../src/ui/dialog/inkscape-preferences.cpp:991
 msgid ""
 "Print warning if redundant style properties found (i.e. if a property has "
 "the default value and a different value is not inherited or if value is the "
@@ -19729,19 +19738,19 @@ msgstr ""
 "vererbt wird oder wenn ein Wert der gleiche ist, wenn er vererbt würde). "
 "Datenbank-Dateien liegen in inkscape_data_dir/Attribute."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:975
+#: ../src/ui/dialog/inkscape-preferences.cpp:993
 msgid "Delete redundant style properties"
 msgstr "Redundante Stileigenschaften löschen"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:977
+#: ../src/ui/dialog/inkscape-preferences.cpp:995
 msgid "Check Attributes and Style Properties on"
 msgstr "Überprüfen Sie Attribute und Style-Eigenschaften auf"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:979
+#: ../src/ui/dialog/inkscape-preferences.cpp:997
 msgid "Reading"
 msgstr "Lesen"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:980
+#: ../src/ui/dialog/inkscape-preferences.cpp:998
 msgid ""
 "Check attributes and style properties on reading in SVG files (including "
 "those internal to Inkscape which will slow down startup)"
@@ -19750,11 +19759,11 @@ msgstr ""
 "Dateien (einschließlich derjenigen internen von Inkscape die den Start "
 "verlangsamen)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:981
+#: ../src/ui/dialog/inkscape-preferences.cpp:999
 msgid "Editing"
 msgstr "Bearbeiten"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:982
+#: ../src/ui/dialog/inkscape-preferences.cpp:1000
 msgid ""
 "Check attributes and style properties while editing SVG files (may slow down "
 "Inkscape, mostly useful for debugging)"
@@ -19762,42 +19771,42 @@ msgstr ""
 "Überprüfen Sie die Attribute und Style-Eigenschaften während der Bearbeitung "
 "von SVG-Dateien (kann Inkscape verlangsamen, meist nützlich zur Fehlersuche)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:983
+#: ../src/ui/dialog/inkscape-preferences.cpp:1001
 msgid "Writing"
 msgstr "Schreiben"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:984
+#: ../src/ui/dialog/inkscape-preferences.cpp:1002
 msgid "Check attributes and style properties on writing out SVG files"
 msgstr ""
 "Überprüfen Sie die Attribut- und Style-Eigenschaften beim Schreiben von SVG-"
 "Dateien"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:986
+#: ../src/ui/dialog/inkscape-preferences.cpp:1004
 msgid "SVG output"
 msgstr "SVG-Ausgabe"
 
 #. TRANSLATORS: see http://www.newsandtech.com/issues/2004/03-04/pt/03-04_rendering.htm
-#: ../src/ui/dialog/inkscape-preferences.cpp:992
+#: ../src/ui/dialog/inkscape-preferences.cpp:1010
 msgid "Perceptual"
 msgstr "Wahrnehmung"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:992
+#: ../src/ui/dialog/inkscape-preferences.cpp:1010
 msgid "Relative Colorimetric"
 msgstr "Relative Farbmetrik"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:992
+#: ../src/ui/dialog/inkscape-preferences.cpp:1010
 msgid "Absolute Colorimetric"
 msgstr "Absolute Farbmetrik"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:996
+#: ../src/ui/dialog/inkscape-preferences.cpp:1014
 msgid "(Note: Color management has been disabled in this build)"
 msgstr "(Hinweis: Farbmanagement wurde in diesem Build deaktiviert)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1000
+#: ../src/ui/dialog/inkscape-preferences.cpp:1018
 msgid "Display adjustment"
 msgstr "Anzeigeanpassungen"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1010
+#: ../src/ui/dialog/inkscape-preferences.cpp:1028
 #, c-format
 msgid ""
 "The ICC profile to use to calibrate display output.\n"
@@ -19806,113 +19815,113 @@ msgstr ""
 "ICC-Profil, das zum Kalibrieren der Anzeige genutzt werden soll.\n"
 "Durchsuchte Verzeichnisse:%s"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1011
+#: ../src/ui/dialog/inkscape-preferences.cpp:1029
 msgid "Display profile:"
 msgstr "Anzeigeprofil:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1016
+#: ../src/ui/dialog/inkscape-preferences.cpp:1034
 msgid "Retrieve profile from display"
 msgstr "Profil von Anzeige ermitteln"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1019
+#: ../src/ui/dialog/inkscape-preferences.cpp:1037
 msgid "Retrieve profiles from those attached to displays via XICC"
 msgstr "Ermittle Profil von angeschlossenen Anzeigegeräten mittels XICC."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1021
+#: ../src/ui/dialog/inkscape-preferences.cpp:1039
 msgid "Retrieve profiles from those attached to displays"
 msgstr "Ermittle Profil von angeschlossenen Anzeigegeräten."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1026
+#: ../src/ui/dialog/inkscape-preferences.cpp:1044
 msgid "Display rendering intent:"
 msgstr "Anzeigenversatz"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1027
+#: ../src/ui/dialog/inkscape-preferences.cpp:1045
 msgid "The rendering intent to use to calibrate display output"
 msgstr ""
 "Geräte-Wiedergabe-Bedeutung wird genutzt, um die Ausgabe zu kalibrieren."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1029
+#: ../src/ui/dialog/inkscape-preferences.cpp:1047
 msgid "Proofing"
 msgstr "Druckprobe"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1031
+#: ../src/ui/dialog/inkscape-preferences.cpp:1049
 msgid "Simulate output on screen"
 msgstr "Simulieren der Ausgabe auf dem Bildschirm"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1033
+#: ../src/ui/dialog/inkscape-preferences.cpp:1051
 msgid "Simulates output of target device"
 msgstr "Simulieren der Ausgabe auf dem Zielgerät"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1035
+#: ../src/ui/dialog/inkscape-preferences.cpp:1053
 msgid "Mark out of gamut colors"
 msgstr "Farben der Farbskala hervorheben"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1037
+#: ../src/ui/dialog/inkscape-preferences.cpp:1055
 msgid "Highlights colors that are out of gamut for the target device"
 msgstr "Hebe Farben hervor die nicht im Farbbereich des Ausgabegerätes liegen."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1049
+#: ../src/ui/dialog/inkscape-preferences.cpp:1067
 msgid "Out of gamut warning color:"
 msgstr "Farbe für Farbbereichswarnung:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1050
+#: ../src/ui/dialog/inkscape-preferences.cpp:1068
 msgid "Selects the color used for out of gamut warning"
 msgstr "Bestimmt die Farbe die für Farbbereichswarnungen genutzt werden soll."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1052
+#: ../src/ui/dialog/inkscape-preferences.cpp:1070
 msgid "Device profile:"
 msgstr "Geräteprofil:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1053
+#: ../src/ui/dialog/inkscape-preferences.cpp:1071
 msgid "The ICC profile to use to simulate device output"
 msgstr "ICC-Profil für Simulation der Geräteausgabe."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1056
+#: ../src/ui/dialog/inkscape-preferences.cpp:1074
 msgid "Device rendering intent:"
 msgstr "Gerätewiedergabe-Bedeutung"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1057
+#: ../src/ui/dialog/inkscape-preferences.cpp:1075
 msgid "The rendering intent to use to calibrate device output"
 msgstr ""
 "Geräte-Wiedergabe-Bedeutung wird genutzt, um die Ausgabe zu kalibrieren."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1059
+#: ../src/ui/dialog/inkscape-preferences.cpp:1077
 msgid "Black point compensation"
 msgstr "Schwarzpunktanpassung"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1061
+#: ../src/ui/dialog/inkscape-preferences.cpp:1079
 msgid "Enables black point compensation"
 msgstr "Ermöglicht Schwarzpunktkompensation"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1063
+#: ../src/ui/dialog/inkscape-preferences.cpp:1081
 msgid "Preserve black"
 msgstr "Schwarzwert beibehalten"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1070
+#: ../src/ui/dialog/inkscape-preferences.cpp:1088
 msgid "(LittleCMS 1.15 or later required)"
 msgstr "(LittleCMS 1.15 oder neuer wird benötigt)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1072
+#: ../src/ui/dialog/inkscape-preferences.cpp:1090
 msgid "Preserve K channel in CMYK -> CMYK transforms"
 msgstr "Lässt K-Kanal in CMYK -> CMYK Transformation unverändert."
 
 # CHECK
-#: ../src/ui/dialog/inkscape-preferences.cpp:1086
+#: ../src/ui/dialog/inkscape-preferences.cpp:1104
 #: ../src/ui/widget/color-icc-selector.cpp:394
 #: ../src/ui/widget/color-icc-selector.cpp:700
 msgid "<none>"
 msgstr "<keins>"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1131
+#: ../src/ui/dialog/inkscape-preferences.cpp:1149
 msgid "Color management"
 msgstr "Farb-Management"
 
 #. Autosave options
-#: ../src/ui/dialog/inkscape-preferences.cpp:1134
+#: ../src/ui/dialog/inkscape-preferences.cpp:1152
 msgid "Enable autosave (requires restart)"
 msgstr "Automatisches Speichern (erfordert Neustart)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1135
+#: ../src/ui/dialog/inkscape-preferences.cpp:1153
 msgid ""
 "Automatically save the current document(s) at a given interval, thus "
 "minimizing loss in case of a crash"
@@ -19920,12 +19929,12 @@ msgstr ""
 "Speichert das Dokument in bestimmten Zeitabständen. Dadurch kann der "
 "Verlust, der durch Programmabstürze entsteht, verringert werden."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1141
+#: ../src/ui/dialog/inkscape-preferences.cpp:1159
 msgctxt "Filesystem"
 msgid "Autosave _directory:"
 msgstr "Ver_zeichnis für automatisches Speichern:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1141
+#: ../src/ui/dialog/inkscape-preferences.cpp:1159
 msgid ""
 "The directory where autosaves will be written. This should be an absolute "
 "path (starts with / on UNIX or a drive letter such as C: on Windows). "
@@ -19934,21 +19943,21 @@ msgstr ""
 "sollte ein absoluter Pfad sein (startet mit / bei UNIX und einem "
 "Laufwerksbuchstaben wir C: bei Windows)."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1143
+#: ../src/ui/dialog/inkscape-preferences.cpp:1161
 msgid "_Interval (in minutes):"
 msgstr "Zeitabstand (in Minuten):"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1143
+#: ../src/ui/dialog/inkscape-preferences.cpp:1161
 msgid "Interval (in minutes) at which document will be autosaved"
 msgstr ""
 "In diesen Zeitabständen (in Minuten) wird das Dokument automatisch "
 "gespeichert."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1145
+#: ../src/ui/dialog/inkscape-preferences.cpp:1163
 msgid "_Maximum number of autosaves:"
 msgstr "Maximale Anzahl an Sicherungen:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1145
+#: ../src/ui/dialog/inkscape-preferences.cpp:1163
 msgid ""
 "Maximum number of autosaved files; use this to limit the storage space used"
 msgstr ""
@@ -19967,15 +19976,15 @@ msgstr ""
 #. _autosave_autosave_interval.signal_changed().connect( sigc::ptr_fun(inkscape_autosave_init), TRUE );
 #.
 #. -----------
-#: ../src/ui/dialog/inkscape-preferences.cpp:1160
+#: ../src/ui/dialog/inkscape-preferences.cpp:1178
 msgid "Autosave"
 msgstr "Automatische Sicherung"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1164
+#: ../src/ui/dialog/inkscape-preferences.cpp:1182
 msgid "Open Clip Art Library _Server Name:"
 msgstr "Open Clip Art Library Servername:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1165
+#: ../src/ui/dialog/inkscape-preferences.cpp:1183
 msgid ""
 "The server name of the Open Clip Art Library webdav server; it's used by the "
 "Import and Export to OCAL function"
@@ -19983,35 +19992,35 @@ msgstr ""
 "Der Servername des \"Open Clip Art Library\" Webdav Servers. Dieser wird "
 "beim Im- und Export zur OCAL verwendet."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1167
+#: ../src/ui/dialog/inkscape-preferences.cpp:1185
 msgid "Open Clip Art Library _Username:"
 msgstr "Open Clip Art Library Benutzername:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1168
+#: ../src/ui/dialog/inkscape-preferences.cpp:1186
 msgid "The username used to log into Open Clip Art Library"
 msgstr "Der Benutzername zum einloggen in die Open Clip Art Library."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1170
+#: ../src/ui/dialog/inkscape-preferences.cpp:1188
 msgid "Open Clip Art Library _Password:"
 msgstr "Open Clip Art Library Kennwort:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1171
+#: ../src/ui/dialog/inkscape-preferences.cpp:1189
 msgid "The password used to log into Open Clip Art Library"
 msgstr "Das Passwort zum einloggen in die Open Clip Art Library."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1172
+#: ../src/ui/dialog/inkscape-preferences.cpp:1190
 msgid "Open Clip Art"
 msgstr "Login bei Open Clip Art"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1177
+#: ../src/ui/dialog/inkscape-preferences.cpp:1195
 msgid "Behavior"
 msgstr "Verhalten"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1181
+#: ../src/ui/dialog/inkscape-preferences.cpp:1199
 msgid "_Simplification threshold:"
 msgstr "Schwellwert für Vereinfachungen:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1182
+#: ../src/ui/dialog/inkscape-preferences.cpp:1200
 msgid ""
 "How strong is the Node tool's Simplify command by default. If you invoke "
 "this command several times in quick succession, it will act more and more "
@@ -20021,47 +20030,47 @@ msgstr ""
 "mehrmals schnell hintereinander ausgeführt, erhöht sich die Stärke; kurze "
 "Pause dazwischen setzt den Schwellwert zurück."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1184
+#: ../src/ui/dialog/inkscape-preferences.cpp:1202
 msgid "Color stock markers the same color as object"
 msgstr ""
 "Standard-Knotenmarkierung in der gleichen Farbe wie das Objekt einfärben"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1185
+#: ../src/ui/dialog/inkscape-preferences.cpp:1203
 msgid "Color custom markers the same color as object"
 msgstr ""
 "Färbe die benutzerdefinierten Marker in der gleichen Farbe wie das Objekt"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1186
-#: ../src/ui/dialog/inkscape-preferences.cpp:1406
+#: ../src/ui/dialog/inkscape-preferences.cpp:1204
+#: ../src/ui/dialog/inkscape-preferences.cpp:1424
 msgid "Update marker color when object color changes"
 msgstr "Aktualisiert die Marker Farbe, wenn das Objekt die Farbe ändert"
 
 #. Selecting options
-#: ../src/ui/dialog/inkscape-preferences.cpp:1189
+#: ../src/ui/dialog/inkscape-preferences.cpp:1207
 msgid "Select in all layers"
 msgstr "In allen Ebenen auswählen"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1190
+#: ../src/ui/dialog/inkscape-preferences.cpp:1208
 msgid "Select only within current layer"
 msgstr "Nur innerhalb der aktuellen Ebene auswählen"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1191
+#: ../src/ui/dialog/inkscape-preferences.cpp:1209
 msgid "Select in current layer and sublayers"
 msgstr "Nur innerhalb der aktuellen Ebene und Unterebenen auswählen"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1192
+#: ../src/ui/dialog/inkscape-preferences.cpp:1210
 msgid "Ignore hidden objects and layers"
 msgstr "Ausgeblendete Objekte und Ebenen ignorieren"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1193
+#: ../src/ui/dialog/inkscape-preferences.cpp:1211
 msgid "Ignore locked objects and layers"
 msgstr "Gesperrte Objekte und Ebenen ignorieren"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1194
+#: ../src/ui/dialog/inkscape-preferences.cpp:1212
 msgid "Deselect upon layer change"
 msgstr "Auswahl bei Ebenenwechsel aufheben"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1197
+#: ../src/ui/dialog/inkscape-preferences.cpp:1215
 msgid ""
 "Uncheck this to be able to keep the current objects selected when the "
 "current layer changes"
@@ -20069,20 +20078,20 @@ msgstr ""
 "Dieses abwählen um Objekte ausgewählt zu lassen, wenn die aktuelle Ebene "
 "geändert wird"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1199
+#: ../src/ui/dialog/inkscape-preferences.cpp:1217
 msgid "Ctrl+A, Tab, Shift+Tab"
 msgstr "Strg+A, Tab, Umschalt+Tab"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1201
+#: ../src/ui/dialog/inkscape-preferences.cpp:1219
 msgid "Make keyboard selection commands work on objects in all layers"
 msgstr "Tastaturkommandos zur Auswahl wirken auf Objekte aller Ebenen"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1203
+#: ../src/ui/dialog/inkscape-preferences.cpp:1221
 msgid "Make keyboard selection commands work on objects in current layer only"
 msgstr ""
 "Tastaturkommandos zur Auswahl wirken nur auf Objekte in der aktuellen Ebene"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1205
+#: ../src/ui/dialog/inkscape-preferences.cpp:1223
 msgid ""
 "Make keyboard selection commands work on objects in current layer and all "
 "its sublayers"
@@ -20090,7 +20099,7 @@ msgstr ""
 "Tastaturkommandos zur Auswahl wirken auf Objekte in der aktuellen Ebene und "
 "aller ihrer Unterebenen"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1207
+#: ../src/ui/dialog/inkscape-preferences.cpp:1225
 msgid ""
 "Uncheck this to be able to select objects that are hidden (either by "
 "themselves or by being in a hidden layer)"
@@ -20098,7 +20107,7 @@ msgstr ""
 "Dieses abwählen, damit ausgeblendete Objekte ausgewählt werden können (gilt "
 "auch für Objekte in ausgeblendeten Ebenen/Gruppierungen)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1209
+#: ../src/ui/dialog/inkscape-preferences.cpp:1227
 msgid ""
 "Uncheck this to be able to select objects that are locked (either by "
 "themselves or by being in a locked layer)"
@@ -20106,77 +20115,77 @@ msgstr ""
 "Dieses abwählen damit gesperrte Objekte ausgewählt werden können (gilt auch "
 "für Objekte in gesperrten Ebenen/Gruppierungen)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1211
+#: ../src/ui/dialog/inkscape-preferences.cpp:1229
 msgid "Wrap when cycling objects in z-order"
 msgstr "Beim drehen von Objekten in Z-Ordnung einwickeln."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1213
+#: ../src/ui/dialog/inkscape-preferences.cpp:1231
 msgid "Alt+Scroll Wheel"
 msgstr "Alt+Scroll-Rad"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1215
+#: ../src/ui/dialog/inkscape-preferences.cpp:1233
 msgid "Wrap around at start and end when cycling objects in z-order"
 msgstr ""
 "Beim drehen von Objekten in Z-Ordnung um den Start- und Endpunkt einwickeln."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1217
+#: ../src/ui/dialog/inkscape-preferences.cpp:1235
 msgid "Selecting"
 msgstr "Auswählen"
 
 #. Transforms options
-#: ../src/ui/dialog/inkscape-preferences.cpp:1220
+#: ../src/ui/dialog/inkscape-preferences.cpp:1238
 #: ../src/widgets/select-toolbar.cpp:564
 msgid "Scale stroke width"
 msgstr "Breite der Kontur skalieren"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1221
+#: ../src/ui/dialog/inkscape-preferences.cpp:1239
 msgid "Scale rounded corners in rectangles"
 msgstr "Abgerundete Ecken in Rechtecken mitskalieren"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1222
+#: ../src/ui/dialog/inkscape-preferences.cpp:1240
 msgid "Transform gradients"
 msgstr "Farbverläufe transformieren"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1223
+#: ../src/ui/dialog/inkscape-preferences.cpp:1241
 msgid "Transform patterns"
 msgstr "Füllmuster transformieren"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1225
+#: ../src/ui/dialog/inkscape-preferences.cpp:1243
 msgid "Preserved"
 msgstr "Beibehalten"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1228
+#: ../src/ui/dialog/inkscape-preferences.cpp:1246
 #: ../src/widgets/select-toolbar.cpp:565
 msgid "When scaling objects, scale the stroke width by the same proportion"
 msgstr ""
 "Wenn Objekte skaliert werden, dann wird die Breite der Kontur ebenso "
 "skaliert."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1230
+#: ../src/ui/dialog/inkscape-preferences.cpp:1248
 #: ../src/widgets/select-toolbar.cpp:576
 msgid "When scaling rectangles, scale the radii of rounded corners"
 msgstr ""
 "Wenn Rechtecke skaliert werden, dann werden die Radien von abgerundeten "
 "Ecken ebenso mitskaliert."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1232
+#: ../src/ui/dialog/inkscape-preferences.cpp:1250
 #: ../src/widgets/select-toolbar.cpp:587
 msgid "Move gradients (in fill or stroke) along with the objects"
 msgstr ""
 "Farbverläufe (in Füllung oder Konturen) zusammen mit den Objekten "
 "transformieren"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1234
+#: ../src/ui/dialog/inkscape-preferences.cpp:1252
 #: ../src/widgets/select-toolbar.cpp:598
 msgid "Move patterns (in fill or stroke) along with the objects"
 msgstr ""
 "Muster (in Füllung oder Konturen) zusammen mit den Objekten transformieren"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1235
+#: ../src/ui/dialog/inkscape-preferences.cpp:1253
 msgid "Store transformation"
 msgstr "Transformation speichern:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1237
+#: ../src/ui/dialog/inkscape-preferences.cpp:1255
 msgid ""
 "If possible, apply transformation to objects without adding a transform= "
 "attribute"
@@ -20184,19 +20193,19 @@ msgstr ""
 "Wenn möglich, dann werden Transformationen auf Objekte angewendet, ohne ein "
 "transform=-Attribut hinzuzufügen."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1239
+#: ../src/ui/dialog/inkscape-preferences.cpp:1257
 msgid "Always store transformation as a transform= attribute on objects"
 msgstr "Transformationen immer als transform=-Attribute speichern."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1241
+#: ../src/ui/dialog/inkscape-preferences.cpp:1259
 msgid "Transforms"
 msgstr "Transformationen"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1245
+#: ../src/ui/dialog/inkscape-preferences.cpp:1263
 msgid "Mouse _wheel scrolls by:"
 msgstr "Mausrad rollt um:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1246
+#: ../src/ui/dialog/inkscape-preferences.cpp:1264
 msgid ""
 "One mouse wheel notch scrolls by this distance in screen pixels "
 "(horizontally with Shift)"
@@ -20204,23 +20213,23 @@ msgstr ""
 "Eine Stufe des Maus-Rades rollt um die angegebene Distanz in Pixeln "
 "(horizontal mit Umschalt)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1247
+#: ../src/ui/dialog/inkscape-preferences.cpp:1265
 msgid "Ctrl+arrows"
 msgstr "Strg+Pfeile"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1249
+#: ../src/ui/dialog/inkscape-preferences.cpp:1267
 msgid "Sc_roll by:"
 msgstr "Rolle um:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1250
+#: ../src/ui/dialog/inkscape-preferences.cpp:1268
 msgid "Pressing Ctrl+arrow key scrolls by this distance (in screen pixels)"
 msgstr "Strg+Pfeiltasten rollen um diese Distanz (in Pixeln)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1252
+#: ../src/ui/dialog/inkscape-preferences.cpp:1270
 msgid "_Acceleration:"
 msgstr "Beschleunigung:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1253
+#: ../src/ui/dialog/inkscape-preferences.cpp:1271
 msgid ""
 "Pressing and holding Ctrl+arrow will gradually speed up scrolling (0 for no "
 "acceleration)"
@@ -20228,15 +20237,15 @@ msgstr ""
 "Drücken von Strg+Pfeiltaste erhöht zunehmend die Rollgeschwindigkeit (0 "
 "bedeutet „keine Beschleunigung“)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1254
+#: ../src/ui/dialog/inkscape-preferences.cpp:1272
 msgid "Autoscrolling"
 msgstr "Automatisches Rollen"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1256
+#: ../src/ui/dialog/inkscape-preferences.cpp:1274
 msgid "_Speed:"
 msgstr "Geschwindigkeit:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1257
+#: ../src/ui/dialog/inkscape-preferences.cpp:1275
 msgid ""
 "How fast the canvas autoscrolls when you drag beyond canvas edge (0 to turn "
 "autoscroll off)"
@@ -20244,12 +20253,12 @@ msgstr ""
 "Geschwindigkeit mit der die Arbeitsfläche verschoben wird, wenn der Zeiger "
 "ihren Rand überschreitet (0: Autorollen ist deaktiviert)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1259
+#: ../src/ui/dialog/inkscape-preferences.cpp:1277
 #: ../src/ui/dialog/tracedialog.cpp:522 ../src/ui/dialog/tracedialog.cpp:721
 msgid "_Threshold:"
 msgstr "Schwellwer_t:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1260
+#: ../src/ui/dialog/inkscape-preferences.cpp:1278
 msgid ""
 "How far (in screen pixels) you need to be from the canvas edge to trigger "
 "autoscroll; positive is outside the canvas, negative is within the canvas"
@@ -20258,23 +20267,23 @@ msgstr ""
 "Autorollen aktiv ist: positive Werte liegen außerhalb, negative Werte "
 "innerhalb der Arbeitsfläche"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1261
+#: ../src/ui/dialog/inkscape-preferences.cpp:1279
 msgid "Mouse move pans when Space is pressed"
 msgstr ""
 "Bewegen der Maus verschiebt die Arbeitsfläche, wenn die Leertaste gedrückt "
 "ist."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1263
+#: ../src/ui/dialog/inkscape-preferences.cpp:1281
 msgid "When on, pressing and holding Space and dragging pans canvas"
 msgstr ""
 "Wenn aktiviert, wird die Arbeitsfläche beim Bewegen der Maus verschoben "
 "während die Leertaste gehalten wird"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1264
+#: ../src/ui/dialog/inkscape-preferences.cpp:1282
 msgid "Mouse wheel zooms by default"
 msgstr "Standardmäßig zoomt das Mausrad"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1266
+#: ../src/ui/dialog/inkscape-preferences.cpp:1284
 msgid ""
 "When on, mouse wheel zooms without Ctrl and scrolls canvas with Ctrl; when "
 "off, it zooms with Ctrl and scrolls without Ctrl"
@@ -20282,55 +20291,55 @@ msgstr ""
 "Wenn aktiviert kann mit dem Mausrad die Ansicht vergrößert/verkleinert "
 "werden. Ist dies deaktiviert benötigt man dazu Strg+Mausrad."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1267
+#: ../src/ui/dialog/inkscape-preferences.cpp:1285
 msgid "Scrolling"
 msgstr "Rollen"
 
 #. Snapping options
-#: ../src/ui/dialog/inkscape-preferences.cpp:1270
+#: ../src/ui/dialog/inkscape-preferences.cpp:1288
 msgid "Snap indicator"
 msgstr "Einrast-Indikator"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1272
+#: ../src/ui/dialog/inkscape-preferences.cpp:1290
 msgid "Enable snap indicator"
 msgstr "Einrast-Indikator aktivieren"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1274
+#: ../src/ui/dialog/inkscape-preferences.cpp:1292
 msgid "After snapping, a symbol is drawn at the point that has snapped"
 msgstr ""
 "Nach dem Einrasten wird ein Symbol an der Stelle, die einrastete, gezeichnet."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1279
+#: ../src/ui/dialog/inkscape-preferences.cpp:1297
 msgid "Snap indicator persistence (in seconds):"
 msgstr "Anzeigedauer des Einrast-Indikators (in Sekunden)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1280
+#: ../src/ui/dialog/inkscape-preferences.cpp:1298
 msgid ""
 "Controls how long the snap indicator message will be shown, before it "
 "disappears"
 msgstr ""
 "Bestimmt wie lange die Einrast-Indikator-Benachrichtigung angezeigt wird."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1282
+#: ../src/ui/dialog/inkscape-preferences.cpp:1300
 msgid "What should snap"
 msgstr "Woran einrasten"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1284
+#: ../src/ui/dialog/inkscape-preferences.cpp:1302
 msgid "Only snap the node closest to the pointer"
 msgstr "Nur an dem Knoten einrasten, der dem Zeiger am nächsten ist."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1286
+#: ../src/ui/dialog/inkscape-preferences.cpp:1304
 msgid ""
 "Only try to snap the node that is initially closest to the mouse pointer"
 msgstr ""
 "Nur versuchen an dem Knoten einzurasten, der dem Mauszeiger zu Beginn am "
 "nächsten ist."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1289
+#: ../src/ui/dialog/inkscape-preferences.cpp:1307
 msgid "_Weight factor:"
 msgstr "Gewichtungsfaktor:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1290
+#: ../src/ui/dialog/inkscape-preferences.cpp:1308
 msgid ""
 "When multiple snap solutions are found, then Inkscape can either prefer the "
 "closest transformation (when set to 0), or prefer the node that was "
@@ -20340,11 +20349,11 @@ msgstr ""
 "Transformation anwenden (wenn auf 0 gesetzt) oder am Knoten, der dem "
 "Mauszeiger am nähesten ist (wenn auf 1 gesetzt) einrasten."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1292
+#: ../src/ui/dialog/inkscape-preferences.cpp:1310
 msgid "Snap the mouse pointer when dragging a constrained knot"
 msgstr "Rastet den Mauszeiger ein, wenn ein festgesetzter Knoten gezogen wird."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1294
+#: ../src/ui/dialog/inkscape-preferences.cpp:1312
 msgid ""
 "When dragging a knot along a constraint line, then snap the position of the "
 "mouse pointer instead of snapping the projection of the knot onto the "
@@ -20353,15 +20362,15 @@ msgstr ""
 "Wird ein Knoten entlang einer festgesetzten Linie gezogen, dann rastet der "
 "Mauszeiger statt der Projektion des Knotens auf der Linie ein."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1296
+#: ../src/ui/dialog/inkscape-preferences.cpp:1314
 msgid "Delayed snap"
 msgstr "Zeitverzögertes Einrasten"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1299
+#: ../src/ui/dialog/inkscape-preferences.cpp:1317
 msgid "Delay (in seconds):"
 msgstr "Verzögerung (Sekunden):"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1300
+#: ../src/ui/dialog/inkscape-preferences.cpp:1318
 msgid ""
 "Postpone snapping as long as the mouse is moving, and then wait an "
 "additional fraction of a second. This additional delay is specified here. "
@@ -20371,16 +20380,16 @@ msgstr ""
 "danach, unterdrücken. Diese zusätzliche Verzögerung wird hier festgelegt. "
 "Ist sie Null oder sehr klein erfolgt sofortiges Einrasten."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1302
+#: ../src/ui/dialog/inkscape-preferences.cpp:1320
 msgid "Snapping"
 msgstr "Einrasten"
 
 #. nudgedistance is limited to 1000 in select-context.cpp: use the same limit here
-#: ../src/ui/dialog/inkscape-preferences.cpp:1307
+#: ../src/ui/dialog/inkscape-preferences.cpp:1325
 msgid "_Arrow keys move by:"
 msgstr "Pfeiltasten bewegen um:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1308
+#: ../src/ui/dialog/inkscape-preferences.cpp:1326
 msgid ""
 "Pressing an arrow key moves selected object(s) or node(s) by this distance"
 msgstr ""
@@ -20388,31 +20397,31 @@ msgstr ""
 "Knoten) um diese Entfernung (in SVG-Pixeln)"
 
 #. defaultscale is limited to 1000 in select-context.cpp: use the same limit here
-#: ../src/ui/dialog/inkscape-preferences.cpp:1311
+#: ../src/ui/dialog/inkscape-preferences.cpp:1329
 msgid "> and < _scale by:"
 msgstr "> und < skalieren um:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1312
+#: ../src/ui/dialog/inkscape-preferences.cpp:1330
 msgid "Pressing > or < scales selection up or down by this increment"
 msgstr ""
 "Drücken von > oder < skaliert die ausgewählten Elemente um diesen Wert "
 "größer oder kleiner (in SVG-Pixeln)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1314
+#: ../src/ui/dialog/inkscape-preferences.cpp:1332
 msgid "_Inset/Outset by:"
 msgstr "Schrumpfen/Erweitern um:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1315
+#: ../src/ui/dialog/inkscape-preferences.cpp:1333
 msgid "Inset and Outset commands displace the path by this distance"
 msgstr ""
 "Schrumpfungs- und Erweiterungsbefehle verändern den Pfad um diese Distanz "
 "(in SVG-Pixeln)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1316
+#: ../src/ui/dialog/inkscape-preferences.cpp:1334
 msgid "Compass-like display of angles"
 msgstr "Anzeige von Winkeln wie bei einem Kompass"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1318
+#: ../src/ui/dialog/inkscape-preferences.cpp:1336
 msgid ""
 "When on, angles are displayed with 0 at north, 0 to 360 range, positive "
 "clockwise; otherwise with 0 at east, -180 to 180 range, positive "
@@ -20423,21 +20432,21 @@ msgstr ""
 "-180 bis 180, positiv entgegen dem Uhrzeigersinn"
 
 # CHECK
-#: ../src/ui/dialog/inkscape-preferences.cpp:1320
+#: ../src/ui/dialog/inkscape-preferences.cpp:1338
 msgctxt "Rotation angle"
 msgid "None"
 msgstr "Keine"
 
 # !!! need %s
-#: ../src/ui/dialog/inkscape-preferences.cpp:1324
+#: ../src/ui/dialog/inkscape-preferences.cpp:1342
 msgid "_Rotation snaps every:"
 msgstr "D_rehung rastet ein alle:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1324
+#: ../src/ui/dialog/inkscape-preferences.cpp:1342
 msgid "degrees"
 msgstr "Grad"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1325
+#: ../src/ui/dialog/inkscape-preferences.cpp:1343
 msgid ""
 "Rotating with Ctrl pressed snaps every that much degrees; also, pressing "
 "[ or ] rotates by this amount"
@@ -20445,11 +20454,11 @@ msgstr ""
 "Drehung mit gedrückter Strg-Taste lässt das Objekt mit dieser Gradrastung "
 "einrasten; die Tasten [ oder ] haben den gleichen Effekt"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1326
+#: ../src/ui/dialog/inkscape-preferences.cpp:1344
 msgid "Relative snapping of guideline angles"
 msgstr "Relatives Einrasten von Hilfslinienwinkeln"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1328
+#: ../src/ui/dialog/inkscape-preferences.cpp:1346
 msgid ""
 "When on, the snap angles when rotating a guideline will be relative to the "
 "original angle"
@@ -20457,17 +20466,17 @@ msgstr ""
 "Wenn eingeschaltet, wird der Einrastwinkel beim Drehen einer Hilfslinie "
 "relativ zum ursprünglichen Winkel"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1330
+#: ../src/ui/dialog/inkscape-preferences.cpp:1348
 msgid "_Zoom in/out by:"
 msgstr "Zoomfaktor vergrößern/verkleinern um:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1330
+#: ../src/ui/dialog/inkscape-preferences.cpp:1348
 #: ../src/ui/dialog/objects.cpp:1662
 #: ../src/ui/widget/filter-effect-chooser.cpp:27
 msgid "%"
 msgstr "%"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1331
+#: ../src/ui/dialog/inkscape-preferences.cpp:1349
 msgid ""
 "Zoom tool click, +/- keys, and middle click zoom in and out by this "
 "multiplier"
@@ -20475,45 +20484,45 @@ msgstr ""
 "Mit dem Zoomwerkzeug klicken, die + oder - Taste drücken, oder die mittlere "
 "Maustaste betätigen, damit sich die Zoomgröße um diesen Faktor ändert"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1332
+#: ../src/ui/dialog/inkscape-preferences.cpp:1350
 msgid "Steps"
 msgstr "Schritte"
 
 #. Clones options
-#: ../src/ui/dialog/inkscape-preferences.cpp:1335
+#: ../src/ui/dialog/inkscape-preferences.cpp:1353
 msgid "Move in parallel"
 msgstr "parallel verschoben"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1337
+#: ../src/ui/dialog/inkscape-preferences.cpp:1355
 msgid "Stay unmoved"
 msgstr "unbewegt bleiben"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1339
+#: ../src/ui/dialog/inkscape-preferences.cpp:1357
 msgid "Move according to transform"
 msgstr "sich entsprechend des transform=-Attributs bewegen"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1341
+#: ../src/ui/dialog/inkscape-preferences.cpp:1359
 msgid "Are unlinked"
 msgstr "ihre Verbindung zum Original verlieren"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1343
+#: ../src/ui/dialog/inkscape-preferences.cpp:1361
 msgid "Are deleted"
 msgstr "ebenso gelöscht"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1346
+#: ../src/ui/dialog/inkscape-preferences.cpp:1364
 msgid "Moving original: clones and linked offsets"
 msgstr "Verschiebe Original: Klone und verbundener Versatz"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1348
+#: ../src/ui/dialog/inkscape-preferences.cpp:1366
 msgid "Clones are translated by the same vector as their original"
 msgstr "Klone werden mit demselben Vektor wie das Original verschoben."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1350
+#: ../src/ui/dialog/inkscape-preferences.cpp:1368
 msgid "Clones preserve their positions when their original is moved"
 msgstr ""
 "Klone bleiben an ihren Positionen, während das Original verschoben wird."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1352
+#: ../src/ui/dialog/inkscape-preferences.cpp:1370
 msgid ""
 "Each clone moves according to the value of its transform= attribute; for "
 "example, a rotated clone will move in a different direction than its original"
@@ -20522,27 +20531,27 @@ msgstr ""
 "Attributs. Ein rotierter Klon wird sich zum Beispiel in eine andere Richtung "
 "als das Original drehen."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1353
+#: ../src/ui/dialog/inkscape-preferences.cpp:1371
 msgid "Deleting original: clones"
 msgstr "Lösche Original: Klone"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1355
+#: ../src/ui/dialog/inkscape-preferences.cpp:1373
 msgid "Orphaned clones are converted to regular objects"
 msgstr "Klone ohne Original werden zu regulären Objekten umgewandelt."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1357
+#: ../src/ui/dialog/inkscape-preferences.cpp:1375
 msgid "Orphaned clones are deleted along with their original"
 msgstr "Klone werden zusammen mit ihrem Original gelöscht."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1359
+#: ../src/ui/dialog/inkscape-preferences.cpp:1377
 msgid "Duplicating original+clones/linked offset"
 msgstr "Duplizieren Original+Klone/verbundener Versatz"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1361
+#: ../src/ui/dialog/inkscape-preferences.cpp:1379
 msgid "Relink duplicated clones"
 msgstr "Duplizierte Klone neu verbinden"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1363
+#: ../src/ui/dialog/inkscape-preferences.cpp:1381
 msgid ""
 "When duplicating a selection containing both a clone and its original "
 "(possibly in groups), relink the duplicated clone to the duplicated original "
@@ -20553,29 +20562,29 @@ msgstr ""
 "den alten Originalen."
 
 #. TRANSLATORS: Heading for the Inkscape Preferences "Clones" Page
-#: ../src/ui/dialog/inkscape-preferences.cpp:1366
+#: ../src/ui/dialog/inkscape-preferences.cpp:1384
 msgid "Clones"
 msgstr "Klone"
 
 #. Clip paths and masks options
-#: ../src/ui/dialog/inkscape-preferences.cpp:1369
+#: ../src/ui/dialog/inkscape-preferences.cpp:1387
 msgid "When applying, use the topmost selected object as clippath/mask"
 msgstr ""
 "Das oberste ausgewählte Objekt soll als Ausschneidepfad oder Maske verwendet "
 "werden."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1371
+#: ../src/ui/dialog/inkscape-preferences.cpp:1389
 msgid ""
 "Uncheck this to use the bottom selected object as the clipping path or mask"
 msgstr ""
 "Häkchen entfernen, um das unterste ausgewählte Objekt als Ausschneidepfad "
 "oder Maske zu verwenden"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1372
+#: ../src/ui/dialog/inkscape-preferences.cpp:1390
 msgid "Remove clippath/mask object after applying"
 msgstr "Ausschneidepfad/Maske nach dem Anwenden entfernen"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1374
+#: ../src/ui/dialog/inkscape-preferences.cpp:1392
 msgid ""
 "After applying, remove the object used as the clipping path or mask from the "
 "drawing"
@@ -20583,62 +20592,62 @@ msgstr ""
 "Das Objekt, welches als Ausschneidepfad oder Maske verwendet wird, nach dem "
 "Anwenden aus der Zeichnung löschen"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1376
+#: ../src/ui/dialog/inkscape-preferences.cpp:1394
 msgid "Before applying"
 msgstr "Vor dem Anwenden"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1378
+#: ../src/ui/dialog/inkscape-preferences.cpp:1396
 msgid "Do not group clipped/masked objects"
 msgstr "Kein Gruppieren ausgeschnittener/maskierter Objekte"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1379
+#: ../src/ui/dialog/inkscape-preferences.cpp:1397
 msgid "Put every clipped/masked object in its own group"
 msgstr ""
 "Jedes ausgeschnittene/maskierte Objekt in seiner eigenen Gruppe anlegen"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1380
+#: ../src/ui/dialog/inkscape-preferences.cpp:1398
 msgid "Put all clipped/masked objects into one group"
 msgstr ""
 "Alle ausgeschnittenen/maskierten Objekte in einer einzelne Gruppe ablegen"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1383
+#: ../src/ui/dialog/inkscape-preferences.cpp:1401
 msgid "Apply clippath/mask to every object"
 msgstr "Ausschneidepfad/Maske auf jedes Objekt anwenden"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1386
+#: ../src/ui/dialog/inkscape-preferences.cpp:1404
 msgid "Apply clippath/mask to groups containing single object"
 msgstr ""
 "Ausschneidepfad/Maske auf neue Gruppen anwenden, die jeweils ein "
 "Einzelobjekt beinhalten"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1389
+#: ../src/ui/dialog/inkscape-preferences.cpp:1407
 msgid "Apply clippath/mask to group containing all objects"
 msgstr ""
 "Ausschneidepfad/Maske auf eine neue Gruppe anwenden, die alle Objekte "
 "beinhaltet"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1391
+#: ../src/ui/dialog/inkscape-preferences.cpp:1409
 msgid "After releasing"
 msgstr "Nach dem Lösen:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1393
+#: ../src/ui/dialog/inkscape-preferences.cpp:1411
 msgid "Ungroup automatically created groups"
 msgstr "Gruppierung automatisch erstellter Gruppen aufheben"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1395
+#: ../src/ui/dialog/inkscape-preferences.cpp:1413
 msgid "Ungroup groups created when setting clip/mask"
 msgstr "Gruppierung aufheben beim Setzen von (Ausschneide-)Maske"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1397
+#: ../src/ui/dialog/inkscape-preferences.cpp:1415
 msgid "Clippaths and masks"
 msgstr "Ausschneidepfade und Masken"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1400
+#: ../src/ui/dialog/inkscape-preferences.cpp:1418
 msgid "Stroke Style Markers"
 msgstr "Strich-Stilmarkierungen"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1402
-#: ../src/ui/dialog/inkscape-preferences.cpp:1404
+#: ../src/ui/dialog/inkscape-preferences.cpp:1420
+#: ../src/ui/dialog/inkscape-preferences.cpp:1422
 msgid ""
 "Stroke color same as object, fill color either object fill color or marker "
 "fill color"
@@ -20646,50 +20655,50 @@ msgstr ""
 "Konturfarbe wie Objekt, Füllfarbe entweder Objekt-Füllfarbe oder "
 "Knotenmarkierung-Füllfarbe"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1408
+#: ../src/ui/dialog/inkscape-preferences.cpp:1426
 #: ../share/extensions/hershey.inx.h:27
 msgid "Markers"
 msgstr "Knotenmarkierungen"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1411
+#: ../src/ui/dialog/inkscape-preferences.cpp:1429
 msgid "Document cleanup"
 msgstr "Dokumentbereinigung"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1412
-#: ../src/ui/dialog/inkscape-preferences.cpp:1414
+#: ../src/ui/dialog/inkscape-preferences.cpp:1430
+#: ../src/ui/dialog/inkscape-preferences.cpp:1432
 msgid "Remove unused swatches when doing a document cleanup"
 msgstr "Entferne unbenutzte Swatches bei der Dokumentenbereinigung"
 
 #. tooltip
-#: ../src/ui/dialog/inkscape-preferences.cpp:1415
+#: ../src/ui/dialog/inkscape-preferences.cpp:1433
 msgid "Cleanup"
 msgstr "Bereinigen"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1423
+#: ../src/ui/dialog/inkscape-preferences.cpp:1441
 msgid "Number of _Threads:"
 msgstr "Anzahl der Threads:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1423
-#: ../src/ui/dialog/inkscape-preferences.cpp:1963
+#: ../src/ui/dialog/inkscape-preferences.cpp:1441
+#: ../src/ui/dialog/inkscape-preferences.cpp:1985
 msgid "(requires restart)"
 msgstr "(erfordert Neustart)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1424
+#: ../src/ui/dialog/inkscape-preferences.cpp:1442
 msgid "Configure number of processors/threads to use when rendering filters"
 msgstr ""
 "Konfiguration der Anzahl an Prozessoren/Threads, die für das Rendern von "
 "Filtern genutzt werden sollen"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1428
+#: ../src/ui/dialog/inkscape-preferences.cpp:1446
 msgid "Rendering _cache size:"
 msgstr "Rendering-Cachegröße:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1428
+#: ../src/ui/dialog/inkscape-preferences.cpp:1446
 msgctxt "mebibyte (2^20 bytes) abbreviation"
 msgid "MiB"
 msgstr "MiB"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1428
+#: ../src/ui/dialog/inkscape-preferences.cpp:1446
 msgid ""
 "Set the amount of memory per document which can be used to store rendered "
 "parts of the drawing for later reuse; set to zero to disable caching"
@@ -20698,39 +20707,55 @@ msgstr ""
 "gerenderte Teile der Zeichnung zur späteren Wiederverwendungzu sichern; auf "
 "Null setzen, um Cachen zu deaktivieren"
 
+#: ../src/ui/dialog/inkscape-preferences.cpp:1450
+#, fuzzy
+msgid "Rendering tile multiplier:"
+msgstr "Rendering-Cachegröße:"
+
+#: ../src/ui/dialog/inkscape-preferences.cpp:1450
+#, fuzzy
+msgid "requires restart"
+msgstr "(erfordert Neustart)"
+
+#: ../src/ui/dialog/inkscape-preferences.cpp:1450
+msgid ""
+"Set the relative size of tiles used to render the canvas. The larger the "
+"value, the bigger the tile size."
+msgstr ""
+
 #. blur quality
 #. filter quality
-#: ../src/ui/dialog/inkscape-preferences.cpp:1431
-#: ../src/ui/dialog/inkscape-preferences.cpp:1455
+#: ../src/ui/dialog/inkscape-preferences.cpp:1453
+#: ../src/ui/dialog/inkscape-preferences.cpp:1477
 msgid "Best quality (slowest)"
 msgstr "Beste Qualität (am langsamsten)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1433
-#: ../src/ui/dialog/inkscape-preferences.cpp:1457
+#: ../src/ui/dialog/inkscape-preferences.cpp:1455
+#: ../src/ui/dialog/inkscape-preferences.cpp:1479
 msgid "Better quality (slower)"
 msgstr "Gute Qualität (langsamer)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1435
-#: ../src/ui/dialog/inkscape-preferences.cpp:1459
+#: ../src/ui/dialog/inkscape-preferences.cpp:1457
+#: ../src/ui/dialog/inkscape-preferences.cpp:1481
 msgid "Average quality"
 msgstr "Durchschnittliche Qualität"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1437
-#: ../src/ui/dialog/inkscape-preferences.cpp:1461
+#: ../src/ui/dialog/inkscape-preferences.cpp:1459
+#: ../src/ui/dialog/inkscape-preferences.cpp:1483
 msgid "Lower quality (faster)"
 msgstr "Niedrigere Qualität (schneller)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1439
-#: ../src/ui/dialog/inkscape-preferences.cpp:1463
+#: ../src/ui/dialog/inkscape-preferences.cpp:1461
+#: ../src/ui/dialog/inkscape-preferences.cpp:1485
 msgid "Lowest quality (fastest)"
 msgstr "Niedrigste Qualität (am schnellsten)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1442
+#: ../src/ui/dialog/inkscape-preferences.cpp:1464
 msgid "Gaussian blur quality for display"
 msgstr "Anzeigequalität des Gaußschen Weichzeichners"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1444
-#: ../src/ui/dialog/inkscape-preferences.cpp:1468
+#: ../src/ui/dialog/inkscape-preferences.cpp:1466
+#: ../src/ui/dialog/inkscape-preferences.cpp:1490
 msgid ""
 "Best quality, but display may be very slow at high zooms (bitmap export "
 "always uses best quality)"
@@ -20738,123 +20763,123 @@ msgstr ""
 "Beste Qualität, aber die Anzeige kann bei hohen Zoomstufen sehr langsam sein "
 "(Bitmap-Export verwendet immer diese Einstellung)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1446
-#: ../src/ui/dialog/inkscape-preferences.cpp:1470
+#: ../src/ui/dialog/inkscape-preferences.cpp:1468
+#: ../src/ui/dialog/inkscape-preferences.cpp:1492
 msgid "Better quality, but slower display"
 msgstr "Bessere Qualität, aber langsamere Anzeige"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1448
-#: ../src/ui/dialog/inkscape-preferences.cpp:1472
+#: ../src/ui/dialog/inkscape-preferences.cpp:1470
+#: ../src/ui/dialog/inkscape-preferences.cpp:1494
 msgid "Average quality, acceptable display speed"
 msgstr "Durchschnittliche Qualität, akzeptable Geschwindigkeit der Anzeige"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1450
-#: ../src/ui/dialog/inkscape-preferences.cpp:1474
+#: ../src/ui/dialog/inkscape-preferences.cpp:1472
+#: ../src/ui/dialog/inkscape-preferences.cpp:1496
 msgid "Lower quality (some artifacts), but display is faster"
 msgstr "Niedrigere Qualität (einige Artefakte), aber schnellere Anzeige"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1452
-#: ../src/ui/dialog/inkscape-preferences.cpp:1476
+#: ../src/ui/dialog/inkscape-preferences.cpp:1474
+#: ../src/ui/dialog/inkscape-preferences.cpp:1498
 msgid "Lowest quality (considerable artifacts), but display is fastest"
 msgstr "Niedrigste Qualität (beträchtliche Artefakte), aber schnellste Anzeige"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1466
+#: ../src/ui/dialog/inkscape-preferences.cpp:1488
 msgid "Filter effects quality for display"
 msgstr "Effekt-Qualität für Anzeige:"
 
 #. build custom preferences tab
-#: ../src/ui/dialog/inkscape-preferences.cpp:1478
-#: ../src/ui/dialog/print.cpp:215
+#: ../src/ui/dialog/inkscape-preferences.cpp:1500
+#: ../src/ui/dialog/print.cpp:219
 msgid "Rendering"
 msgstr "Rendern"
 
 #. Note: /options/bitmapoversample removed with Cairo renderer
-#: ../src/ui/dialog/inkscape-preferences.cpp:1484 ../src/verbs.cpp:156
+#: ../src/ui/dialog/inkscape-preferences.cpp:1506 ../src/verbs.cpp:156
 #: ../src/widgets/calligraphy-toolbar.cpp:626
 msgid "Edit"
 msgstr "Bearbeiten"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1485
+#: ../src/ui/dialog/inkscape-preferences.cpp:1507
 msgid "Automatically reload bitmaps"
 msgstr "Automatisches Aktualisieren von Bildern"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1487
+#: ../src/ui/dialog/inkscape-preferences.cpp:1509
 msgid "Automatically reload linked images when file is changed on disk"
 msgstr "Bilder neu laden, wenn diese auf dem Datenträger geändert wurden."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1489
+#: ../src/ui/dialog/inkscape-preferences.cpp:1511
 msgid "_Bitmap editor:"
 msgstr "_Bitmap-Editor:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1491
+#: ../src/ui/dialog/inkscape-preferences.cpp:1513
 #: ../share/extensions/guillotine.inx.h:5 ../share/extensions/plotter.inx.h:65
 #: ../share/extensions/print_win32_vector.inx.h:2
 msgid "Export"
 msgstr "Exportieren"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1493
+#: ../src/ui/dialog/inkscape-preferences.cpp:1515
 msgid "Default export _resolution:"
 msgstr "Standard-Exportauflösung:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1494
+#: ../src/ui/dialog/inkscape-preferences.cpp:1516
 msgid "Default bitmap resolution (in dots per inch) in the Export dialog"
 msgstr ""
 "Bevorzugte Auflösung der Bitmap (Punkte pro Zoll) im Exportieren-Dialog"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1495
+#: ../src/ui/dialog/inkscape-preferences.cpp:1517
 #: ../src/ui/dialog/xml-tree.cpp:921
 msgid "Create"
 msgstr "Erstellen"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1497
+#: ../src/ui/dialog/inkscape-preferences.cpp:1519
 msgid "Resolution for Create Bitmap _Copy:"
 msgstr "Auflösung für Bitmap-_Kopie erstellen:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1498
+#: ../src/ui/dialog/inkscape-preferences.cpp:1520
 msgid "Resolution used by the Create Bitmap Copy command"
 msgstr "Auflösung von Bildern die mit \"Kopiere als Bitmap\" erstellt werden."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1501
+#: ../src/ui/dialog/inkscape-preferences.cpp:1523
 msgid "Ask about linking and scaling when importing"
 msgstr "Nach Verknüpfung und Skalierung beim Importieren fragen"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1503
+#: ../src/ui/dialog/inkscape-preferences.cpp:1525
 msgid "Pop-up linking and scaling dialog when importing bitmap image."
 msgstr ""
 "Dialog für Verknüpfung und Skalierung beim Importieren von Bitmaps anzeigen."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1509
+#: ../src/ui/dialog/inkscape-preferences.cpp:1531
 msgid "Bitmap link:"
 msgstr "Bitmap-Verknüpfung:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1516
+#: ../src/ui/dialog/inkscape-preferences.cpp:1538
 msgid "Bitmap scale (image-rendering):"
 msgstr "Bitmap Skalierung (image-rendering)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1521
+#: ../src/ui/dialog/inkscape-preferences.cpp:1543
 msgid "Default _import resolution:"
 msgstr "Standard-Importauflösung:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1522
+#: ../src/ui/dialog/inkscape-preferences.cpp:1544
 msgid "Default bitmap resolution (in dots per inch) for bitmap import"
 msgstr "Standard-Bitmapauflösung (Punkte pro Zoll) für Bitmap-Import"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1523
+#: ../src/ui/dialog/inkscape-preferences.cpp:1545
 msgid "Override file resolution"
 msgstr "Dateiauflösung überschreiben"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1525
+#: ../src/ui/dialog/inkscape-preferences.cpp:1547
 msgid "Use default bitmap resolution in favor of information from file"
 msgstr ""
 "Verwenden Sie Standard-Bitmap-Auflösung zu Gunsten von Informationen aus der "
 "Datei"
 
 #. rendering outlines for pixmap image tags
-#: ../src/ui/dialog/inkscape-preferences.cpp:1529
+#: ../src/ui/dialog/inkscape-preferences.cpp:1551
 msgid "Images in Outline Mode"
 msgstr "Bilder im Umrissmodus"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1530
+#: ../src/ui/dialog/inkscape-preferences.cpp:1552
 msgid ""
 "When active will render images while in outline mode instead of a red box "
 "with an x. This is useful for manual tracing."
@@ -20862,11 +20887,11 @@ msgstr ""
 "Bei Aktivierung werden Bilder als Umgrenzung anstelle eines roten Rechtecks "
 "mit X dargestellt. Nützlich für manuelles Nachzeichnen."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1532
+#: ../src/ui/dialog/inkscape-preferences.cpp:1554
 msgid "Bitmaps"
 msgstr "Bitmaps"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1544
+#: ../src/ui/dialog/inkscape-preferences.cpp:1566
 msgid ""
 "Select a file of predefined shortcuts to use. Any customized shortcuts you "
 "create will be added separately to "
@@ -20874,25 +20899,25 @@ msgstr ""
 "Wählen Sie eine Datei mit vorderfinierten Tastenkürzeln. Jeder "
 "benutzerdefinierte Kürzel, der erstellt wird, wird separat hinzugefügt zu"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1547
+#: ../src/ui/dialog/inkscape-preferences.cpp:1569
 msgid "Shortcut file:"
 msgstr "Tastenkürzel-Datei:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1550
+#: ../src/ui/dialog/inkscape-preferences.cpp:1572
 #: ../src/ui/dialog/template-load-tab.cpp:49
 msgid "Search:"
 msgstr "Suchen:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1562
+#: ../src/ui/dialog/inkscape-preferences.cpp:1584
 msgid "Shortcut"
 msgstr "Tastenkürzel"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1563
+#: ../src/ui/dialog/inkscape-preferences.cpp:1585
 #: ../src/ui/widget/page-sizer.cpp:287
 msgid "Description"
 msgstr "Beschreibung"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1618
+#: ../src/ui/dialog/inkscape-preferences.cpp:1640
 msgid ""
 "Remove all your customized keyboard shortcuts, and revert to the shortcuts "
 "in the shortcut file listed above"
@@ -20900,46 +20925,46 @@ msgstr ""
 "Alle individuellen Tastenkürzel entfernen und zurück zu den Tastenkürzeln in "
 "der oben aufgeführten Tastenkürzel-Datei"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1622
+#: ../src/ui/dialog/inkscape-preferences.cpp:1644
 msgid "Import ..."
 msgstr "_Importieren ..."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1622
+#: ../src/ui/dialog/inkscape-preferences.cpp:1644
 msgid "Import custom keyboard shortcuts from a file"
 msgstr "Importieren einer benutzerdefinierten Tastenkürzel-Datei"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1625
+#: ../src/ui/dialog/inkscape-preferences.cpp:1647
 msgid "Export ..."
 msgstr "Exportieren ..."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1625
+#: ../src/ui/dialog/inkscape-preferences.cpp:1647
 msgid "Export custom keyboard shortcuts to a file"
 msgstr "Benutzerdefinierte Tastenkürzel in eine Datei exportieren"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1635
+#: ../src/ui/dialog/inkscape-preferences.cpp:1657
 msgid "Keyboard Shortcuts"
 msgstr "Tastenkürzel"
 
 #. Find this group in the tree
-#: ../src/ui/dialog/inkscape-preferences.cpp:1798
+#: ../src/ui/dialog/inkscape-preferences.cpp:1820
 msgid "Misc"
 msgstr "Sonstiges"
 
 # CHECK
-#: ../src/ui/dialog/inkscape-preferences.cpp:1904
+#: ../src/ui/dialog/inkscape-preferences.cpp:1926
 msgctxt "Spellchecker language"
 msgid "None"
 msgstr "Keine"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1925
+#: ../src/ui/dialog/inkscape-preferences.cpp:1947
 msgid "Set the main spell check language"
 msgstr "Setzen der Hauptsprache der Rechtschreibprüfung"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1928
+#: ../src/ui/dialog/inkscape-preferences.cpp:1950
 msgid "Second language:"
 msgstr "Zweite Sprache:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1929
+#: ../src/ui/dialog/inkscape-preferences.cpp:1951
 msgid ""
 "Set the second spell check language; checking will only stop on words "
 "unknown in ALL chosen languages"
@@ -20947,11 +20972,11 @@ msgstr ""
 "Setzen der zweiten Sprache der Rechtschreibprüfung; die Prüfung stoppt nur "
 "bei Wörtern, die in allen ausgewählten Sprachen unbekannt sind."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1932
+#: ../src/ui/dialog/inkscape-preferences.cpp:1954
 msgid "Third language:"
 msgstr "Dritte Sprache:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1933
+#: ../src/ui/dialog/inkscape-preferences.cpp:1955
 msgid ""
 "Set the third spell check language; checking will only stop on words unknown "
 "in ALL chosen languages"
@@ -20959,31 +20984,31 @@ msgstr ""
 "Festlegen der dritten Sprache der Rechtschreibprüfung; die Prüfung stoppt "
 "nur bei Wörtern, die in allen ausgewählten Sprachen unbekannt sind."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1935
+#: ../src/ui/dialog/inkscape-preferences.cpp:1957
 msgid "Ignore words with digits"
 msgstr "Wörter mit Zahlen ignorieren"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1937
+#: ../src/ui/dialog/inkscape-preferences.cpp:1959
 msgid "Ignore words containing digits, such as \"R2D2\""
 msgstr "Wörter mit Zahlen ignorieren, wie \"R2D2\""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1939
+#: ../src/ui/dialog/inkscape-preferences.cpp:1961
 msgid "Ignore words in ALL CAPITALS"
 msgstr "Wörter in GROSSGESCHRIEBEN ignorieren"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1941
+#: ../src/ui/dialog/inkscape-preferences.cpp:1963
 msgid "Ignore words in all capitals, such as \"IUPAC\""
 msgstr "Wörter ignorieren, die GROSSGESCHRIEBEN sind, wie \"IUPAC\""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1943
+#: ../src/ui/dialog/inkscape-preferences.cpp:1965
 msgid "Spellcheck"
 msgstr "Rechtschreibprüfung"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1963
+#: ../src/ui/dialog/inkscape-preferences.cpp:1985
 msgid "Latency _skew:"
 msgstr "Latenz-_Schrägstellung:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1964
+#: ../src/ui/dialog/inkscape-preferences.cpp:1986
 msgid ""
 "Factor by which the event clock is skewed from the actual time (0.9766 on "
 "some systems)"
@@ -20991,11 +21016,11 @@ msgstr ""
 "Faktor, um den die Ereigniszeit gegenüber der Systemzeit verlangsamt wird "
 "(0,9766 auf manchen Systemen)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1966
+#: ../src/ui/dialog/inkscape-preferences.cpp:1988
 msgid "Pre-render named icons"
 msgstr "Symbole mit Namen im Voraus rendern"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1968
+#: ../src/ui/dialog/inkscape-preferences.cpp:1990
 msgid ""
 "When on, named icons will be rendered before displaying the ui. This is for "
 "working around bugs in GTK+ named icon notification"
@@ -21004,83 +21029,83 @@ msgstr ""
 "wird. Damit werden Fehler in der GTK+-Hinweisen zu benannten Symbolen "
 "umgangen."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1976
+#: ../src/ui/dialog/inkscape-preferences.cpp:1998
 msgid "System info"
 msgstr "Systeminformation"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1980
+#: ../src/ui/dialog/inkscape-preferences.cpp:2002
 msgid "User config: "
 msgstr "Benutzerkonfiguration: "
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1980
+#: ../src/ui/dialog/inkscape-preferences.cpp:2002
 msgid "Location of users configuration"
 msgstr "Ort der Benutzerkonfiguration"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1984
+#: ../src/ui/dialog/inkscape-preferences.cpp:2006
 msgid "User preferences: "
 msgstr "Benutzereinstellungen: "
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1984
+#: ../src/ui/dialog/inkscape-preferences.cpp:2006
 msgid "Location of the users preferences file"
 msgstr "Ort der Benutzer-Einstellungsdatei"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1988
+#: ../src/ui/dialog/inkscape-preferences.cpp:2010
 msgid "User extensions: "
 msgstr "Benutzererweiterungen: "
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1988
+#: ../src/ui/dialog/inkscape-preferences.cpp:2010
 msgid "Location of the users extensions"
 msgstr "Ort der Benutzererweiterungen"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1992
+#: ../src/ui/dialog/inkscape-preferences.cpp:2014
 msgid "User cache: "
 msgstr "Benutzer-Cache: "
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1992
+#: ../src/ui/dialog/inkscape-preferences.cpp:2014
 msgid "Location of users cache"
 msgstr "Ort des Benutzer-Caches"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:2000
+#: ../src/ui/dialog/inkscape-preferences.cpp:2022
 msgid "Temporary files: "
 msgstr "Temporäre Dateien: "
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:2000
+#: ../src/ui/dialog/inkscape-preferences.cpp:2022
 msgid "Location of the temporary files used for autosave"
 msgstr "Ort der temp. Dateien, die für die autom. Speicherung verwendet werden"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:2004
+#: ../src/ui/dialog/inkscape-preferences.cpp:2026
 msgid "Inkscape data: "
 msgstr "Inkscape-Daten:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:2004
+#: ../src/ui/dialog/inkscape-preferences.cpp:2026
 msgid "Location of Inkscape data"
 msgstr "Ort der Inkscape-Daten"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:2008
+#: ../src/ui/dialog/inkscape-preferences.cpp:2030
 msgid "Inkscape extensions: "
 msgstr "Inkscape-Erweiterungen: "
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:2008
+#: ../src/ui/dialog/inkscape-preferences.cpp:2030
 msgid "Location of the Inkscape extensions"
 msgstr "Ort der Inkscape-Erweiterungen"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:2017
+#: ../src/ui/dialog/inkscape-preferences.cpp:2039
 msgid "System data: "
 msgstr "Systemdaten: "
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:2017
+#: ../src/ui/dialog/inkscape-preferences.cpp:2039
 msgid "Locations of system data"
 msgstr "Ort der Systemdaten"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:2041
+#: ../src/ui/dialog/inkscape-preferences.cpp:2063
 msgid "Icon theme: "
 msgstr "Symbolthema: "
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:2041
+#: ../src/ui/dialog/inkscape-preferences.cpp:2063
 msgid "Locations of icon themes"
 msgstr "Ort der Symbolthemen"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:2043
+#: ../src/ui/dialog/inkscape-preferences.cpp:2065
 msgid "System"
 msgstr "System"
 
@@ -21896,19 +21921,19 @@ msgstr "Keine Beschreibung"
 msgid "Searching clipart..."
 msgstr "Suche Clipart..."
 
-#: ../src/ui/dialog/ocaldialogs.cpp:1099 ../src/ui/dialog/ocaldialogs.cpp:1120
+#: ../src/ui/dialog/ocaldialogs.cpp:1121
 msgid "Could not connect to the Open Clip Art Library"
 msgstr "Konnte nicht zu Open Clip Art Library verbinden"
 
-#: ../src/ui/dialog/ocaldialogs.cpp:1145
+#: ../src/ui/dialog/ocaldialogs.cpp:1146
 msgid "Could not parse search results"
 msgstr "Konnte Suchergebnisse nicht analysieren"
 
-#: ../src/ui/dialog/ocaldialogs.cpp:1177
+#: ../src/ui/dialog/ocaldialogs.cpp:1178
 msgid "No clipart named <b>%1</b> was found."
 msgstr "Kein Clipart mit Namen <b>%1</b> gefunden."
 
-#: ../src/ui/dialog/ocaldialogs.cpp:1179
+#: ../src/ui/dialog/ocaldialogs.cpp:1180
 msgid ""
 "Please make sure all keywords are spelled correctly, or try again with "
 "different keywords."
@@ -21916,11 +21941,11 @@ msgstr ""
 "Bitte stellen Sie sicher, dass alle Schlüsselwörter richtig eingegeben "
 "wurden, oder versuchen Sie es mit anderen Suchbegriffen."
 
-#: ../src/ui/dialog/ocaldialogs.cpp:1231
+#: ../src/ui/dialog/ocaldialogs.cpp:1232
 msgid "Search"
 msgstr "Suchen"
 
-#: ../src/ui/dialog/ocaldialogs.cpp:1243
+#: ../src/ui/dialog/ocaldialogs.cpp:1244
 msgid "Close"
 msgstr "Schließen"
 
@@ -22117,25 +22142,25 @@ msgstr "In der Auswahl konnte keine Ellipse gefunden werden"
 msgid "Arrange on ellipse"
 msgstr "Auf Ellipse anordnen"
 
-#: ../src/ui/dialog/print.cpp:111
+#: ../src/ui/dialog/print.cpp:115
 msgid "Could not open temporary PNG for bitmap printing"
 msgstr "Konnte temporäres PNG für Rasterdruck nicht öffnen"
 
-#: ../src/ui/dialog/print.cpp:138
+#: ../src/ui/dialog/print.cpp:142
 msgid "Could not set up Document"
 msgstr "Dokument konnte nicht eingerichtet werden"
 
 # CairoRenderContext ist Eigenname?
-#: ../src/ui/dialog/print.cpp:142
+#: ../src/ui/dialog/print.cpp:146
 msgid "Failed to set CairoRenderContext"
 msgstr "Fehler beim Setzen von CairoRenderContext"
 
 #. set up dialog title, based on document name
-#: ../src/ui/dialog/print.cpp:180
+#: ../src/ui/dialog/print.cpp:184
 msgid "SVG Document"
 msgstr "SVG-Dokument"
 
-#: ../src/ui/dialog/print.cpp:181
+#: ../src/ui/dialog/print.cpp:185
 msgid "Print"
 msgstr "Drucken"
 
@@ -22376,32 +22401,32 @@ msgstr "Beispieltext"
 msgid "Preview Text:"
 msgstr "Textvorschau:"
 
-#: ../src/ui/dialog/swatches.cpp:202 ../src/ui/tools/gradient-tool.cpp:366
+#: ../src/ui/dialog/swatches.cpp:203 ../src/ui/tools/gradient-tool.cpp:366
 #: ../src/ui/tools/gradient-tool.cpp:464 ../src/widgets/gradient-vector.cpp:801
 msgid "Add gradient stop"
 msgstr "Zwischenfarbe zum Farbverlauf hinzufügen"
 
 #. TRANSLATORS: An item in context menu on a colour in the swatches
-#: ../src/ui/dialog/swatches.cpp:257
+#: ../src/ui/dialog/swatches.cpp:258
 msgid "Set fill"
 msgstr "Füllung festlegen"
 
 #. TRANSLATORS: An item in context menu on a colour in the swatches
-#: ../src/ui/dialog/swatches.cpp:265
+#: ../src/ui/dialog/swatches.cpp:266
 msgid "Set stroke"
 msgstr "Kontur festlegen"
 
-#: ../src/ui/dialog/swatches.cpp:286
+#: ../src/ui/dialog/swatches.cpp:287
 msgid "Edit..."
 msgstr "Bearbeiten..."
 
 # !!! not the best translation
-#: ../src/ui/dialog/swatches.cpp:298
+#: ../src/ui/dialog/swatches.cpp:299
 msgid "Convert"
 msgstr "Konvertieren"
 
 # !!! palettes, not swatches?
-#: ../src/ui/dialog/swatches.cpp:543
+#: ../src/ui/dialog/swatches.cpp:551
 #, c-format
 msgid "Palettes directory (%s) is unavailable."
 msgstr "Palettenverzeichnis (%s) nicht auffindbar."
@@ -22510,27 +22535,27 @@ msgid "AaBbCcIiPpQq12369$€¢?.;/()"
 msgstr "AaBbCcIiPpQqÜü12369$€ß?.;/()"
 
 #. Align buttons
-#: ../src/ui/dialog/text-edit.cpp:97 ../src/widgets/text-toolbar.cpp:1797
-#: ../src/widgets/text-toolbar.cpp:1798
+#: ../src/ui/dialog/text-edit.cpp:97 ../src/widgets/text-toolbar.cpp:1866
+#: ../src/widgets/text-toolbar.cpp:1867
 msgid "Align left"
 msgstr "Linksbündig ausrichten"
 
-#: ../src/ui/dialog/text-edit.cpp:98 ../src/widgets/text-toolbar.cpp:1805
-#: ../src/widgets/text-toolbar.cpp:1806
+#: ../src/ui/dialog/text-edit.cpp:98 ../src/widgets/text-toolbar.cpp:1874
+#: ../src/widgets/text-toolbar.cpp:1875
 msgid "Align center"
 msgstr "Zentriert ausrichten"
 
-#: ../src/ui/dialog/text-edit.cpp:99 ../src/widgets/text-toolbar.cpp:1813
-#: ../src/widgets/text-toolbar.cpp:1814
+#: ../src/ui/dialog/text-edit.cpp:99 ../src/widgets/text-toolbar.cpp:1882
+#: ../src/widgets/text-toolbar.cpp:1883
 msgid "Align right"
 msgstr "Rechtsbündig ausrichten"
 
-#: ../src/ui/dialog/text-edit.cpp:100 ../src/widgets/text-toolbar.cpp:1822
+#: ../src/ui/dialog/text-edit.cpp:100 ../src/widgets/text-toolbar.cpp:1891
 msgid "Justify (only flowed text)"
 msgstr "Ausrichten - Nur Fließtext"
 
 #. Direction buttons
-#: ../src/ui/dialog/text-edit.cpp:109 ../src/widgets/text-toolbar.cpp:1857
+#: ../src/ui/dialog/text-edit.cpp:109 ../src/widgets/text-toolbar.cpp:1926
 msgid "Horizontal text"
 msgstr "Horizontaler Text"
 
@@ -23842,44 +23867,44 @@ msgstr "Anfasser ziehen"
 msgid "Retract handle"
 msgstr "Anfasser zurückziehen"
 
-#: ../src/ui/tool/transform-handle-set.cpp:203
+#: ../src/ui/tool/transform-handle-set.cpp:208
 msgctxt "Transform handle tip"
 msgid "<b>Shift+Ctrl</b>: scale uniformly about the rotation center"
 msgstr "<b>Umschalt + Strg</b>: Um Mittelpunkt einheitlich skalieren"
 
-#: ../src/ui/tool/transform-handle-set.cpp:205
+#: ../src/ui/tool/transform-handle-set.cpp:210
 msgctxt "Transform handle tip"
 msgid "<b>Ctrl:</b> scale uniformly"
 msgstr "<b>Strg</b>: einheitlich skalieren"
 
-#: ../src/ui/tool/transform-handle-set.cpp:210
+#: ../src/ui/tool/transform-handle-set.cpp:215
 msgctxt "Transform handle tip"
 msgid ""
 "<b>Shift+Alt</b>: scale using an integer ratio about the rotation center"
 msgstr "<b>Umschalt</b>: Skalieren mit Ganzzahl-Faktor um den Mittelpunkt"
 
-#: ../src/ui/tool/transform-handle-set.cpp:212
+#: ../src/ui/tool/transform-handle-set.cpp:217
 msgctxt "Transform handle tip"
 msgid "<b>Shift</b>: scale from the rotation center"
 msgstr "<b>Umschalt</b>: Skalieren aus dem Mittelpunkt heraus"
 
-#: ../src/ui/tool/transform-handle-set.cpp:215
+#: ../src/ui/tool/transform-handle-set.cpp:220
 msgctxt "Transform handle tip"
 msgid "<b>Alt</b>: scale using an integer ratio"
 msgstr "<b>Alt</b>: Skalieren mit Ganzzahl-Faktor"
 
-#: ../src/ui/tool/transform-handle-set.cpp:217
+#: ../src/ui/tool/transform-handle-set.cpp:222
 msgctxt "Transform handle tip"
 msgid "<b>Scale handle</b>: drag to scale the selection"
 msgstr "<b>Skaliere Anfasser</b>: Ziehen um die Auswahl zu skalieren"
 
-#: ../src/ui/tool/transform-handle-set.cpp:222
+#: ../src/ui/tool/transform-handle-set.cpp:227
 #, c-format
 msgctxt "Transform handle tip"
 msgid "Scale by %.2f%% x %.2f%%"
 msgstr "Scaieren mit %.2f%% x %.2f%%"
 
-#: ../src/ui/tool/transform-handle-set.cpp:449
+#: ../src/ui/tool/transform-handle-set.cpp:454
 #, c-format
 msgctxt "Transform handle tip"
 msgid ""
@@ -23889,18 +23914,18 @@ msgstr ""
 "<b>Umschalt+Strg</b>: Um die gegenüberliegende Ecke rotieren und Einrasten "
 "des Winkels um %f° Stufen"
 
-#: ../src/ui/tool/transform-handle-set.cpp:452
+#: ../src/ui/tool/transform-handle-set.cpp:457
 msgctxt "Transform handle tip"
 msgid "<b>Shift</b>: rotate around the opposite corner"
 msgstr "<b>Umschalt</b>: dreht um die gegenüberliegende Ecke"
 
-#: ../src/ui/tool/transform-handle-set.cpp:456
+#: ../src/ui/tool/transform-handle-set.cpp:461
 #, c-format
 msgctxt "Transform handle tip"
 msgid "<b>Ctrl</b>: snap angle to %f° increments"
 msgstr "<b>Strg</b>: Winkel um %f° Stufen einrasten"
 
-#: ../src/ui/tool/transform-handle-set.cpp:458
+#: ../src/ui/tool/transform-handle-set.cpp:463
 msgctxt "Transform handle tip"
 msgid ""
 "<b>Rotation handle</b>: drag to rotate the selection around the rotation "
@@ -23908,13 +23933,13 @@ msgid ""
 msgstr "<b>Drehanfaser</b>: Ziehen, um die Auswahl um den Drehpunkt zu drehen"
 
 #. event
-#: ../src/ui/tool/transform-handle-set.cpp:463
+#: ../src/ui/tool/transform-handle-set.cpp:468
 #, c-format
 msgctxt "Transform handle tip"
 msgid "Rotate by %.2f°"
 msgstr "Rotieren um %.2f°"
 
-#: ../src/ui/tool/transform-handle-set.cpp:588
+#: ../src/ui/tool/transform-handle-set.cpp:593
 #, c-format
 msgctxt "Transform handle tip"
 msgid ""
@@ -23923,18 +23948,18 @@ msgid ""
 msgstr ""
 "<b>Umschalt+Strg</b>: Um den Drehpunkt krümmen mit Einrasten auf %f° Stufen"
 
-#: ../src/ui/tool/transform-handle-set.cpp:591
+#: ../src/ui/tool/transform-handle-set.cpp:596
 msgctxt "Transform handle tip"
 msgid "<b>Shift</b>: skew about the rotation center"
 msgstr "<b>Umschalt</b>: Um Mittelpunkt abschrägen"
 
-#: ../src/ui/tool/transform-handle-set.cpp:595
+#: ../src/ui/tool/transform-handle-set.cpp:600
 #, c-format
 msgctxt "Transform handle tip"
 msgid "<b>Ctrl</b>: snap skew angle to %f° increments"
 msgstr "<b>Strg</b>: Einrasten des Abschrägungswinkels um %f° Stufen"
 
-#: ../src/ui/tool/transform-handle-set.cpp:598
+#: ../src/ui/tool/transform-handle-set.cpp:603
 msgctxt "Transform handle tip"
 msgid ""
 "<b>Skew handle</b>: drag to skew (shear) selection about the opposite handle"
@@ -23942,19 +23967,19 @@ msgstr ""
 "<b>Krümmungs-Anfasser</b>: Ziehen, um die Auswahl um den gegenüberliegenden "
 "Anfasser zu krümmen (scheren)"
 
-#: ../src/ui/tool/transform-handle-set.cpp:604
+#: ../src/ui/tool/transform-handle-set.cpp:609
 #, c-format
 msgctxt "Transform handle tip"
 msgid "Skew horizontally by %.2f°"
 msgstr "Horizontal um %.2f° abschrägen"
 
-#: ../src/ui/tool/transform-handle-set.cpp:607
+#: ../src/ui/tool/transform-handle-set.cpp:612
 #, c-format
 msgctxt "Transform handle tip"
 msgid "Skew vertically by %.2f°"
 msgstr "Vertikal um %.2f° abschrägen"
 
-#: ../src/ui/tool/transform-handle-set.cpp:666
+#: ../src/ui/tool/transform-handle-set.cpp:671
 msgctxt "Transform handle tip"
 msgid "<b>Rotation center</b>: drag to change the origin of transforms"
 msgstr ""
@@ -24836,7 +24861,7 @@ msgstr "Verschieben abgebrochen."
 msgid "Selection canceled."
 msgstr "Auswahl abgebrochen."
 
-#: ../src/ui/tools/select-tool.cpp:645
+#: ../src/ui/tools/select-tool.cpp:647
 msgid ""
 "<b>Draw over</b> objects to select them; release <b>Alt</b> to switch to "
 "rubberband selection"
@@ -24844,7 +24869,7 @@ msgstr ""
 "<b>Zeichnen über</b> Objekten wählt sie aus; <b>Alt</b> loslassen, um mit "
 "Gummiband auszuwählen"
 
-#: ../src/ui/tools/select-tool.cpp:647
+#: ../src/ui/tools/select-tool.cpp:649
 msgid ""
 "<b>Drag around</b> objects to select them; press <b>Alt</b> to switch to "
 "touch selection"
@@ -24852,19 +24877,19 @@ msgstr ""
 "<b>Ziehen um</b> Objekte wählt sie aus; <b>Alt</b> drücken, um durch "
 "Berührung auszuwählen"
 
-#: ../src/ui/tools/select-tool.cpp:888
+#: ../src/ui/tools/select-tool.cpp:890
 msgid "<b>Ctrl</b>: click to select in groups; drag to move hor/vert"
 msgstr ""
 "<b>Strg</b>: Klick um in Gruppierung auszuwählen; Ziehen um horizontal/"
 "vertikal bewegen"
 
-#: ../src/ui/tools/select-tool.cpp:889
+#: ../src/ui/tools/select-tool.cpp:891
 msgid "<b>Shift</b>: click to toggle select; drag for rubberband selection"
 msgstr ""
 "<b>Umschalt</b>: Klick um Auswahl aktivieren/deaktivieren, Ziehen für "
 "Gummiband-Auswahl"
 
-#: ../src/ui/tools/select-tool.cpp:890
+#: ../src/ui/tools/select-tool.cpp:892
 msgid ""
 "<b>Alt</b>: click to select under; scroll mouse-wheel to cycle-select; drag "
 "to move selected or select by touch"
@@ -24872,7 +24897,7 @@ msgstr ""
 "<b>Alt</b>: Klick um verdeckte Objekte auswählen; Ziehen um gewähltes Objekt "
 "zu verschieben oder durch Berühren auszuwählen"
 
-#: ../src/ui/tools/select-tool.cpp:1098
+#: ../src/ui/tools/select-tool.cpp:1100
 msgid "Selected object is not a group. Cannot enter."
 msgstr "Ausgewähltes Objekt ist keine Gruppe - kann diese nicht betreten."
 
@@ -25128,7 +25153,7 @@ msgstr[1] ""
 msgid "Type text"
 msgstr "Text eingeben"
 
-#: ../src/ui/tools/tool-base.cpp:705
+#: ../src/ui/tools/tool-base.cpp:708
 msgid "<b>Space+mouse move</b> to pan canvas"
 msgstr "<b>Leertaste+Maus ziehen</b>, um die Arbeitsfläche zu verschieben"
 
@@ -25275,18 +25300,18 @@ msgid "Hexadecimal RGBA value of the color"
 msgstr "Hexadezimaler RGBA-Wert der Farbe"
 
 #: ../src/ui/widget/color-icc-selector.cpp:176
-#: ../src/ui/widget/color-scales.cpp:384
+#: ../src/ui/widget/color-scales.cpp:385
 msgid "_R:"
 msgstr "_R:"
 
 #. TYPE_RGB_16
 #: ../src/ui/widget/color-icc-selector.cpp:177
-#: ../src/ui/widget/color-scales.cpp:387
+#: ../src/ui/widget/color-scales.cpp:388
 msgid "_G:"
 msgstr "_G:"
 
 #: ../src/ui/widget/color-icc-selector.cpp:178
-#: ../src/ui/widget/color-scales.cpp:390
+#: ../src/ui/widget/color-scales.cpp:391
 msgid "_B:"
 msgstr "_B:"
 
@@ -25298,26 +25323,26 @@ msgstr "Grau"
 #. TYPE_GRAY_16
 #: ../src/ui/widget/color-icc-selector.cpp:182
 #: ../src/ui/widget/color-icc-selector.cpp:186
-#: ../src/ui/widget/color-scales.cpp:410
+#: ../src/ui/widget/color-scales.cpp:411
 msgid "_H:"
 msgstr "_H:"
 
 #. TYPE_HSV_16
 #: ../src/ui/widget/color-icc-selector.cpp:183
 #: ../src/ui/widget/color-icc-selector.cpp:188
-#: ../src/ui/widget/color-scales.cpp:413
+#: ../src/ui/widget/color-scales.cpp:414
 msgid "_S:"
 msgstr "_S:"
 
 #. TYPE_HLS_16
 #: ../src/ui/widget/color-icc-selector.cpp:187
-#: ../src/ui/widget/color-scales.cpp:416
+#: ../src/ui/widget/color-scales.cpp:417
 msgid "_L:"
 msgstr "_L:"
 
 #: ../src/ui/widget/color-icc-selector.cpp:190
 #: ../src/ui/widget/color-icc-selector.cpp:195
-#: ../src/ui/widget/color-scales.cpp:438
+#: ../src/ui/widget/color-scales.cpp:439
 msgid "_C:"
 msgstr "_C:"
 
@@ -25325,18 +25350,18 @@ msgstr "_C:"
 #. TYPE_CMY_16
 #: ../src/ui/widget/color-icc-selector.cpp:191
 #: ../src/ui/widget/color-icc-selector.cpp:196
-#: ../src/ui/widget/color-scales.cpp:441
+#: ../src/ui/widget/color-scales.cpp:442
 msgid "_M:"
 msgstr "_M:"
 
 #: ../src/ui/widget/color-icc-selector.cpp:192
 #: ../src/ui/widget/color-icc-selector.cpp:197
-#: ../src/ui/widget/color-scales.cpp:444
+#: ../src/ui/widget/color-scales.cpp:445
 msgid "_Y:"
 msgstr "Y:"
 
 #: ../src/ui/widget/color-icc-selector.cpp:193
-#: ../src/ui/widget/color-scales.cpp:447
+#: ../src/ui/widget/color-scales.cpp:448
 msgid "_K:"
 msgstr "_K:"
 
@@ -25356,17 +25381,17 @@ msgstr "Legt RGB-Ausweichwert für Entsprechung des icc-color()-Parameters fest"
 
 #. Label
 #: ../src/ui/widget/color-icc-selector.cpp:496
-#: ../src/ui/widget/color-scales.cpp:393 ../src/ui/widget/color-scales.cpp:419
-#: ../src/ui/widget/color-scales.cpp:450
+#: ../src/ui/widget/color-scales.cpp:394 ../src/ui/widget/color-scales.cpp:420
+#: ../src/ui/widget/color-scales.cpp:451
 #: ../src/ui/widget/color-wheel-selector.cpp:83
 msgid "_A:"
 msgstr "_A:"
 
 #: ../src/ui/widget/color-icc-selector.cpp:513
 #: ../src/ui/widget/color-icc-selector.cpp:524
-#: ../src/ui/widget/color-scales.cpp:394 ../src/ui/widget/color-scales.cpp:395
-#: ../src/ui/widget/color-scales.cpp:420 ../src/ui/widget/color-scales.cpp:421
-#: ../src/ui/widget/color-scales.cpp:451 ../src/ui/widget/color-scales.cpp:452
+#: ../src/ui/widget/color-scales.cpp:395 ../src/ui/widget/color-scales.cpp:396
+#: ../src/ui/widget/color-scales.cpp:421 ../src/ui/widget/color-scales.cpp:422
+#: ../src/ui/widget/color-scales.cpp:452 ../src/ui/widget/color-scales.cpp:453
 #: ../src/ui/widget/color-wheel-selector.cpp:112
 #: ../src/ui/widget/color-wheel-selector.cpp:142
 msgid "Alpha (opacity)"
@@ -25810,8 +25835,15 @@ msgid "Scale _y:"
 msgstr "Skalierung _y:"
 
 #: ../src/ui/widget/page-sizer.cpp:245
-msgid "Scale Y"
-msgstr "Y skalieren"
+msgid ""
+"While SVG allows non-uniform scaling it is recommended to use only uniform "
+"scaling in Inkscape. To set a non-uniform scaling, set the 'viewBox' "
+"directly."
+msgstr ""
+"Obwohl das SVG-Format unterschiedliche Skalierungsfaktoren erlaubt, wird "
+"dies für die Verwendung in Inkscape nicht empfohlen. Um unterschiedliche "
+"Skalierungsfaktoren festzulegen kann das 'viewBox' Attribut direkt "
+"bearbeitet werden."
 
 #: ../src/ui/widget/page-sizer.cpp:323
 msgid "Orientation:"
@@ -25846,34 +25878,23 @@ msgstr ""
 "Seitengröße so verändern, daß die aktuelle Auswahl, oder, falls nichts "
 "ausgewählt ist,  die gesamte Zeichnung, hineinpasst."
 
-#: ../src/ui/widget/page-sizer.cpp:479
-msgid ""
-"While SVG allows non-uniform scaling it is recommended to use only uniform "
-"scaling in Inkscape. To set a non-uniform scaling, set the 'viewBox' "
-"directly."
-msgstr ""
-"Obwohl das SVG-Format unterschiedliche Skalierungsfaktoren erlaubt, wird "
-"dies für die Verwendung in Inkscape nicht empfohlen. Um unterschiedliche "
-"Skalierungsfaktoren festzulegen kann das 'viewBox' Attribut direkt "
-"bearbeitet werden."
-
-#: ../src/ui/widget/page-sizer.cpp:483
+#: ../src/ui/widget/page-sizer.cpp:478
 msgid "_Viewbox..."
 msgstr "_Viewbox..."
 
-#: ../src/ui/widget/page-sizer.cpp:590
+#: ../src/ui/widget/page-sizer.cpp:585
 msgid "Set page size"
 msgstr "Seitengröße setzen"
 
-#: ../src/ui/widget/page-sizer.cpp:836
+#: ../src/ui/widget/page-sizer.cpp:831
 msgid "User units per "
 msgstr "SVG-Benutzereinheiten pro "
 
-#: ../src/ui/widget/page-sizer.cpp:932
+#: ../src/ui/widget/page-sizer.cpp:927
 msgid "Set page scale"
 msgstr "Seitenskalierung festlegen"
 
-#: ../src/ui/widget/page-sizer.cpp:958
+#: ../src/ui/widget/page-sizer.cpp:953
 msgid "Set 'viewBox'"
 msgstr "'viewBox' festlegen"
 
@@ -28881,16 +28902,21 @@ msgstr "Ein eingebettetes Script entfernen"
 msgid "Center on horizontal and vertical axis"
 msgstr "An horizontalen und vertikalen Achsen ausrichten"
 
-#: ../src/widgets/arc-toolbar.cpp:129
+#: ../src/widgets/arc-toolbar.cpp:143
+#, fuzzy
+msgid "Change arc"
+msgstr "Weichzeichner ändern"
+
+#: ../src/widgets/arc-toolbar.cpp:209
 msgid "Arc: Change start/end"
 msgstr "Bogen: Beginn/Ende ändern"
 
-#: ../src/widgets/arc-toolbar.cpp:191
+#: ../src/widgets/arc-toolbar.cpp:271
 msgid "Arc: Change open/closed"
 msgstr "Bogen: Offen/geschlossen ändern"
 
 # !!!
-#: ../src/widgets/arc-toolbar.cpp:280 ../src/widgets/arc-toolbar.cpp:310
+#: ../src/widgets/arc-toolbar.cpp:385 ../src/widgets/arc-toolbar.cpp:424
 #: ../src/widgets/rect-toolbar.cpp:260 ../src/widgets/rect-toolbar.cpp:299
 #: ../src/widgets/spiral-toolbar.cpp:210 ../src/widgets/spiral-toolbar.cpp:234
 #: ../src/widgets/star-toolbar.cpp:382 ../src/widgets/star-toolbar.cpp:444
@@ -28900,51 +28926,86 @@ msgstr "<b>Neu:</b>"
 # !!!
 #. FIXME: implement averaging of all parameters for multiple selected
 #. gtk_label_set_markup(GTK_LABEL(l), _("<b>Average:</b>"));
-#: ../src/widgets/arc-toolbar.cpp:283 ../src/widgets/arc-toolbar.cpp:294
+#: ../src/widgets/arc-toolbar.cpp:388 ../src/widgets/arc-toolbar.cpp:405
 #: ../src/widgets/rect-toolbar.cpp:268 ../src/widgets/rect-toolbar.cpp:286
 #: ../src/widgets/spiral-toolbar.cpp:212 ../src/widgets/spiral-toolbar.cpp:223
 #: ../src/widgets/star-toolbar.cpp:384
 msgid "<b>Change:</b>"
 msgstr "<b>Ändern:</b>"
 
-#: ../src/widgets/arc-toolbar.cpp:319
+#: ../src/widgets/arc-toolbar.cpp:435 ../src/widgets/rect-toolbar.cpp:351
+msgid "Horizontal radius"
+msgstr "Horizontaler Radius"
+
+#: ../src/widgets/arc-toolbar.cpp:435 ../src/widgets/rect-toolbar.cpp:351
+msgid "Rx:"
+msgstr "Rx:"
+
+#: ../src/widgets/arc-toolbar.cpp:435
+#, fuzzy
+msgid "Horizontal radius of the circle, ellipse, or arc"
+msgstr "Horizontaler Radius einer abgerundeten Ecke"
+
+#: ../src/widgets/arc-toolbar.cpp:452 ../src/widgets/rect-toolbar.cpp:366
+msgid "Vertical radius"
+msgstr "Vertikaler Radius"
+
+#: ../src/widgets/arc-toolbar.cpp:452 ../src/widgets/rect-toolbar.cpp:366
+msgid "Ry:"
+msgstr "Ry:"
+
+#: ../src/widgets/arc-toolbar.cpp:452
+#, fuzzy
+msgid "Vertical radius of the circle, ellipse, or arc"
+msgstr "Kreise, Ellipsen und Bögen erstellen"
+
+#. Add the units menu.
+#: ../src/widgets/arc-toolbar.cpp:466 ../src/widgets/lpe-toolbar.cpp:387
+#: ../src/widgets/node-toolbar.cpp:613
+#: ../src/widgets/paintbucket-toolbar.cpp:168
+#: ../src/widgets/rect-toolbar.cpp:378 ../src/widgets/select-toolbar.cpp:530
+#: ../src/widgets/text-toolbar.cpp:2108
+msgid "Units"
+msgstr "Einheiten"
+
+#: ../src/widgets/arc-toolbar.cpp:473
 msgid "Start:"
 msgstr "Anfang:"
 
-#: ../src/widgets/arc-toolbar.cpp:320
+#: ../src/widgets/arc-toolbar.cpp:474
 msgid "The angle (in degrees) from the horizontal to the arc's start point"
 msgstr ""
 "Der Winkel (in Grad) von der Horizontalen bis zum Startpunkt des Bogens"
 
-#: ../src/widgets/arc-toolbar.cpp:332
+#: ../src/widgets/arc-toolbar.cpp:486
 msgid "End:"
 msgstr "Ende:"
 
-#: ../src/widgets/arc-toolbar.cpp:333
+#: ../src/widgets/arc-toolbar.cpp:487
 msgid "The angle (in degrees) from the horizontal to the arc's end point"
 msgstr "Der Winkel (in Grad) von der Horizontalen bis zum Endpunkt des Bogens"
 
-#: ../src/widgets/arc-toolbar.cpp:349
+#: ../src/widgets/arc-toolbar.cpp:503
 msgid "Closed arc"
 msgstr "Geschlossener Bogen"
 
-#: ../src/widgets/arc-toolbar.cpp:350
+#: ../src/widgets/arc-toolbar.cpp:504
 msgid "Switch to segment (closed shape with two radii)"
 msgstr "Zu Segment (geschlossene Form mit zwei Radien) umschalten"
 
-#: ../src/widgets/arc-toolbar.cpp:356
+#: ../src/widgets/arc-toolbar.cpp:510
 msgid "Open Arc"
 msgstr "Offener Bogen"
 
-#: ../src/widgets/arc-toolbar.cpp:357
+#: ../src/widgets/arc-toolbar.cpp:511
 msgid "Switch to arc (unclosed shape)"
 msgstr "Zu Bogen umschalten (offene Form)"
 
-#: ../src/widgets/arc-toolbar.cpp:380
+#: ../src/widgets/arc-toolbar.cpp:534
 msgid "Make whole"
 msgstr "Schließen"
 
-#: ../src/widgets/arc-toolbar.cpp:381
+#: ../src/widgets/arc-toolbar.cpp:535
 msgid "Make the shape a whole ellipse, not arc or segment"
 msgstr "Die Form zur ganzen Ellipse anstelle eines Bogens oder Segments machen"
 
@@ -29649,8 +29710,8 @@ msgstr "Muster für die Füllung setzen"
 msgid "Set pattern on stroke"
 msgstr "Muster für die Kontur setzen"
 
-#: ../src/widgets/font-selector.cpp:120 ../src/widgets/text-toolbar.cpp:1318
-#: ../src/widgets/text-toolbar.cpp:1723
+#: ../src/widgets/font-selector.cpp:120 ../src/widgets/text-toolbar.cpp:1378
+#: ../src/widgets/text-toolbar.cpp:1792
 msgid "Font size"
 msgstr "Schriftgröße"
 
@@ -29991,14 +30052,6 @@ msgstr "Messwert anzeigen"
 msgid "Display measuring info for selected items"
 msgstr "Messwert aür ausgewählte Objekte anzeigen"
 
-#. Add the units menu.
-#: ../src/widgets/lpe-toolbar.cpp:387 ../src/widgets/node-toolbar.cpp:613
-#: ../src/widgets/paintbucket-toolbar.cpp:168
-#: ../src/widgets/rect-toolbar.cpp:378 ../src/widgets/select-toolbar.cpp:530
-#: ../src/widgets/text-toolbar.cpp:1993
-msgid "Units"
-msgstr "Einheiten"
-
 #: ../src/widgets/lpe-toolbar.cpp:397
 msgid "Open LPE dialog"
 msgstr "LPE Dialog öffnen"
@@ -30039,7 +30092,7 @@ msgstr "Alle Teilstrecken auswerten."
 msgid "Compute max length."
 msgstr "Gesamtsrecke auswerten."
 
-#: ../src/widgets/measure-toolbar.cpp:274 ../src/widgets/text-toolbar.cpp:1726
+#: ../src/widgets/measure-toolbar.cpp:274 ../src/widgets/text-toolbar.cpp:1795
 msgid "Font Size"
 msgstr "Schriftgröße"
 
@@ -30766,24 +30819,8 @@ msgid "not rounded"
 msgstr "nicht abgerundet"
 
 #: ../src/widgets/rect-toolbar.cpp:351
-msgid "Horizontal radius"
-msgstr "Horizontaler Radius"
-
-#: ../src/widgets/rect-toolbar.cpp:351
-msgid "Rx:"
-msgstr "Rx:"
-
-#: ../src/widgets/rect-toolbar.cpp:351
 msgid "Horizontal radius of rounded corners"
 msgstr "Horizontaler Radius einer abgerundeten Ecke"
-
-#: ../src/widgets/rect-toolbar.cpp:366
-msgid "Vertical radius"
-msgstr "Vertikaler Radius"
-
-#: ../src/widgets/rect-toolbar.cpp:366
-msgid "Ry:"
-msgstr "Ry:"
 
 #: ../src/widgets/rect-toolbar.cpp:366
 msgid "Vertical radius of rounded corners"
@@ -31626,318 +31663,352 @@ msgstr "Farbmuster-Farbe ändern"
 msgid "Text: Change font family"
 msgstr "Text: Schriftfamilie ändern"
 
-#: ../src/widgets/text-toolbar.cpp:274
+#: ../src/widgets/text-toolbar.cpp:275
 msgid "Text: Change font size"
 msgstr "Text: Schriftgröße ändern"
 
-#: ../src/widgets/text-toolbar.cpp:310
+#: ../src/widgets/text-toolbar.cpp:320
 msgid "Text: Change font style"
 msgstr "Text: Schriftstil ändern"
 
-#: ../src/widgets/text-toolbar.cpp:345
+#: ../src/widgets/text-toolbar.cpp:359
 msgid "Text: Unset line height."
 msgstr "Text: Zeilenhöhe nicht setzen."
 
-#: ../src/widgets/text-toolbar.cpp:422
+#: ../src/widgets/text-toolbar.cpp:436
 msgid "Text: Change superscript or subscript"
 msgstr "Text: Ändern von Hoch- und Tiefgestellt"
 
-#: ../src/widgets/text-toolbar.cpp:565
+#: ../src/widgets/text-toolbar.cpp:579
 msgid "Text: Change alignment"
 msgstr "Text: Ausrichtung ändern"
 
-#: ../src/widgets/text-toolbar.cpp:668
+#: ../src/widgets/text-toolbar.cpp:682
 msgid "Text: Change line-height"
 msgstr "Text: Linienhöhe ändern"
 
-#: ../src/widgets/text-toolbar.cpp:824
+#: ../src/widgets/text-toolbar.cpp:838
 msgid "Text: Change line-height unit"
 msgstr "Text: Einheit für Zeilenabstand ändern"
 
-#: ../src/widgets/text-toolbar.cpp:873
+#: ../src/widgets/text-toolbar.cpp:887
 msgid "Text: Change word-spacing"
 msgstr "Text: Wortabstand ändern"
 
-#: ../src/widgets/text-toolbar.cpp:913
+#: ../src/widgets/text-toolbar.cpp:927
 msgid "Text: Change letter-spacing"
 msgstr "Text: Buchstabenabstand ändern"
 
-#: ../src/widgets/text-toolbar.cpp:951
+#: ../src/widgets/text-toolbar.cpp:965
 msgid "Text: Change dx (kern)"
 msgstr "Text: Ändern dx (kern)"
 
-#: ../src/widgets/text-toolbar.cpp:985
+#: ../src/widgets/text-toolbar.cpp:999
 msgid "Text: Change dy"
 msgstr "Text: Ändern dy"
 
-#: ../src/widgets/text-toolbar.cpp:1020
+#: ../src/widgets/text-toolbar.cpp:1034
 msgid "Text: Change rotate"
 msgstr "Text: Ändern Drehung"
 
-#: ../src/widgets/text-toolbar.cpp:1073
+#: ../src/widgets/text-toolbar.cpp:1087
 msgid "Text: Change writing mode"
 msgstr "Textrichtung ändern"
 
-#: ../src/widgets/text-toolbar.cpp:1127
+#: ../src/widgets/text-toolbar.cpp:1141
 msgid "Text: Change orientation"
 msgstr "Textausrichtung ändern"
 
-#: ../src/widgets/text-toolbar.cpp:1656
+#: ../src/widgets/text-toolbar.cpp:1188
+#, fuzzy
+msgid "Text: Change direction"
+msgstr "Textausrichtung ändern"
+
+#: ../src/widgets/text-toolbar.cpp:1725
 msgid "Font Family"
 msgstr "Schriftfamilie"
 
-#: ../src/widgets/text-toolbar.cpp:1657
+#: ../src/widgets/text-toolbar.cpp:1726
 msgid "Select Font Family (Alt-X to access)"
 msgstr "Schriftart-Familie auswählen (Alt + X zum Setzen)"
 
 #. Focus widget
 #. Enable entry completion
-#: ../src/widgets/text-toolbar.cpp:1667
+#: ../src/widgets/text-toolbar.cpp:1736
 msgid "Select all text with this font-family"
 msgstr "Wähle allen Text mit dieser Schriftart-Familie aus"
 
-#: ../src/widgets/text-toolbar.cpp:1671
+#: ../src/widgets/text-toolbar.cpp:1740
 msgid "Font not found on system"
 msgstr "Schrift wurde im System nicht gefunden"
 
-#: ../src/widgets/text-toolbar.cpp:1748
+#: ../src/widgets/text-toolbar.cpp:1817
 msgid "Font Style"
 msgstr "Schriftstil"
 
-#: ../src/widgets/text-toolbar.cpp:1749
+#: ../src/widgets/text-toolbar.cpp:1818
 msgid "Font style"
 msgstr "Schriftstil"
 
 #. Name
-#: ../src/widgets/text-toolbar.cpp:1766
+#: ../src/widgets/text-toolbar.cpp:1835
 msgid "Toggle Superscript"
 msgstr "Hochgestellt umschalten"
 
 #. Label
-#: ../src/widgets/text-toolbar.cpp:1767
+#: ../src/widgets/text-toolbar.cpp:1836
 msgid "Toggle superscript"
 msgstr "Hochgestellt umschalten"
 
 #. Name
-#: ../src/widgets/text-toolbar.cpp:1779
+#: ../src/widgets/text-toolbar.cpp:1848
 msgid "Toggle Subscript"
 msgstr "Tiefgestellt umschalten"
 
 #. Label
-#: ../src/widgets/text-toolbar.cpp:1780
+#: ../src/widgets/text-toolbar.cpp:1849
 msgid "Toggle subscript"
 msgstr "Tiefgestellt umschalten"
 
-#: ../src/widgets/text-toolbar.cpp:1821
+#: ../src/widgets/text-toolbar.cpp:1890
 msgid "Justify"
 msgstr "Blocksatz"
 
 # Alignment (left, center, right, block)
 #. Name
-#: ../src/widgets/text-toolbar.cpp:1828
+#: ../src/widgets/text-toolbar.cpp:1897
 msgid "Alignment"
 msgstr "Ausrichtung"
 
 #. Label
-#: ../src/widgets/text-toolbar.cpp:1829
+#: ../src/widgets/text-toolbar.cpp:1898
 msgid "Text alignment"
 msgstr "Textausrichtung"
 
-#: ../src/widgets/text-toolbar.cpp:1856
+#: ../src/widgets/text-toolbar.cpp:1925
 msgid "Horizontal"
 msgstr "Horizontal"
 
-#: ../src/widgets/text-toolbar.cpp:1863
+#: ../src/widgets/text-toolbar.cpp:1932
 msgid "Vertical — RL"
 msgstr "Vertikal — RL"
 
-#: ../src/widgets/text-toolbar.cpp:1864
+#: ../src/widgets/text-toolbar.cpp:1933
 msgid "Vertical text — lines: right to left"
 msgstr "Vertikaler Text — Zeilen von rechts nach links"
 
-#: ../src/widgets/text-toolbar.cpp:1870
+#: ../src/widgets/text-toolbar.cpp:1939
 msgid "Vertical — LR"
 msgstr "Vertikal — LR"
 
-#: ../src/widgets/text-toolbar.cpp:1871
+#: ../src/widgets/text-toolbar.cpp:1940
 msgid "Vertical text — lines: left to right"
 msgstr "Vertikaler Text — Zeilen von links nach rechts"
 
 # Writing mode (Horizontal, Vertical-LR, Vertical-RL)
 #. Name
-#: ../src/widgets/text-toolbar.cpp:1876
+#: ../src/widgets/text-toolbar.cpp:1945
 msgid "Writing mode"
 msgstr "Textrichtung"
 
 #. Label
-#: ../src/widgets/text-toolbar.cpp:1877
+#: ../src/widgets/text-toolbar.cpp:1946
 msgid "Block progression"
 msgstr "Textrichtung"
 
-#: ../src/widgets/text-toolbar.cpp:1906
+#: ../src/widgets/text-toolbar.cpp:1975
 msgid "Auto glyph orientation"
 msgstr "Automatische Zeichenausrichtung"
 
-#: ../src/widgets/text-toolbar.cpp:1913
+#: ../src/widgets/text-toolbar.cpp:1982
 msgid "Upright"
 msgstr "Aufrecht"
 
-#: ../src/widgets/text-toolbar.cpp:1914
+#: ../src/widgets/text-toolbar.cpp:1983
 msgid "Upright glyph orientation"
 msgstr "Aufrechte Zeichenausrichtung"
 
-#: ../src/widgets/text-toolbar.cpp:1921
+#: ../src/widgets/text-toolbar.cpp:1990
 msgid "Sideways"
 msgstr "Gedreht"
 
-#: ../src/widgets/text-toolbar.cpp:1922
+#: ../src/widgets/text-toolbar.cpp:1991
 msgid "Sideways glyph orientation"
 msgstr "Gedrehte Zeichenausrichtung"
 
 # Text (glyph) orientation (Auto (mixed), Upright, Sideways)
 #. Name
-#: ../src/widgets/text-toolbar.cpp:1928
+#: ../src/widgets/text-toolbar.cpp:1997
 msgid "Text orientation"
 msgstr "Zeichenausrichtung"
 
 #. Label
-#: ../src/widgets/text-toolbar.cpp:1929
+#: ../src/widgets/text-toolbar.cpp:1998
 msgid "Text (glyph) orientation in vertical text."
 msgstr "Zeichenausrichtung in vertikalem Text"
 
+#: ../src/widgets/text-toolbar.cpp:2028
+msgid "LTR"
+msgstr ""
+
+#: ../src/widgets/text-toolbar.cpp:2029
+#, fuzzy
+msgid "Left to right text"
+msgstr "Links nach Rechts"
+
+#: ../src/widgets/text-toolbar.cpp:2036
+msgid "RTL"
+msgstr ""
+
+#: ../src/widgets/text-toolbar.cpp:2037
+#, fuzzy
+msgid "Right to left text"
+msgstr "Rechts nach Links"
+
+#. Name
+#: ../src/widgets/text-toolbar.cpp:2043
+#, fuzzy
+msgid "Text direction"
+msgstr "Textrichtung:"
+
+#. Label
+#: ../src/widgets/text-toolbar.cpp:2044
+msgid "Text direction for normally horizontal text."
+msgstr ""
+
 #. Drop down menu
-#: ../src/widgets/text-toolbar.cpp:1962
+#: ../src/widgets/text-toolbar.cpp:2077
 msgid "Smaller spacing"
 msgstr "Kleinerer Abstand"
 
-#: ../src/widgets/text-toolbar.cpp:1962 ../src/widgets/text-toolbar.cpp:2001
-#: ../src/widgets/text-toolbar.cpp:2032
+#: ../src/widgets/text-toolbar.cpp:2077 ../src/widgets/text-toolbar.cpp:2116
+#: ../src/widgets/text-toolbar.cpp:2147
 msgctxt "Text tool"
 msgid "Normal"
 msgstr "Normal"
 
-#: ../src/widgets/text-toolbar.cpp:1962
+#: ../src/widgets/text-toolbar.cpp:2077
 msgid "Larger spacing"
 msgstr "Größerer Abstand"
 
 #. name
-#: ../src/widgets/text-toolbar.cpp:1967
+#: ../src/widgets/text-toolbar.cpp:2082
 msgid "Line Height"
 msgstr "Linienhöhe"
 
 #. label
-#: ../src/widgets/text-toolbar.cpp:1968
+#: ../src/widgets/text-toolbar.cpp:2083
 msgid "Line:"
 msgstr "Linie:"
 
 #. short label
-#: ../src/widgets/text-toolbar.cpp:1969
+#: ../src/widgets/text-toolbar.cpp:2084
 msgid "Spacing between baselines (times font size)"
 msgstr "Abstand zwischen Grundlinien (relativ zur Schriftgröße)"
 
 #. Drop down menu
-#: ../src/widgets/text-toolbar.cpp:2001 ../src/widgets/text-toolbar.cpp:2032
+#: ../src/widgets/text-toolbar.cpp:2116 ../src/widgets/text-toolbar.cpp:2147
 msgid "Negative spacing"
 msgstr "Negativer Abstand"
 
-#: ../src/widgets/text-toolbar.cpp:2001 ../src/widgets/text-toolbar.cpp:2032
+#: ../src/widgets/text-toolbar.cpp:2116 ../src/widgets/text-toolbar.cpp:2147
 msgid "Positive spacing"
 msgstr "Positiver Abstand"
 
 #. name
-#: ../src/widgets/text-toolbar.cpp:2006
+#: ../src/widgets/text-toolbar.cpp:2121
 msgid "Word spacing"
 msgstr "Wortabstand"
 
 #. label
-#: ../src/widgets/text-toolbar.cpp:2007
+#: ../src/widgets/text-toolbar.cpp:2122
 msgid "Word:"
 msgstr "Wort:"
 
 #. short label
-#: ../src/widgets/text-toolbar.cpp:2008
+#: ../src/widgets/text-toolbar.cpp:2123
 msgid "Spacing between words (px)"
 msgstr "Wortabstand (px)"
 
 #. name
-#: ../src/widgets/text-toolbar.cpp:2037
+#: ../src/widgets/text-toolbar.cpp:2152
 msgid "Letter spacing"
 msgstr "Buchstabenabstand"
 
 #. label
-#: ../src/widgets/text-toolbar.cpp:2038
+#: ../src/widgets/text-toolbar.cpp:2153
 msgid "Letter:"
 msgstr "Buchstabe:"
 
 #. short label
-#: ../src/widgets/text-toolbar.cpp:2039
+#: ../src/widgets/text-toolbar.cpp:2154
 msgid "Spacing between letters (px)"
 msgstr "Zeichenabstand (px)"
 
 #. name
-#: ../src/widgets/text-toolbar.cpp:2068
+#: ../src/widgets/text-toolbar.cpp:2183
 msgid "Kerning"
 msgstr "Unterschneidung"
 
 #. label
-#: ../src/widgets/text-toolbar.cpp:2069
+#: ../src/widgets/text-toolbar.cpp:2184
 msgid "Kern:"
 msgstr "Kern:"
 
 #. short label
-#: ../src/widgets/text-toolbar.cpp:2070
+#: ../src/widgets/text-toolbar.cpp:2185
 msgid "Horizontal kerning (px)"
 msgstr "Horizontale Unterschneidung (px)"
 
 #. name
-#: ../src/widgets/text-toolbar.cpp:2099
+#: ../src/widgets/text-toolbar.cpp:2214
 msgid "Vertical Shift"
 msgstr "Vertikaler Versatz"
 
 #. label
-#: ../src/widgets/text-toolbar.cpp:2100
+#: ../src/widgets/text-toolbar.cpp:2215
 msgid "Vert:"
 msgstr "Vert:"
 
 #. short label
-#: ../src/widgets/text-toolbar.cpp:2101
+#: ../src/widgets/text-toolbar.cpp:2216
 msgid "Vertical shift (px)"
 msgstr "Vertikaler Versatz (px)"
 
 #. name
-#: ../src/widgets/text-toolbar.cpp:2130
+#: ../src/widgets/text-toolbar.cpp:2245
 msgid "Letter rotation"
 msgstr "Buchstabendrehung"
 
 #. label
-#: ../src/widgets/text-toolbar.cpp:2131
+#: ../src/widgets/text-toolbar.cpp:2246
 msgid "Rot:"
 msgstr "Dreh:"
 
 #. short label
-#: ../src/widgets/text-toolbar.cpp:2132
+#: ../src/widgets/text-toolbar.cpp:2247
 msgid "Character rotation (degrees)"
 msgstr "Zeichendrehung (Grad)"
 
 #. Name
-#: ../src/widgets/text-toolbar.cpp:2156
+#: ../src/widgets/text-toolbar.cpp:2271
 msgid "Unset line height"
 msgstr "Zeilenhöhe aufheben"
 
 #. Label
-#: ../src/widgets/text-toolbar.cpp:2157
+#: ../src/widgets/text-toolbar.cpp:2272
 msgid "If enabled, line height is set on part of selection. Click to unset."
 msgstr ""
 "Wenn aktiviert, wird die Zeilenhöhe nur für die Auswahl gesetzt. Klicken, um "
 "die gesetzte Zeilenhöhe zu entfernen."
 
 #. Name
-#: ../src/widgets/text-toolbar.cpp:2169
+#: ../src/widgets/text-toolbar.cpp:2284
 msgid "Show outer style"
 msgstr "Stil des gesamten Textobjektes anzeigen"
 
 #. Label
-#: ../src/widgets/text-toolbar.cpp:2170
+#: ../src/widgets/text-toolbar.cpp:2285
 msgid ""
 "Show style of outermost text element. The 'font-size' and 'line-height' "
 "values of the outermost text element determine the minimum line spacing in "
@@ -31991,133 +32062,133 @@ msgstr "\"Beschreibung fehlt noch!\""
 msgid "Style of Paint Bucket fill objects"
 msgstr "Stil von neuen Farbeimer-Objekten"
 
-#: ../src/widgets/toolbox.cpp:1758
+#: ../src/widgets/toolbox.cpp:1757
 msgid "Bounding box"
 msgstr "Objektrahmen"
 
-#: ../src/widgets/toolbox.cpp:1758
+#: ../src/widgets/toolbox.cpp:1757
 msgid "Snap bounding boxes"
 msgstr "Objektrahmen einrasten"
 
-#: ../src/widgets/toolbox.cpp:1767
+#: ../src/widgets/toolbox.cpp:1766
 msgid "Bounding box edges"
 msgstr "Kanten des Objektrahmens"
 
-#: ../src/widgets/toolbox.cpp:1767
+#: ../src/widgets/toolbox.cpp:1766
 msgid "Snap to edges of a bounding box"
 msgstr "An Kanten eines Objektrahmens einrasten"
 
-#: ../src/widgets/toolbox.cpp:1776
+#: ../src/widgets/toolbox.cpp:1775
 msgid "Bounding box corners"
 msgstr "Ecken des Objektrahmens"
 
-#: ../src/widgets/toolbox.cpp:1776
+#: ../src/widgets/toolbox.cpp:1775
 msgid "Snap bounding box corners"
 msgstr "Ecken des Objektrahmens einrasten"
 
-#: ../src/widgets/toolbox.cpp:1785
+#: ../src/widgets/toolbox.cpp:1784
 msgid "BBox Edge Midpoints"
 msgstr "Mittelpunkte von Objektrahmenlinien"
 
-#: ../src/widgets/toolbox.cpp:1785
+#: ../src/widgets/toolbox.cpp:1784
 msgid "Snap midpoints of bounding box edges"
 msgstr "Mittelpunkte von Objektrahmenlinien einrasten"
 
-#: ../src/widgets/toolbox.cpp:1795
+#: ../src/widgets/toolbox.cpp:1794
 msgid "BBox Centers"
 msgstr "Mittelpunkte von Objektrahmen"
 
-#: ../src/widgets/toolbox.cpp:1795
+#: ../src/widgets/toolbox.cpp:1794
 msgid "Snapping centers of bounding boxes"
 msgstr "Mittelpunkte von Objektrahmen einrasten"
 
-#: ../src/widgets/toolbox.cpp:1804
+#: ../src/widgets/toolbox.cpp:1803
 msgid "Snap nodes, paths, and handles"
 msgstr "Knoten, Pfade und Anfasser einrasten"
 
-#: ../src/widgets/toolbox.cpp:1812
+#: ../src/widgets/toolbox.cpp:1811
 msgid "Snap to paths"
 msgstr "An Pfaden einrasten"
 
-#: ../src/widgets/toolbox.cpp:1821
+#: ../src/widgets/toolbox.cpp:1820
 msgid "Path intersections"
 msgstr "Pfadüberschneidungen"
 
-#: ../src/widgets/toolbox.cpp:1821
+#: ../src/widgets/toolbox.cpp:1820
 msgid "Snap to path intersections"
 msgstr "An Pfadüberschneidungen einrasten"
 
-#: ../src/widgets/toolbox.cpp:1830
+#: ../src/widgets/toolbox.cpp:1829
 msgid "To nodes"
 msgstr "An Knoten"
 
-#: ../src/widgets/toolbox.cpp:1830
+#: ../src/widgets/toolbox.cpp:1829
 msgid "Snap cusp nodes, incl. rectangle corners"
 msgstr "Spitze Knoten einrasten, inkl. Ecken von Rechtecken"
 
-#: ../src/widgets/toolbox.cpp:1839
+#: ../src/widgets/toolbox.cpp:1838
 msgid "Smooth nodes"
 msgstr "Glatte Knoten"
 
-#: ../src/widgets/toolbox.cpp:1839
+#: ../src/widgets/toolbox.cpp:1838
 msgid "Snap smooth nodes, incl. quadrant points of ellipses"
 msgstr "Glatte Knoten einrasten, inkl. Quadrantenpunkte von Ellipsen"
 
-#: ../src/widgets/toolbox.cpp:1848
+#: ../src/widgets/toolbox.cpp:1847
 msgid "Line Midpoints"
 msgstr "Linien-Mittelpunkte"
 
-#: ../src/widgets/toolbox.cpp:1848
+#: ../src/widgets/toolbox.cpp:1847
 msgid "Snap midpoints of line segments"
 msgstr "Mittelpunkte von Liniensegmenten einrasten"
 
-#: ../src/widgets/toolbox.cpp:1857
+#: ../src/widgets/toolbox.cpp:1856
 msgid "Others"
 msgstr "Andere"
 
-#: ../src/widgets/toolbox.cpp:1857
+#: ../src/widgets/toolbox.cpp:1856
 msgid "Snap other points (centers, guide origins, gradient handles, etc.)"
 msgstr ""
 "Andere Punkte einrasten (Mittelpunkte, Ursprünge von Hilfslinien, Anfasser "
 "von Farbverläufen, usw.)"
 
-#: ../src/widgets/toolbox.cpp:1865
+#: ../src/widgets/toolbox.cpp:1864
 msgid "Object Centers"
 msgstr "Objektmittelpunkte"
 
-#: ../src/widgets/toolbox.cpp:1865
+#: ../src/widgets/toolbox.cpp:1864
 msgid "Snap centers of objects"
 msgstr "Objektmittelpunkte einrasten"
 
-#: ../src/widgets/toolbox.cpp:1874
+#: ../src/widgets/toolbox.cpp:1873
 msgid "Rotation Centers"
 msgstr "Drehpunkte"
 
-#: ../src/widgets/toolbox.cpp:1874
+#: ../src/widgets/toolbox.cpp:1873
 msgid "Snap an item's rotation center"
 msgstr "Drehpunkte von Objekten einrasten"
 
-#: ../src/widgets/toolbox.cpp:1883
+#: ../src/widgets/toolbox.cpp:1882
 msgid "Text baseline"
 msgstr "Text-Grundlinie"
 
-#: ../src/widgets/toolbox.cpp:1883
+#: ../src/widgets/toolbox.cpp:1882
 msgid "Snap text anchors and baselines"
 msgstr "Textanker und Grundlinien einrasten"
 
-#: ../src/widgets/toolbox.cpp:1893
+#: ../src/widgets/toolbox.cpp:1892
 msgid "Page border"
 msgstr "Seitenrand"
 
-#: ../src/widgets/toolbox.cpp:1893
+#: ../src/widgets/toolbox.cpp:1892
 msgid "Snap to the page border"
 msgstr "Am Seitenrand einrasten"
 
-#: ../src/widgets/toolbox.cpp:1902
+#: ../src/widgets/toolbox.cpp:1901
 msgid "Snap to grids"
 msgstr "Am Gitter einrasten"
 
-#: ../src/widgets/toolbox.cpp:1911
+#: ../src/widgets/toolbox.cpp:1910
 msgid "Snap guides"
 msgstr "Hilfslinien einrasten"
 
@@ -32413,7 +32484,7 @@ msgstr ""
 "Fehler: Feld 'Übereinstimmender Ebenenname' muss ausgefüllt sein, wenn die "
 "Option 'Nach Namensübereinstimmung' verwendet wird."
 
-#: ../share/extensions/dxf_outlines.py:357
+#: ../share/extensions/dxf_outlines.py:364
 #, python-format
 msgid "Warning: Layer '%s' not found!"
 msgstr "Warnung: Ebene '%s' nicht gefunden!"
@@ -40182,6 +40253,15 @@ msgstr "Ein beliebtes Dateiformat für Clipart"
 #: ../share/extensions/xaml2svg.inx.h:1
 msgid "XAML Input"
 msgstr "XAML einlesen"
+
+#~ msgid ""
+#~ "Only for PS/EPS/PDF, sets margin in mm around exported area (default 0)"
+#~ msgstr ""
+#~ "Nur für PS/EPS/PDF. Setzt einen Rand in mm um den exportierten Bereich "
+#~ "(Standard 0)"
+
+#~ msgid "Scale Y"
+#~ msgstr "Y skalieren"
 
 #~ msgid ""
 #~ "Old Inkscape files use 1in == 90px. CSS requires 1in == 96px.\n"

--- a/0.92/de.po
+++ b/0.92/de.po
@@ -16,15 +16,15 @@
 # Benjamin Weis <benjamin.weis@gmx.com>, 2014.
 # Heiko Wöhrle <mail@heikowoehrle.de>, 2014.
 # Sönke Roggatz <s.roggatz@mailing-werkstatt.de>, 2015.
-# Maren Hachmann <marenhachmann@yahoo.com>, 2015, 2016, 2017.
+# Maren Hachmann <marenhachmann@yahoo.com>, 2015, 2016, 2017, 2018.
 # Eduard Braun <eduard.braun2@gmx.de>, 2015-2017.
 msgid ""
 msgstr ""
 "Project-Id-Version: inkscape\n"
 "Report-Msgid-Bugs-To: inkscape-devel@lists.sourceforge.net\n"
 "POT-Creation-Date: 2018-02-03 23:41+0100\n"
-"PO-Revision-Date: 2017-08-05 00:39+0100\n"
-"Last-Translator: Eduard Braun <eduard.braun2@gmx.de>\n"
+"PO-Revision-Date: 2018-02-12 23:56+0100\n"
+"Last-Translator: Maren Hachmann <marenhachmann@yahoo.com>\n"
 "Language-Team: German <kde-i18n-de@kde.org>\n"
 "Language: de\n"
 "MIME-Version: 1.0\n"
@@ -397,7 +397,7 @@ msgstr "Stacheldraht"
 
 #: ../share/filters/filters.svg.h:96
 msgid "Gray bevelled wires with drop shadows"
-msgstr "Graue verworrene Drähte mit abgesetztem Schatten"
+msgstr "Graue verworrene Drähte mit Schlagschatten"
 
 #: ../share/filters/filters.svg.h:98
 msgid "Swiss Cheese"
@@ -7668,7 +7668,7 @@ msgstr "Schnee liegt auf dem Objekt"
 
 #: ../src/extension/internal/filter/shadows.h:57
 msgid "Drop Shadow"
-msgstr "Abgesetzter Schatten"
+msgstr "Schlagschatten"
 
 #: ../src/extension/internal/filter/shadows.h:61
 msgid "Blur radius (px)"
@@ -8425,7 +8425,6 @@ msgid "More details..."
 msgstr "Nähere Informationen..."
 
 #: ../src/file-update.cpp:343
-#, fuzzy
 msgid ""
 "<small>We've updated Inkscape to follow the CSS standard of 96 DPI for "
 "better browser compatibility; we used to use 90 DPI. Digital artwork for "
@@ -8450,8 +8449,8 @@ msgstr ""
 "<small>Wir haben Inkscape aktualisiert, um den CSS-Standard von 96 dpi "
 "Auflösung für bessere Kompatibilität mit Webbrowsern zu erfüllen. Früher "
 "haben wir 90 dpi verwendet. Digitales Bildmaterial, das auf einem Bildschirm "
-"dargestellt werden sollen, werden ohne Größenänderung zu 96 dpi konvertiert "
-"und sollten nicht betroffen sein. Kunstwerke, die mit 90 dpi für eine "
+"dargestellt werden soll, wird ohne Größenänderung zu 96 dpi konvertiert "
+"und sollte nicht betroffen sein. Kunstwerke, die mit 90 dpi für eine "
 "bestimmte physische Größe erstellt worden sind, werden zu klein sein, wenn "
 "sie ohne Größenänderung zu 96 dpi konvertiert werden. Es gibt zwei Methoden "
 "zur Anpassung der Größe:\n"
@@ -8467,8 +8466,9 @@ msgstr ""
 "Sie eignet sich jedoch besser für die Ausgabe auf physischen Medien, wenn "
 "eine korrekte Größe und Position wichtig sind (z.B. für den 3D-Druck).\n"
 "\n"
-"Mehr Informationen zu dieser Änderung gibt es in der <a href='https://"
-"inkscape.org/de/learn/faq#todo-todo-todo'>Inkscape-FAQ</a></small>"
+"Mehr Informationen zu dieser Änderung gibt es in der <a href='https:// "
+"inkscape.org/de/lernen/haufig-gestellte-fragen/#dpi_change'>Inkscape-FAQ</a><"
+"/small>."
 
 #: ../src/file-update.cpp:387
 msgid "OK"
@@ -10089,9 +10089,8 @@ msgid "Paths from which to take the original path data"
 msgstr "Pfade, von denen die Orginal-Pfaddaten genommen werden"
 
 #: ../src/live_effects/lpe-fill-between-many.cpp:26
-#, fuzzy
 msgid "Allow transforms"
-msgstr "Transformationen"
+msgstr "Transformationen erlauben"
 
 #: ../src/live_effects/lpe-fill-between-strokes.cpp:24
 msgid "Second path:"
@@ -12085,6 +12084,8 @@ msgid ""
 "Sets margin around exported area (default 0) in units of page size for SVG "
 "and mm for PS/EPS/PDF"
 msgstr ""
+"Fügt einen Rand um den exportierten Bereich ein. Die Einheit ist für SVG die"
+" Einheit der Seitengröße, für PS/EPS/PDF mm (Standardwert 0)."
 
 #: ../src/main.cpp:356 ../src/main.cpp:398
 msgid "VALUE"
@@ -12327,11 +12328,12 @@ msgstr ""
 "früher) erstellt wurden beim Öffnen nicht automatisch korrigieren."
 
 #: ../src/main.cpp:541
-#, fuzzy
 msgid ""
 "Method used to convert pre-.92 document dpi, if needed. ([none|scale-viewbox|"
 "scale-document])"
-msgstr "Methode zur DPI-Konvertierung von pre-0.92-Dokumenten"
+msgstr ""
+"Methode, die zur DPI-Konvertierung von pre-0.92-Dokumenten verwendet werden"
+" soll, falls nötig ([none|scale-viewbox|scale-document])"
 
 #: ../src/main.cpp:891 ../src/main.cpp:1379
 msgid ""
@@ -16752,7 +16754,7 @@ msgid ""
 msgstr ""
 "Der Filterbaustein <b>Gaußscher Weichzeichner</b> zeichnet die Quelle weich. "
 "Er wird normalerweise zusammen mit dem Filterbaustein Versatz benutzt, um "
-"abgesetzte Schatten zu erzeugen."
+"Schlagschatten zu erzeugen."
 
 #: ../src/ui/dialog/filter-effects-dialog.cpp:3022
 msgid ""
@@ -16791,7 +16793,7 @@ msgid ""
 "a slightly different position than the actual object."
 msgstr ""
 "Der Filterbaustein <b>Versatz</b> verschiebt das Bild um einen "
-"benutzerdefinierten Betrag. Dies ist z. B. für abgesetzte Schatten nützlich, "
+"benutzerdefinierten Betrag. Dies ist z. B. für Schlagschatten nützlich, "
 "die sich an einer leicht anderen Position als das eigentliche Objekt "
 "befinden."
 
@@ -20708,20 +20710,21 @@ msgstr ""
 "Null setzen, um Cachen zu deaktivieren"
 
 #: ../src/ui/dialog/inkscape-preferences.cpp:1450
-#, fuzzy
 msgid "Rendering tile multiplier:"
-msgstr "Rendering-Cachegröße:"
+msgstr "Renderkachel-Multiplikator:"
 
 #: ../src/ui/dialog/inkscape-preferences.cpp:1450
-#, fuzzy
 msgid "requires restart"
-msgstr "(erfordert Neustart)"
+msgstr "erfordert Neustart"
 
 #: ../src/ui/dialog/inkscape-preferences.cpp:1450
 msgid ""
 "Set the relative size of tiles used to render the canvas. The larger the "
 "value, the bigger the tile size."
 msgstr ""
+"Bestimmt die Größe der Kacheln für die Darstellung der Zeichnung "
+"im Verhältnis zur Zeichenfläche. Je größer der Wert, desto größer sind "
+"die einzelnen Kacheln."
 
 #. blur quality
 #. filter quality
@@ -28903,9 +28906,8 @@ msgid "Center on horizontal and vertical axis"
 msgstr "An horizontalen und vertikalen Achsen ausrichten"
 
 #: ../src/widgets/arc-toolbar.cpp:143
-#, fuzzy
 msgid "Change arc"
-msgstr "Weichzeichner ändern"
+msgstr "Bogen ändern"
 
 #: ../src/widgets/arc-toolbar.cpp:209
 msgid "Arc: Change start/end"
@@ -28942,9 +28944,8 @@ msgid "Rx:"
 msgstr "Rx:"
 
 #: ../src/widgets/arc-toolbar.cpp:435
-#, fuzzy
 msgid "Horizontal radius of the circle, ellipse, or arc"
-msgstr "Horizontaler Radius einer abgerundeten Ecke"
+msgstr "Horizontaler Radius des Kreises, der Ellipse oder des Bogens"
 
 #: ../src/widgets/arc-toolbar.cpp:452 ../src/widgets/rect-toolbar.cpp:366
 msgid "Vertical radius"
@@ -28955,9 +28956,8 @@ msgid "Ry:"
 msgstr "Ry:"
 
 #: ../src/widgets/arc-toolbar.cpp:452
-#, fuzzy
 msgid "Vertical radius of the circle, ellipse, or arc"
-msgstr "Kreise, Ellipsen und Bögen erstellen"
+msgstr "Vertikaler Radius des Kreises, der Ellipse oder des Bogens"
 
 #. Add the units menu.
 #: ../src/widgets/arc-toolbar.cpp:466 ../src/widgets/lpe-toolbar.cpp:387
@@ -31720,9 +31720,8 @@ msgid "Text: Change orientation"
 msgstr "Textausrichtung ändern"
 
 #: ../src/widgets/text-toolbar.cpp:1188
-#, fuzzy
 msgid "Text: Change direction"
-msgstr "Textausrichtung ändern"
+msgstr "Text: Schreibrichtung ändern"
 
 #: ../src/widgets/text-toolbar.cpp:1725
 msgid "Font Family"
@@ -31849,32 +31848,29 @@ msgstr "Zeichenausrichtung in vertikalem Text"
 
 #: ../src/widgets/text-toolbar.cpp:2028
 msgid "LTR"
-msgstr ""
+msgstr "LTR"
 
 #: ../src/widgets/text-toolbar.cpp:2029
-#, fuzzy
 msgid "Left to right text"
-msgstr "Links nach Rechts"
+msgstr "Text von links nach rechts"
 
 #: ../src/widgets/text-toolbar.cpp:2036
 msgid "RTL"
-msgstr ""
+msgstr "RTL"
 
 #: ../src/widgets/text-toolbar.cpp:2037
-#, fuzzy
 msgid "Right to left text"
-msgstr "Rechts nach Links"
+msgstr "Text von rechts nach links"
 
 #. Name
 #: ../src/widgets/text-toolbar.cpp:2043
-#, fuzzy
 msgid "Text direction"
-msgstr "Textrichtung:"
+msgstr "Schreibrichtung"
 
 #. Label
 #: ../src/widgets/text-toolbar.cpp:2044
 msgid "Text direction for normally horizontal text."
-msgstr ""
+msgstr "Schreibrichtung für normalerweise horizontal geschriebenen Text"
 
 #. Drop down menu
 #: ../src/widgets/text-toolbar.cpp:2077

--- a/0.92/inkscape.pot
+++ b/0.92/inkscape.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: inkscape-devel@lists.sourceforge.net\n"
-"POT-Creation-Date: 2017-07-24 23:11+0200\n"
+"POT-Creation-Date: 2018-02-03 23:41+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -317,7 +317,7 @@ msgstr ""
 
 #. Pencil
 #: ../share/filters/filters.svg.h:78
-#: ../src/ui/dialog/inkscape-preferences.cpp:433
+#: ../src/ui/dialog/inkscape-preferences.cpp:451
 msgid "Pencil"
 msgstr ""
 
@@ -4409,7 +4409,7 @@ msgstr ""
 
 #. 3D box
 #: ../src/box3d.cpp:255 ../src/box3d.cpp:1309
-#: ../src/ui/dialog/inkscape-preferences.cpp:416
+#: ../src/ui/dialog/inkscape-preferences.cpp:434
 msgid "3D Box"
 msgstr ""
 
@@ -4470,8 +4470,8 @@ msgid "_Origin X:"
 msgstr ""
 
 #: ../src/display/canvas-axonomgrid.cpp:359 ../src/display/canvas-grid.cpp:715
-#: ../src/ui/dialog/inkscape-preferences.cpp:786
-#: ../src/ui/dialog/inkscape-preferences.cpp:811
+#: ../src/ui/dialog/inkscape-preferences.cpp:804
+#: ../src/ui/dialog/inkscape-preferences.cpp:829
 msgid "X coordinate of grid origin"
 msgstr ""
 
@@ -4480,8 +4480,8 @@ msgid "O_rigin Y:"
 msgstr ""
 
 #: ../src/display/canvas-axonomgrid.cpp:362 ../src/display/canvas-grid.cpp:718
-#: ../src/ui/dialog/inkscape-preferences.cpp:787
-#: ../src/ui/dialog/inkscape-preferences.cpp:812
+#: ../src/ui/dialog/inkscape-preferences.cpp:805
+#: ../src/ui/dialog/inkscape-preferences.cpp:830
 msgid "Y coordinate of grid origin"
 msgstr ""
 
@@ -4490,29 +4490,29 @@ msgid "Spacing _Y:"
 msgstr ""
 
 #: ../src/display/canvas-axonomgrid.cpp:365
-#: ../src/ui/dialog/inkscape-preferences.cpp:815
+#: ../src/ui/dialog/inkscape-preferences.cpp:833
 msgid "Base length of z-axis"
 msgstr ""
 
 #: ../src/display/canvas-axonomgrid.cpp:368
-#: ../src/ui/dialog/inkscape-preferences.cpp:818
+#: ../src/ui/dialog/inkscape-preferences.cpp:836
 #: ../src/widgets/box3d-toolbar.cpp:302
 msgid "Angle X:"
 msgstr ""
 
 #: ../src/display/canvas-axonomgrid.cpp:368
-#: ../src/ui/dialog/inkscape-preferences.cpp:818
+#: ../src/ui/dialog/inkscape-preferences.cpp:836
 msgid "Angle of x-axis"
 msgstr ""
 
 #: ../src/display/canvas-axonomgrid.cpp:370
-#: ../src/ui/dialog/inkscape-preferences.cpp:819
+#: ../src/ui/dialog/inkscape-preferences.cpp:837
 #: ../src/widgets/box3d-toolbar.cpp:381
 msgid "Angle Z:"
 msgstr ""
 
 #: ../src/display/canvas-axonomgrid.cpp:370
-#: ../src/ui/dialog/inkscape-preferences.cpp:819
+#: ../src/ui/dialog/inkscape-preferences.cpp:837
 msgid "Angle of z-axis"
 msgstr ""
 
@@ -4521,7 +4521,7 @@ msgid "Minor grid line _color:"
 msgstr ""
 
 #: ../src/display/canvas-axonomgrid.cpp:374 ../src/display/canvas-grid.cpp:729
-#: ../src/ui/dialog/inkscape-preferences.cpp:770
+#: ../src/ui/dialog/inkscape-preferences.cpp:788
 msgid "Minor grid line color"
 msgstr ""
 
@@ -4534,7 +4534,7 @@ msgid "Ma_jor grid line color:"
 msgstr ""
 
 #: ../src/display/canvas-axonomgrid.cpp:379 ../src/display/canvas-grid.cpp:734
-#: ../src/ui/dialog/inkscape-preferences.cpp:772
+#: ../src/ui/dialog/inkscape-preferences.cpp:790
 msgid "Major grid line color"
 msgstr ""
 
@@ -4597,12 +4597,12 @@ msgid "Spacing _X:"
 msgstr ""
 
 #: ../src/display/canvas-grid.cpp:721
-#: ../src/ui/dialog/inkscape-preferences.cpp:792
+#: ../src/ui/dialog/inkscape-preferences.cpp:810
 msgid "Distance between vertical grid lines"
 msgstr ""
 
 #: ../src/display/canvas-grid.cpp:724
-#: ../src/ui/dialog/inkscape-preferences.cpp:793
+#: ../src/ui/dialog/inkscape-preferences.cpp:811
 msgid "Distance between horizontal grid lines"
 msgstr ""
 
@@ -4979,7 +4979,7 @@ msgid ""
 "this extension."
 msgstr ""
 
-#: ../src/extension/implementation/script.cpp:1111
+#: ../src/extension/implementation/script.cpp:1119
 msgid ""
 "Inkscape has received additional data from the script executed.  The script "
 "did not return an error, but this may indicate the results will not be as "
@@ -5843,42 +5843,42 @@ msgid "EMF Output"
 msgstr ""
 
 #: ../src/extension/internal/emf-inout.cpp:3633
-#: ../src/extension/internal/wmf-inout.cpp:3212
+#: ../src/extension/internal/wmf-inout.cpp:3222
 msgid "Convert texts to paths"
 msgstr ""
 
 #: ../src/extension/internal/emf-inout.cpp:3634
-#: ../src/extension/internal/wmf-inout.cpp:3213
+#: ../src/extension/internal/wmf-inout.cpp:3223
 msgid "Map Unicode to Symbol font"
 msgstr ""
 
 #: ../src/extension/internal/emf-inout.cpp:3635
-#: ../src/extension/internal/wmf-inout.cpp:3214
+#: ../src/extension/internal/wmf-inout.cpp:3224
 msgid "Map Unicode to Wingdings"
 msgstr ""
 
 #: ../src/extension/internal/emf-inout.cpp:3636
-#: ../src/extension/internal/wmf-inout.cpp:3215
+#: ../src/extension/internal/wmf-inout.cpp:3225
 msgid "Map Unicode to Zapf Dingbats"
 msgstr ""
 
 #: ../src/extension/internal/emf-inout.cpp:3637
-#: ../src/extension/internal/wmf-inout.cpp:3216
+#: ../src/extension/internal/wmf-inout.cpp:3226
 msgid "Use MS Unicode PUA (0xF020-0xF0FF) for converted characters"
 msgstr ""
 
 #: ../src/extension/internal/emf-inout.cpp:3638
-#: ../src/extension/internal/wmf-inout.cpp:3217
+#: ../src/extension/internal/wmf-inout.cpp:3227
 msgid "Compensate for PPT font bug"
 msgstr ""
 
 #: ../src/extension/internal/emf-inout.cpp:3639
-#: ../src/extension/internal/wmf-inout.cpp:3218
+#: ../src/extension/internal/wmf-inout.cpp:3228
 msgid "Convert dashed/dotted lines to single lines"
 msgstr ""
 
 #: ../src/extension/internal/emf-inout.cpp:3640
-#: ../src/extension/internal/wmf-inout.cpp:3219
+#: ../src/extension/internal/wmf-inout.cpp:3229
 msgid "Convert gradients to colored polygon series"
 msgstr ""
 
@@ -5984,7 +5984,7 @@ msgstr ""
 #: ../src/extension/internal/filter/transparency.h:214
 #: ../src/extension/internal/filter/transparency.h:287
 #: ../src/extension/internal/filter/transparency.h:349
-#: ../src/ui/dialog/inkscape-preferences.cpp:1801
+#: ../src/ui/dialog/inkscape-preferences.cpp:1823
 #, c-format
 msgid "Filters"
 msgstr ""
@@ -6195,7 +6195,7 @@ msgstr ""
 #: ../src/extension/internal/filter/paint.h:702
 #: ../src/extension/internal/filter/textures.h:77
 #: ../src/extension/internal/filter/transparency.h:61
-#: ../src/filter-enums.cpp:52 ../src/ui/dialog/inkscape-preferences.cpp:693
+#: ../src/filter-enums.cpp:52 ../src/ui/dialog/inkscape-preferences.cpp:711
 msgid "Normal"
 msgstr ""
 
@@ -6234,7 +6234,7 @@ msgstr ""
 #: ../src/extension/internal/filter/transparency.h:132
 #: ../src/filter-enums.cpp:128 ../src/ui/tools/flood-tool.cpp:92
 #: ../src/ui/widget/color-icc-selector.cpp:176
-#: ../src/ui/widget/color-scales.cpp:385 ../src/ui/widget/color-scales.cpp:386
+#: ../src/ui/widget/color-scales.cpp:386 ../src/ui/widget/color-scales.cpp:387
 msgid "Red"
 msgstr ""
 
@@ -6246,7 +6246,7 @@ msgstr ""
 #: ../src/extension/internal/filter/transparency.h:133
 #: ../src/filter-enums.cpp:129 ../src/ui/tools/flood-tool.cpp:93
 #: ../src/ui/widget/color-icc-selector.cpp:177
-#: ../src/ui/widget/color-scales.cpp:388 ../src/ui/widget/color-scales.cpp:389
+#: ../src/ui/widget/color-scales.cpp:389 ../src/ui/widget/color-scales.cpp:390
 msgid "Green"
 msgstr ""
 
@@ -6258,7 +6258,7 @@ msgstr ""
 #: ../src/extension/internal/filter/transparency.h:134
 #: ../src/filter-enums.cpp:130 ../src/ui/tools/flood-tool.cpp:94
 #: ../src/ui/widget/color-icc-selector.cpp:178
-#: ../src/ui/widget/color-scales.cpp:391 ../src/ui/widget/color-scales.cpp:392
+#: ../src/ui/widget/color-scales.cpp:392 ../src/ui/widget/color-scales.cpp:393
 #: ../share/extensions/nicechart.inx.h:34
 msgid "Blue"
 msgstr ""
@@ -6297,7 +6297,7 @@ msgstr ""
 #: ../src/extension/internal/filter/paint.h:707
 #: ../src/ui/tools/flood-tool.cpp:97
 #: ../src/ui/widget/color-icc-selector.cpp:187
-#: ../src/ui/widget/color-scales.cpp:417 ../src/ui/widget/color-scales.cpp:418
+#: ../src/ui/widget/color-scales.cpp:418 ../src/ui/widget/color-scales.cpp:419
 #: ../src/widgets/tweak-toolbar.cpp:318
 msgid "Lightness"
 msgstr ""
@@ -6321,7 +6321,7 @@ msgid "Distant"
 msgstr ""
 
 #: ../src/extension/internal/filter/bumps.h:106
-#: ../src/ui/dialog/inkscape-preferences.cpp:470
+#: ../src/ui/dialog/inkscape-preferences.cpp:488
 msgid "Point"
 msgstr ""
 
@@ -6492,11 +6492,11 @@ msgstr ""
 #: ../src/extension/internal/filter/color.h:157
 #: ../src/extension/internal/filter/color.h:332
 #: ../src/extension/internal/filter/paint.h:87 ../src/filter-enums.cpp:66
-#: ../src/ui/dialog/inkscape-preferences.cpp:992
+#: ../src/ui/dialog/inkscape-preferences.cpp:1010
 #: ../src/ui/tools/flood-tool.cpp:96
 #: ../src/ui/widget/color-icc-selector.cpp:183
 #: ../src/ui/widget/color-icc-selector.cpp:188
-#: ../src/ui/widget/color-scales.cpp:414 ../src/ui/widget/color-scales.cpp:415
+#: ../src/ui/widget/color-scales.cpp:415 ../src/ui/widget/color-scales.cpp:416
 #: ../src/widgets/tweak-toolbar.cpp:302
 msgid "Saturation"
 msgstr ""
@@ -6674,21 +6674,21 @@ msgstr ""
 #: ../src/extension/internal/filter/color.h:715
 #: ../src/ui/widget/color-icc-selector.cpp:190
 #: ../src/ui/widget/color-icc-selector.cpp:195
-#: ../src/ui/widget/color-scales.cpp:439 ../src/ui/widget/color-scales.cpp:440
+#: ../src/ui/widget/color-scales.cpp:440 ../src/ui/widget/color-scales.cpp:441
 msgid "Cyan"
 msgstr ""
 
 #: ../src/extension/internal/filter/color.h:716
 #: ../src/ui/widget/color-icc-selector.cpp:191
 #: ../src/ui/widget/color-icc-selector.cpp:196
-#: ../src/ui/widget/color-scales.cpp:442 ../src/ui/widget/color-scales.cpp:443
+#: ../src/ui/widget/color-scales.cpp:443 ../src/ui/widget/color-scales.cpp:444
 msgid "Magenta"
 msgstr ""
 
 #: ../src/extension/internal/filter/color.h:717
 #: ../src/ui/widget/color-icc-selector.cpp:192
 #: ../src/ui/widget/color-icc-selector.cpp:197
-#: ../src/ui/widget/color-scales.cpp:445 ../src/ui/widget/color-scales.cpp:446
+#: ../src/ui/widget/color-scales.cpp:446 ../src/ui/widget/color-scales.cpp:447
 msgid "Yellow"
 msgstr ""
 
@@ -6714,7 +6714,7 @@ msgstr ""
 
 #: ../src/extension/internal/filter/color.h:819
 #: ../src/ui/widget/color-icc-selector.cpp:193
-#: ../src/ui/widget/color-scales.cpp:448 ../src/ui/widget/color-scales.cpp:449
+#: ../src/ui/widget/color-scales.cpp:449 ../src/ui/widget/color-scales.cpp:450
 #: ../src/ui/widget/selected-style.cpp:275
 msgid "Black"
 msgstr ""
@@ -7718,13 +7718,13 @@ msgid ""
 msgstr ""
 
 #: ../src/extension/internal/gdkpixbuf-input.cpp:196
-#: ../src/ui/dialog/inkscape-preferences.cpp:1506
+#: ../src/ui/dialog/inkscape-preferences.cpp:1528
 #, c-format
 msgid "Embed"
 msgstr ""
 
 #: ../src/extension/internal/gdkpixbuf-input.cpp:197 ../src/sp-anchor.cpp:105
-#: ../src/ui/dialog/inkscape-preferences.cpp:1506
+#: ../src/ui/dialog/inkscape-preferences.cpp:1528
 #, c-format
 msgid "Link"
 msgstr ""
@@ -7764,19 +7764,19 @@ msgid ""
 msgstr ""
 
 #: ../src/extension/internal/gdkpixbuf-input.cpp:206
-#: ../src/ui/dialog/inkscape-preferences.cpp:1513
+#: ../src/ui/dialog/inkscape-preferences.cpp:1535
 #, c-format
 msgid "None (auto)"
 msgstr ""
 
 #: ../src/extension/internal/gdkpixbuf-input.cpp:207
-#: ../src/ui/dialog/inkscape-preferences.cpp:1513
+#: ../src/ui/dialog/inkscape-preferences.cpp:1535
 #, c-format
 msgid "Smooth (optimizeQuality)"
 msgstr ""
 
 #: ../src/extension/internal/gdkpixbuf-input.cpp:208
-#: ../src/ui/dialog/inkscape-preferences.cpp:1513
+#: ../src/ui/dialog/inkscape-preferences.cpp:1535
 #, c-format
 msgid "Blocky (optimizeSpeed)"
 msgstr ""
@@ -7828,7 +7828,7 @@ msgid "Vertical Offset:"
 msgstr ""
 
 #: ../src/extension/internal/grid.cpp:209
-#: ../src/ui/dialog/inkscape-preferences.cpp:1527
+#: ../src/ui/dialog/inkscape-preferences.cpp:1549
 #: ../share/extensions/draw_from_triangle.inx.h:58
 #: ../share/extensions/eqtexsvg.inx.h:4 ../share/extensions/foldablebox.inx.h:9
 #: ../share/extensions/funcplot.inx.h:38
@@ -7859,8 +7859,8 @@ msgstr ""
 
 #: ../src/extension/internal/grid.cpp:210
 #: ../src/ui/dialog/document-properties.cpp:163
-#: ../src/ui/dialog/inkscape-preferences.cpp:827
-#: ../src/widgets/toolbox.cpp:1902
+#: ../src/ui/dialog/inkscape-preferences.cpp:845
+#: ../src/widgets/toolbox.cpp:1901
 msgid "Grids"
 msgstr ""
 
@@ -7896,15 +7896,15 @@ msgstr ""
 msgid "LaTeX Print"
 msgstr ""
 
-#: ../src/extension/internal/odf.cpp:2138
+#: ../src/extension/internal/odf.cpp:2135
 msgid "OpenDocument Drawing Output"
 msgstr ""
 
-#: ../src/extension/internal/odf.cpp:2143
+#: ../src/extension/internal/odf.cpp:2140
 msgid "OpenDocument drawing (*.odg)"
 msgstr ""
 
-#: ../src/extension/internal/odf.cpp:2144
+#: ../src/extension/internal/odf.cpp:2141
 msgid "OpenDocument drawing file"
 msgstr ""
 
@@ -8018,27 +8018,27 @@ msgctxt "PDF input precision"
 msgid "very fine"
 msgstr ""
 
-#: ../src/extension/internal/pdfinput/pdf-input.cpp:937
+#: ../src/extension/internal/pdfinput/pdf-input.cpp:943
 msgid "PDF Input"
 msgstr ""
 
-#: ../src/extension/internal/pdfinput/pdf-input.cpp:942
+#: ../src/extension/internal/pdfinput/pdf-input.cpp:948
 msgid "Adobe PDF (*.pdf)"
 msgstr ""
 
-#: ../src/extension/internal/pdfinput/pdf-input.cpp:943
+#: ../src/extension/internal/pdfinput/pdf-input.cpp:949
 msgid "Adobe Portable Document Format"
 msgstr ""
 
-#: ../src/extension/internal/pdfinput/pdf-input.cpp:950
+#: ../src/extension/internal/pdfinput/pdf-input.cpp:956
 msgid "AI Input"
 msgstr ""
 
-#: ../src/extension/internal/pdfinput/pdf-input.cpp:955
+#: ../src/extension/internal/pdfinput/pdf-input.cpp:961
 msgid "Adobe Illustrator 9.0 and above (*.ai)"
 msgstr ""
 
-#: ../src/extension/internal/pdfinput/pdf-input.cpp:956
+#: ../src/extension/internal/pdfinput/pdf-input.cpp:962
 msgid "Open files saved in Adobe Illustrator 9.0 and newer versions"
 msgstr ""
 
@@ -8163,32 +8163,32 @@ msgstr ""
 msgid "Microsoft Visio 2013 drawing (*.vsdx)"
 msgstr ""
 
-#: ../src/extension/internal/wmf-inout.cpp:3196
+#: ../src/extension/internal/wmf-inout.cpp:3206
 msgid "WMF Input"
 msgstr ""
 
-#: ../src/extension/internal/wmf-inout.cpp:3201
+#: ../src/extension/internal/wmf-inout.cpp:3211
 msgid "Windows Metafiles (*.wmf)"
 msgstr ""
 
-#: ../src/extension/internal/wmf-inout.cpp:3202
+#: ../src/extension/internal/wmf-inout.cpp:3212
 msgid "Windows Metafiles"
 msgstr ""
 
-#: ../src/extension/internal/wmf-inout.cpp:3210
+#: ../src/extension/internal/wmf-inout.cpp:3220
 msgid "WMF Output"
 msgstr ""
 
-#: ../src/extension/internal/wmf-inout.cpp:3220
+#: ../src/extension/internal/wmf-inout.cpp:3230
 msgid "Map all fill patterns to standard WMF hatches"
 msgstr ""
 
-#: ../src/extension/internal/wmf-inout.cpp:3224
+#: ../src/extension/internal/wmf-inout.cpp:3234
 #: ../share/extensions/wmf_input.inx.h:2 ../share/extensions/wmf_output.inx.h:2
 msgid "Windows Metafile (*.wmf)"
 msgstr ""
 
-#: ../src/extension/internal/wmf-inout.cpp:3225
+#: ../src/extension/internal/wmf-inout.cpp:3235
 msgid "Windows Metafile"
 msgstr ""
 
@@ -8220,43 +8220,43 @@ msgstr ""
 msgid "Convert legacy Inkscape file"
 msgstr ""
 
-#: ../src/file-update.cpp:319
+#: ../src/file-update.cpp:320
 msgid ""
 "was created in an older version of Inkscape (90 DPI) and we need to make it "
 "compatible with newer versions (96 DPI). Tell us about this file:\n"
 msgstr ""
 
-#: ../src/file-update.cpp:327
+#: ../src/file-update.cpp:328
 msgid ""
 "This file contains digital artwork for screen display. <b>(Choose if "
 "unsure.)</b>"
 msgstr ""
 
-#: ../src/file-update.cpp:330
+#: ../src/file-update.cpp:331
 msgid "This file is intended for physical output, such as paper or 3D prints."
 msgstr ""
 
-#: ../src/file-update.cpp:332
+#: ../src/file-update.cpp:333
 msgid ""
 "The appearance of elements such as clips, masks, filters, and clones\n"
 "is most important. <b>(Choose if unsure.)</b>"
 msgstr ""
 
-#: ../src/file-update.cpp:336
+#: ../src/file-update.cpp:337
 msgid ""
 "The accuracy of the physical unit size and position values of objects\n"
 "in the file is most important. (Experimental.)"
 msgstr ""
 
-#: ../src/file-update.cpp:338
+#: ../src/file-update.cpp:339
 msgid "Create a backup file in same directory."
 msgstr ""
 
-#: ../src/file-update.cpp:339
+#: ../src/file-update.cpp:340
 msgid "More details..."
 msgstr ""
 
-#: ../src/file-update.cpp:342
+#: ../src/file-update.cpp:343
 msgid ""
 "<small>We've updated Inkscape to follow the CSS standard of 96 DPI for "
 "better browser compatibility; we used to use 90 DPI. Digital artwork for "
@@ -8276,16 +8276,16 @@ msgid ""
 "printing.)\n"
 "\n"
 "More information about this change are available in the <a href='https://"
-"inkscape.org/en/learn/faq#todo-todo-todo'>Inkscape FAQ</a></small>"
+"inkscape.org/en/learn/faq#dpi_change'>Inkscape FAQ</a></small>"
 msgstr ""
 
-#: ../src/file-update.cpp:386
+#: ../src/file-update.cpp:387
 msgid "OK"
 msgstr ""
 
 #. Look for SPNamedView and SPDefs loop
 #. desktop->getDocument()->ensureUpToDate();  // Does not update box3d!
-#: ../src/file-update.cpp:569
+#: ../src/file-update.cpp:570
 msgid "Update Document"
 msgstr ""
 
@@ -8389,8 +8389,8 @@ msgstr ""
 msgid "Saving document..."
 msgstr ""
 
-#: ../src/file.cpp:1280 ../src/ui/dialog/inkscape-preferences.cpp:1500
-#: ../src/ui/dialog/ocaldialogs.cpp:1244
+#: ../src/file.cpp:1280 ../src/ui/dialog/inkscape-preferences.cpp:1522
+#: ../src/ui/dialog/ocaldialogs.cpp:1245
 msgid "Import"
 msgstr ""
 
@@ -8498,7 +8498,7 @@ msgstr ""
 #: ../src/filter-enums.cpp:65 ../src/ui/tools/flood-tool.cpp:95
 #: ../src/ui/widget/color-icc-selector.cpp:182
 #: ../src/ui/widget/color-icc-selector.cpp:186
-#: ../src/ui/widget/color-scales.cpp:411 ../src/ui/widget/color-scales.cpp:412
+#: ../src/ui/widget/color-scales.cpp:412 ../src/ui/widget/color-scales.cpp:413
 #: ../src/widgets/tweak-toolbar.cpp:286
 msgid "Hue"
 msgstr ""
@@ -8566,7 +8566,7 @@ msgstr ""
 msgid "Arithmetic"
 msgstr ""
 
-#: ../src/filter-enums.cpp:120 ../src/selection-chemistry.cpp:545
+#: ../src/filter-enums.cpp:120 ../src/selection-chemistry.cpp:553
 #: ../src/ui/dialog/objects.cpp:1927
 msgid "Duplicate"
 msgstr ""
@@ -8765,22 +8765,22 @@ msgstr ""
 msgid "Autosave complete."
 msgstr ""
 
-#: ../src/inkscape.cpp:618
+#: ../src/inkscape.cpp:619
 msgid "Untitled document"
 msgstr ""
 
 #. Show nice dialog box
-#: ../src/inkscape.cpp:650
+#: ../src/inkscape.cpp:651
 msgid "Inkscape encountered an internal error and will close now.\n"
 msgstr ""
 
-#: ../src/inkscape.cpp:651
+#: ../src/inkscape.cpp:652
 msgid ""
 "Automatic backups of unsaved documents were done to the following "
 "locations:\n"
 msgstr ""
 
-#: ../src/inkscape.cpp:652
+#: ../src/inkscape.cpp:653
 msgid "Automatic backup of the following documents failed:\n"
 msgstr ""
 
@@ -8984,8 +8984,8 @@ msgid "The index of the current page"
 msgstr ""
 
 #: ../src/libgdl/gdl-dock-object.c:125
-#: ../src/live_effects/parameter/originalpatharray.cpp:82
-#: ../src/ui/dialog/inkscape-preferences.cpp:1561
+#: ../src/live_effects/parameter/originalpatharray.cpp:87
+#: ../src/ui/dialog/inkscape-preferences.cpp:1583
 #: ../src/ui/widget/page-sizer.cpp:285 ../src/widgets/gradient-selector.cpp:150
 #: ../src/widgets/sp-xmlview-attr-list.cpp:49
 msgid "Name"
@@ -9140,8 +9140,8 @@ msgstr ""
 msgid "Dockitem which 'owns' this tablabel"
 msgstr ""
 
-#: ../src/libgdl/gdl-dock.c:176 ../src/ui/dialog/inkscape-preferences.cpp:682
-#: ../src/ui/dialog/inkscape-preferences.cpp:725
+#: ../src/libgdl/gdl-dock.c:176 ../src/ui/dialog/inkscape-preferences.cpp:700
+#: ../src/ui/dialog/inkscape-preferences.cpp:743
 msgid "Floating"
 msgstr ""
 
@@ -9365,7 +9365,7 @@ msgstr ""
 msgid "Fill between strokes"
 msgstr ""
 
-#: ../src/live_effects/effect.cpp:152 ../src/selection-chemistry.cpp:2963
+#: ../src/live_effects/effect.cpp:152 ../src/selection-chemistry.cpp:2973
 msgid "Fill between many"
 msgstr ""
 
@@ -9501,20 +9501,20 @@ msgstr ""
 msgid "Rotates the original 90 degrees, before bending it along the bend path"
 msgstr ""
 
-#: ../src/live_effects/lpe-bendpath.cpp:178
+#: ../src/live_effects/lpe-bendpath.cpp:179
 #: ../src/live_effects/lpe-patternalongpath.cpp:281
 msgid "Change the width"
 msgstr ""
 
 #: ../src/live_effects/lpe-bounding-box.cpp:24
-#: ../src/live_effects/lpe-clone-original.cpp:18
+#: ../src/live_effects/lpe-clone-original.cpp:24
 #: ../src/live_effects/lpe-fill-between-many.cpp:25
 #: ../src/live_effects/lpe-fill-between-strokes.cpp:23
 msgid "Linked path:"
 msgstr ""
 
 #: ../src/live_effects/lpe-bounding-box.cpp:24
-#: ../src/live_effects/lpe-clone-original.cpp:18
+#: ../src/live_effects/lpe-clone-original.cpp:24
 #: ../src/live_effects/lpe-fill-between-strokes.cpp:23
 msgid "Path from which to take the original path data"
 msgstr ""
@@ -9812,6 +9812,10 @@ msgstr ""
 msgid "Paths from which to take the original path data"
 msgstr ""
 
+#: ../src/live_effects/lpe-fill-between-many.cpp:26
+msgid "Allow transforms"
+msgstr ""
+
 #: ../src/live_effects/lpe-fill-between-strokes.cpp:24
 msgid "Second path:"
 msgstr ""
@@ -9829,7 +9833,7 @@ msgid "Reverses the second path order"
 msgstr ""
 
 #: ../src/live_effects/lpe-fillet-chamfer.cpp:41
-#: ../src/widgets/text-toolbar.cpp:1905
+#: ../src/widgets/text-toolbar.cpp:1974
 #: ../share/extensions/render_barcode_qrcode.inx.h:5
 msgid "Auto"
 msgstr ""
@@ -10998,13 +11002,13 @@ msgstr ""
 
 #: ../src/live_effects/lpe-ruler.cpp:33
 #: ../src/live_effects/lpe-transform_2pts.cpp:37
-#: ../src/ui/tools/measure-tool.cpp:755 ../src/widgets/arc-toolbar.cpp:319
+#: ../src/ui/tools/measure-tool.cpp:755 ../src/widgets/arc-toolbar.cpp:473
 msgid "Start"
 msgstr ""
 
 #: ../src/live_effects/lpe-ruler.cpp:34
 #: ../src/live_effects/lpe-transform_2pts.cpp:38
-#: ../src/ui/tools/measure-tool.cpp:756 ../src/widgets/arc-toolbar.cpp:332
+#: ../src/ui/tools/measure-tool.cpp:756 ../src/widgets/arc-toolbar.cpp:486
 msgid "End"
 msgstr ""
 
@@ -11395,7 +11399,7 @@ msgid "Change index of knot"
 msgstr ""
 
 #: ../src/live_effects/lpe-transform_2pts.cpp:349
-#: ../src/ui/dialog/inkscape-preferences.cpp:1618
+#: ../src/ui/dialog/inkscape-preferences.cpp:1640
 #: ../src/ui/dialog/pixelartdialog.cpp:296
 #: ../src/ui/dialog/svg-fonts-dialog.cpp:697
 #: ../src/ui/dialog/tracedialog.cpp:813
@@ -11493,69 +11497,69 @@ msgid ""
 "dialog, <b>Ctrl+Alt+Click</b> reset"
 msgstr ""
 
-#: ../src/live_effects/parameter/originalpath.cpp:67
-#: ../src/live_effects/parameter/originalpatharray.cpp:155
+#: ../src/live_effects/parameter/originalpath.cpp:68
+#: ../src/live_effects/parameter/originalpatharray.cpp:162
 msgid "Link to path"
 msgstr ""
 
-#: ../src/live_effects/parameter/originalpath.cpp:79
+#: ../src/live_effects/parameter/originalpath.cpp:80
 msgid "Select original"
 msgstr ""
 
-#: ../src/live_effects/parameter/originalpatharray.cpp:90
+#: ../src/live_effects/parameter/originalpatharray.cpp:95
 #: ../src/widgets/gradient-toolbar.cpp:1205
 msgid "Reverse"
 msgstr ""
 
-#: ../src/live_effects/parameter/originalpatharray.cpp:130
-#: ../src/live_effects/parameter/originalpatharray.cpp:315
-#: ../src/live_effects/parameter/path.cpp:509
+#: ../src/live_effects/parameter/originalpatharray.cpp:137
+#: ../src/live_effects/parameter/originalpatharray.cpp:322
+#: ../src/live_effects/parameter/path.cpp:516
 msgid "Link path parameter to path"
 msgstr ""
 
-#: ../src/live_effects/parameter/originalpatharray.cpp:167
+#: ../src/live_effects/parameter/originalpatharray.cpp:174
 msgid "Remove Path"
 msgstr ""
 
-#: ../src/live_effects/parameter/originalpatharray.cpp:179
+#: ../src/live_effects/parameter/originalpatharray.cpp:186
 #: ../src/ui/dialog/objects.cpp:1888
 msgid "Move Down"
 msgstr ""
 
-#: ../src/live_effects/parameter/originalpatharray.cpp:191
+#: ../src/live_effects/parameter/originalpatharray.cpp:198
 #: ../src/ui/dialog/objects.cpp:1896
 msgid "Move Up"
 msgstr ""
 
-#: ../src/live_effects/parameter/originalpatharray.cpp:231
+#: ../src/live_effects/parameter/originalpatharray.cpp:238
 msgid "Move path up"
 msgstr ""
 
-#: ../src/live_effects/parameter/originalpatharray.cpp:261
+#: ../src/live_effects/parameter/originalpatharray.cpp:268
 msgid "Move path down"
 msgstr ""
 
-#: ../src/live_effects/parameter/originalpatharray.cpp:279
+#: ../src/live_effects/parameter/originalpatharray.cpp:286
 msgid "Remove path"
 msgstr ""
 
-#: ../src/live_effects/parameter/path.cpp:184
+#: ../src/live_effects/parameter/path.cpp:187
 msgid "Edit on-canvas"
 msgstr ""
 
-#: ../src/live_effects/parameter/path.cpp:194
+#: ../src/live_effects/parameter/path.cpp:197
 msgid "Copy path"
 msgstr ""
 
-#: ../src/live_effects/parameter/path.cpp:204
+#: ../src/live_effects/parameter/path.cpp:207
 msgid "Paste path"
 msgstr ""
 
-#: ../src/live_effects/parameter/path.cpp:214
+#: ../src/live_effects/parameter/path.cpp:217
 msgid "Link to path on clipboard"
 msgstr ""
 
-#: ../src/live_effects/parameter/path.cpp:477
+#: ../src/live_effects/parameter/path.cpp:484
 msgid "Paste path parameter"
 msgstr ""
 
@@ -11602,280 +11606,284 @@ msgstr ""
 msgid "Unable to find node ID: '%s'\n"
 msgstr ""
 
-#: ../src/main.cpp:304
+#: ../src/main.cpp:305
 msgid "Print the Inkscape version number"
 msgstr ""
 
-#: ../src/main.cpp:309
+#: ../src/main.cpp:310
 msgid "Do not use X server (only process files from console)"
 msgstr ""
 
-#: ../src/main.cpp:314
+#: ../src/main.cpp:315
 msgid "Try to use X server (even if $DISPLAY is not set)"
 msgstr ""
 
-#: ../src/main.cpp:319
+#: ../src/main.cpp:320
 msgid "Open specified document(s) (option string may be excluded)"
 msgstr ""
 
-#: ../src/main.cpp:320 ../src/main.cpp:325 ../src/main.cpp:330
-#: ../src/main.cpp:402 ../src/main.cpp:407 ../src/main.cpp:412
-#: ../src/main.cpp:423 ../src/main.cpp:439 ../src/main.cpp:444
+#: ../src/main.cpp:321 ../src/main.cpp:326 ../src/main.cpp:331
+#: ../src/main.cpp:403 ../src/main.cpp:408 ../src/main.cpp:413
+#: ../src/main.cpp:424 ../src/main.cpp:440 ../src/main.cpp:445
 msgid "FILENAME"
 msgstr ""
 
-#: ../src/main.cpp:324
+#: ../src/main.cpp:325
 msgid "Print document(s) to specified output file (use '| program' for pipe)"
 msgstr ""
 
-#: ../src/main.cpp:329
+#: ../src/main.cpp:330
 msgid "Export document to a PNG file"
 msgstr ""
 
-#: ../src/main.cpp:334
+#: ../src/main.cpp:335
 msgid ""
 "Resolution for exporting to bitmap and for rasterization of filters in PS/"
 "EPS/PDF (default 96)"
 msgstr ""
 
-#: ../src/main.cpp:335 ../src/ui/widget/rendering-options.cpp:37
+#: ../src/main.cpp:336 ../src/ui/widget/rendering-options.cpp:37
 msgid "DPI"
 msgstr ""
 
-#: ../src/main.cpp:339
+#: ../src/main.cpp:340
 msgid ""
 "Exported area in SVG user units (default is the page; 0,0 is lower-left "
 "corner)"
 msgstr ""
 
-#: ../src/main.cpp:340
+#: ../src/main.cpp:341
 msgid "x0:y0:x1:y1"
 msgstr ""
 
-#: ../src/main.cpp:344
+#: ../src/main.cpp:345
 msgid "Exported area is the entire drawing (not page)"
 msgstr ""
 
-#: ../src/main.cpp:349
+#: ../src/main.cpp:350
 msgid "Exported area is the entire page"
 msgstr ""
 
-#: ../src/main.cpp:354
-msgid "Only for PS/EPS/PDF, sets margin in mm around exported area (default 0)"
+#: ../src/main.cpp:355
+msgid ""
+"Sets margin around exported area (default 0) in units of page size for SVG "
+"and mm for PS/EPS/PDF"
 msgstr ""
 
-#: ../src/main.cpp:355 ../src/main.cpp:397
+#: ../src/main.cpp:356 ../src/main.cpp:398
 msgid "VALUE"
 msgstr ""
 
-#: ../src/main.cpp:359
+#: ../src/main.cpp:360
 msgid ""
 "Snap the bitmap export area outwards to the nearest integer values (in SVG "
 "user units)"
 msgstr ""
 
-#: ../src/main.cpp:364
+#: ../src/main.cpp:365
 msgid "The width of exported bitmap in pixels (overrides export-dpi)"
 msgstr ""
 
-#: ../src/main.cpp:365
+#: ../src/main.cpp:366
 msgid "WIDTH"
 msgstr ""
 
-#: ../src/main.cpp:369
+#: ../src/main.cpp:370
 msgid "The height of exported bitmap in pixels (overrides export-dpi)"
 msgstr ""
 
-#: ../src/main.cpp:370
+#: ../src/main.cpp:371
 msgid "HEIGHT"
 msgstr ""
 
-#: ../src/main.cpp:374
+#: ../src/main.cpp:375
 msgid "The ID of the object to export"
 msgstr ""
 
-#: ../src/main.cpp:375 ../src/main.cpp:488
-#: ../src/ui/dialog/inkscape-preferences.cpp:1564
+#: ../src/main.cpp:376 ../src/main.cpp:489
+#: ../src/ui/dialog/inkscape-preferences.cpp:1586
 msgid "ID"
 msgstr ""
 
 #. TRANSLATORS: this means: "Only export the object whose id is given in --export-id".
 #. See "man inkscape" for details.
-#: ../src/main.cpp:381
+#: ../src/main.cpp:382
 msgid ""
 "Export just the object with export-id, hide all others (only with export-id)"
 msgstr ""
 
-#: ../src/main.cpp:386
+#: ../src/main.cpp:387
 msgid "Use stored filename and DPI hints when exporting (only with export-id)"
 msgstr ""
 
-#: ../src/main.cpp:391
+#: ../src/main.cpp:392
 msgid "Background color of exported bitmap (any SVG-supported color string)"
 msgstr ""
 
-#: ../src/main.cpp:392
+#: ../src/main.cpp:393
 msgid "COLOR"
 msgstr ""
 
-#: ../src/main.cpp:396
+#: ../src/main.cpp:397
 msgid "Background opacity of exported bitmap (either 0.0 to 1.0, or 1 to 255)"
 msgstr ""
 
-#: ../src/main.cpp:401
+#: ../src/main.cpp:402
 msgid "Export document to plain SVG file (no sodipodi or inkscape namespaces)"
 msgstr ""
 
-#: ../src/main.cpp:406
+#: ../src/main.cpp:407
 msgid "Export document to a PS file"
 msgstr ""
 
-#: ../src/main.cpp:411
+#: ../src/main.cpp:412
 msgid "Export document to an EPS file"
 msgstr ""
 
-#: ../src/main.cpp:416
+#: ../src/main.cpp:417
 msgid ""
 "Choose the PostScript Level used to export. Possible choices are 2 and 3 "
 "(the default)"
 msgstr ""
 
-#: ../src/main.cpp:418
+#: ../src/main.cpp:419
 msgid "PS Level"
 msgstr ""
 
-#: ../src/main.cpp:422
+#: ../src/main.cpp:423
 msgid "Export document to a PDF file"
 msgstr ""
 
 #. TRANSLATORS: "--export-pdf-version" is an Inkscape command line option; see "inkscape --help"
-#: ../src/main.cpp:428
+#: ../src/main.cpp:429
 msgid ""
 "Export PDF to given version. (hint: make sure to input the exact string "
 "found in the PDF export dialog, e.g. \"1.4\" which is PDF-a conformant)"
 msgstr ""
 
-#: ../src/main.cpp:429
+#: ../src/main.cpp:430
 msgid "PDF_VERSION"
 msgstr ""
 
-#: ../src/main.cpp:433
+#: ../src/main.cpp:434
 msgid ""
 "Export PDF/PS/EPS without text. Besides the PDF/PS/EPS, a LaTeX file is "
 "exported, putting the text on top of the PDF/PS/EPS file. Include the result "
 "in LaTeX like: \\input{latexfile.tex}"
 msgstr ""
 
-#: ../src/main.cpp:438
+#: ../src/main.cpp:439
 msgid "Export document to an Enhanced Metafile (EMF) File"
 msgstr ""
 
-#: ../src/main.cpp:443
+#: ../src/main.cpp:444
 msgid "Export document to a Windows Metafile (WMF) File"
 msgstr ""
 
-#: ../src/main.cpp:448
+#: ../src/main.cpp:449
 msgid "Convert text object to paths on export (PS, EPS, PDF, SVG)"
 msgstr ""
 
-#: ../src/main.cpp:453
+#: ../src/main.cpp:454
 msgid ""
 "Render filtered objects without filters, instead of rasterizing (PS, EPS, "
 "PDF)"
 msgstr ""
 
 #. TRANSLATORS: "--query-id" is an Inkscape command line option; see "inkscape --help"
-#: ../src/main.cpp:459
+#: ../src/main.cpp:460
 msgid ""
 "Query the X coordinate of the drawing or, if specified, of the object with --"
 "query-id"
 msgstr ""
 
 #. TRANSLATORS: "--query-id" is an Inkscape command line option; see "inkscape --help"
-#: ../src/main.cpp:465
+#: ../src/main.cpp:466
 msgid ""
 "Query the Y coordinate of the drawing or, if specified, of the object with --"
 "query-id"
 msgstr ""
 
 #. TRANSLATORS: "--query-id" is an Inkscape command line option; see "inkscape --help"
-#: ../src/main.cpp:471
+#: ../src/main.cpp:472
 msgid ""
 "Query the width of the drawing or, if specified, of the object with --query-"
 "id"
 msgstr ""
 
 #. TRANSLATORS: "--query-id" is an Inkscape command line option; see "inkscape --help"
-#: ../src/main.cpp:477
+#: ../src/main.cpp:478
 msgid ""
 "Query the height of the drawing or, if specified, of the object with --query-"
 "id"
 msgstr ""
 
-#: ../src/main.cpp:482
+#: ../src/main.cpp:483
 msgid "List id,x,y,w,h for all objects"
 msgstr ""
 
-#: ../src/main.cpp:487
+#: ../src/main.cpp:488
 msgid "The ID of the object whose dimensions are queried"
 msgstr ""
 
 #. TRANSLATORS: this option makes Inkscape print the name (path) of the extension directory
-#: ../src/main.cpp:493
+#: ../src/main.cpp:494
 msgid "Print out the extension directory and exit"
 msgstr ""
 
-#: ../src/main.cpp:498
+#: ../src/main.cpp:499
 msgid "Remove unused definitions from the defs section(s) of the document"
 msgstr ""
 
-#: ../src/main.cpp:504
+#: ../src/main.cpp:505
 msgid "Enter a listening loop for D-Bus messages in console mode"
 msgstr ""
 
-#: ../src/main.cpp:509
+#: ../src/main.cpp:510
 msgid ""
 "Specify the D-Bus bus name to listen for messages on (default is org."
 "inkscape)"
 msgstr ""
 
-#: ../src/main.cpp:510
+#: ../src/main.cpp:511
 msgid "BUS-NAME"
 msgstr ""
 
-#: ../src/main.cpp:515
+#: ../src/main.cpp:516
 msgid "List the IDs of all the verbs in Inkscape"
 msgstr ""
 
-#: ../src/main.cpp:520
+#: ../src/main.cpp:521
 msgid "Verb to call when Inkscape opens."
 msgstr ""
 
-#: ../src/main.cpp:521
+#: ../src/main.cpp:522
 msgid "VERB-ID"
 msgstr ""
 
-#: ../src/main.cpp:525
+#: ../src/main.cpp:526
 msgid "Object ID to select when Inkscape opens."
 msgstr ""
 
-#: ../src/main.cpp:526
+#: ../src/main.cpp:527
 msgid "OBJECT-ID"
 msgstr ""
 
-#: ../src/main.cpp:530
+#: ../src/main.cpp:531
 msgid "Start Inkscape in interactive shell mode."
 msgstr ""
 
-#: ../src/main.cpp:535
+#: ../src/main.cpp:536
 msgid "Do not fix legacy (pre-0.92) files' text baseline spacing on opening."
 msgstr ""
 
-#: ../src/main.cpp:540
-msgid "Method used to convert pre-.92 document dpi, if needed."
+#: ../src/main.cpp:541
+msgid ""
+"Method used to convert pre-.92 document dpi, if needed. ([none|scale-viewbox|"
+"scale-document])"
 msgstr ""
 
-#: ../src/main.cpp:890 ../src/main.cpp:1363
+#: ../src/main.cpp:891 ../src/main.cpp:1379
 msgid ""
 "[OPTIONS...] [FILE...]\n"
 "\n"
@@ -12160,7 +12168,7 @@ msgstr ""
 
 #. Create the Title label and edit control
 #. TRANSLATORS: for info, see http://www.w3.org/TR/2000/CR-SVG-20000802/linking.html#AElementXLinkTitleAttribute
-#: ../src/rdf.cpp:235 ../src/ui/dialog/filedialogimpl-win32.cpp:1885
+#: ../src/rdf.cpp:235 ../src/ui/dialog/filedialogimpl-win32.cpp:1886
 #: ../src/ui/dialog/object-attributes.cpp:57
 msgid "Title:"
 msgstr ""
@@ -12235,7 +12243,7 @@ msgstr ""
 msgid "A related resource"
 msgstr ""
 
-#: ../src/rdf.cpp:267 ../src/ui/dialog/inkscape-preferences.cpp:1924
+#: ../src/rdf.cpp:267 ../src/ui/dialog/inkscape-preferences.cpp:1946
 msgid "Language:"
 msgstr ""
 
@@ -12313,7 +12321,7 @@ msgstr ""
 
 #: ../src/selection-chemistry.cpp:426
 #: ../src/ui/dialog/calligraphic-profile-rename.cpp:75
-#: ../src/ui/dialog/swatches.cpp:277 ../src/ui/tools/text-tool.cpp:965
+#: ../src/ui/dialog/swatches.cpp:278 ../src/ui/tools/text-tool.cpp:965
 #: ../src/widgets/eraser-toolbar.cpp:120
 #: ../src/widgets/gradient-toolbar.cpp:1181
 #: ../src/widgets/gradient-toolbar.cpp:1195
@@ -12325,432 +12333,432 @@ msgstr ""
 msgid "Select <b>object(s)</b> to duplicate."
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:551
+#: ../src/selection-chemistry.cpp:559
 #, c-format
 msgid "%s copy"
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:574
+#: ../src/selection-chemistry.cpp:582
 msgid "Delete all"
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:762
+#: ../src/selection-chemistry.cpp:770
 msgid "Select <b>some objects</b> to group."
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:775
+#: ../src/selection-chemistry.cpp:783
 msgctxt "Verb"
 msgid "Group"
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:798
+#: ../src/selection-chemistry.cpp:806
 msgid "<b>No objects selected</b> to pop out of group."
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:808
+#: ../src/selection-chemistry.cpp:816
 msgid "Selection <b>not in a group</b>."
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:822
+#: ../src/selection-chemistry.cpp:830
 msgid "Pop selection from group"
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:830
+#: ../src/selection-chemistry.cpp:838
 msgid "Select a <b>group</b> to ungroup."
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:845
+#: ../src/selection-chemistry.cpp:853
 msgid "<b>No groups</b> to ungroup in the selection."
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:901 ../src/sp-item-group.cpp:660
+#: ../src/selection-chemistry.cpp:909 ../src/sp-item-group.cpp:660
 #: ../src/ui/dialog/objects.cpp:1950
 msgid "Ungroup"
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:988
+#: ../src/selection-chemistry.cpp:996
 msgid "Select <b>object(s)</b> to raise."
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:994 ../src/selection-chemistry.cpp:1047
-#: ../src/selection-chemistry.cpp:1073 ../src/selection-chemistry.cpp:1188
+#: ../src/selection-chemistry.cpp:1002 ../src/selection-chemistry.cpp:1055
+#: ../src/selection-chemistry.cpp:1081 ../src/selection-chemistry.cpp:1196
 msgid ""
 "You cannot raise/lower objects from <b>different groups</b> or <b>layers</b>."
 msgstr ""
 
 #. TRANSLATORS: "Raise" means "to raise an object" in the undo history
-#: ../src/selection-chemistry.cpp:1031
+#: ../src/selection-chemistry.cpp:1039
 msgctxt "Undo action"
 msgid "Raise"
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:1039
+#: ../src/selection-chemistry.cpp:1047
 msgid "Select <b>object(s)</b> to raise to top."
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:1060
+#: ../src/selection-chemistry.cpp:1068
 msgid "Raise to top"
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:1067
+#: ../src/selection-chemistry.cpp:1075
 msgid "Select <b>object(s)</b> to lower."
 msgstr ""
 
 #. TRANSLATORS: "Lower" means "to lower an object" in the undo history
-#: ../src/selection-chemistry.cpp:1115
+#: ../src/selection-chemistry.cpp:1123
 msgctxt "Undo action"
 msgid "Lower"
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:1124
+#: ../src/selection-chemistry.cpp:1132
 msgid "Select <b>object(s)</b> to stack down."
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:1136
+#: ../src/selection-chemistry.cpp:1144
 msgid "We hit bottom."
 msgstr ""
 
 #. TRANSLATORS: "Lower" means "to lower an object" in the undo history
-#: ../src/selection-chemistry.cpp:1143
+#: ../src/selection-chemistry.cpp:1151
 msgctxt "Undo action"
 msgid "stack down"
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:1152
+#: ../src/selection-chemistry.cpp:1160
 msgid "Select <b>object(s)</b> to stack up."
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:1165
+#: ../src/selection-chemistry.cpp:1173
 msgid "We hit top."
 msgstr ""
 
 #. TRANSLATORS: "Lower" means "to lower an object" in the undo history
-#: ../src/selection-chemistry.cpp:1172
+#: ../src/selection-chemistry.cpp:1180
 msgctxt "Undo action"
 msgid "stack up"
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:1180
+#: ../src/selection-chemistry.cpp:1188
 msgid "Select <b>object(s)</b> to lower to bottom."
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:1211
+#: ../src/selection-chemistry.cpp:1219
 msgid "Lower to bottom"
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:1221
+#: ../src/selection-chemistry.cpp:1229
 msgid "Nothing to undo."
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:1232
+#: ../src/selection-chemistry.cpp:1240
 msgid "Nothing to redo."
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:1304
+#: ../src/selection-chemistry.cpp:1312
 msgid "Paste"
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:1312
+#: ../src/selection-chemistry.cpp:1320
 msgid "Paste style"
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:1322
+#: ../src/selection-chemistry.cpp:1330
 msgid "Paste live path effect"
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:1344
+#: ../src/selection-chemistry.cpp:1352
 msgid "Select <b>object(s)</b> to remove live path effects from."
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:1356
+#: ../src/selection-chemistry.cpp:1364
 msgid "Remove live path effect"
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:1367
+#: ../src/selection-chemistry.cpp:1375
 msgid "Select <b>object(s)</b> to remove filters from."
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:1377
+#: ../src/selection-chemistry.cpp:1385
 #: ../src/ui/dialog/filter-effects-dialog.cpp:1695
 msgid "Remove filter"
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:1386
+#: ../src/selection-chemistry.cpp:1394
 msgid "Paste size"
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:1395
+#: ../src/selection-chemistry.cpp:1403
 msgid "Paste size separately"
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:1424
+#: ../src/selection-chemistry.cpp:1432
 msgid "Select <b>object(s)</b> to move to the layer above."
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:1450
+#: ../src/selection-chemistry.cpp:1458
 msgid "Raise to next layer"
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:1457
+#: ../src/selection-chemistry.cpp:1465
 msgid "No more layers above."
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:1468
+#: ../src/selection-chemistry.cpp:1476
 msgid "Select <b>object(s)</b> to move to the layer below."
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:1494
+#: ../src/selection-chemistry.cpp:1502
 msgid "Lower to previous layer"
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:1501
+#: ../src/selection-chemistry.cpp:1509
 msgid "No more layers below."
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:1511
+#: ../src/selection-chemistry.cpp:1519
 msgid "Select <b>object(s)</b> to move."
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:1529 ../src/verbs.cpp:2672
+#: ../src/selection-chemistry.cpp:1537 ../src/verbs.cpp:2672
 msgid "Move selection to layer"
 msgstr ""
 
 #. An SVG element cannot have a transform. We could change 'x' and 'y' in response
 #. to a translation... but leave that for another day.
-#: ../src/selection-chemistry.cpp:1618 ../src/seltrans.cpp:391
+#: ../src/selection-chemistry.cpp:1626 ../src/seltrans.cpp:391
 msgid "Cannot transform an embedded SVG."
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:1788
+#: ../src/selection-chemistry.cpp:1796
 msgid "Remove transform"
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:1895
+#: ../src/selection-chemistry.cpp:1903
 msgid "Rotate 90° CCW"
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:1895
+#: ../src/selection-chemistry.cpp:1903
 msgid "Rotate 90° CW"
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:1916 ../src/seltrans.cpp:484
+#: ../src/selection-chemistry.cpp:1924 ../src/seltrans.cpp:484
 #: ../src/ui/dialog/transformation.cpp:890
 msgid "Rotate"
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:2265
+#: ../src/selection-chemistry.cpp:2273
 msgid "Rotate by pixels"
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:2295 ../src/seltrans.cpp:481
+#: ../src/selection-chemistry.cpp:2303 ../src/seltrans.cpp:481
 #: ../src/ui/dialog/transformation.cpp:864 ../src/ui/widget/page-sizer.cpp:450
 #: ../share/extensions/interp_att_g.inx.h:14
 msgid "Scale"
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:2320
+#: ../src/selection-chemistry.cpp:2328
 msgid "Scale by whole factor"
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:2335
+#: ../src/selection-chemistry.cpp:2343
 msgid "Move vertically"
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:2338
+#: ../src/selection-chemistry.cpp:2346
 msgid "Move horizontally"
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:2341 ../src/selection-chemistry.cpp:2367
+#: ../src/selection-chemistry.cpp:2349 ../src/selection-chemistry.cpp:2375
 #: ../src/seltrans.cpp:478 ../src/ui/dialog/transformation.cpp:801
 msgid "Move"
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:2361
+#: ../src/selection-chemistry.cpp:2369
 msgid "Move vertically by pixels"
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:2364
+#: ../src/selection-chemistry.cpp:2372
 msgid "Move horizontally by pixels"
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:2567
+#: ../src/selection-chemistry.cpp:2575
 msgid "The selection has no applied path effect."
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:2659 ../src/ui/dialog/clonetiler.cpp:2238
+#: ../src/selection-chemistry.cpp:2667 ../src/ui/dialog/clonetiler.cpp:2238
 msgid "Select an <b>object</b> to clone."
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:2694
+#: ../src/selection-chemistry.cpp:2702
 msgctxt "Action"
 msgid "Clone"
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:2708
+#: ../src/selection-chemistry.cpp:2716
 msgid "Select <b>clones</b> to relink."
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:2715
+#: ../src/selection-chemistry.cpp:2723
 msgid "Copy an <b>object</b> to clipboard to relink clones to."
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:2736
+#: ../src/selection-chemistry.cpp:2744
 msgid "<b>No clones to relink</b> in the selection."
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:2739
+#: ../src/selection-chemistry.cpp:2747
 msgid "Relink clone"
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:2753
+#: ../src/selection-chemistry.cpp:2761
 msgid "Select <b>clones</b> to unlink."
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:2806
+#: ../src/selection-chemistry.cpp:2814
 msgid "<b>No clones to unlink</b> in the selection."
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:2810
+#: ../src/selection-chemistry.cpp:2818
 msgid "Unlink clone"
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:2823
+#: ../src/selection-chemistry.cpp:2831
 msgid ""
 "Select a <b>clone</b> to go to its original. Select a <b>linked offset</b> "
 "to go to its source. Select a <b>text on path</b> to go to the path. Select "
 "a <b>flowed text</b> to go to its frame."
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:2873
+#: ../src/selection-chemistry.cpp:2881
 msgid ""
 "<b>Cannot find</b> the object to select (orphaned clone, offset, textpath, "
 "flowed text?)"
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:2879
+#: ../src/selection-chemistry.cpp:2887
 msgid ""
 "The object you're trying to select is <b>not visible</b> (it is in &lt;"
 "defs&gt;)"
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:2969
+#: ../src/selection-chemistry.cpp:2979
 msgid "Select path(s) to fill."
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:2987
+#: ../src/selection-chemistry.cpp:2997
 msgid "Select <b>object(s)</b> to convert to marker."
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:3061
+#: ../src/selection-chemistry.cpp:3071
 msgid "Objects to marker"
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:3087
+#: ../src/selection-chemistry.cpp:3097
 msgid "Select <b>object(s)</b> to convert to guides."
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:3108
+#: ../src/selection-chemistry.cpp:3118
 msgid "Objects to guides"
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:3144
+#: ../src/selection-chemistry.cpp:3154
 msgid "Select <b>objects</b> to convert to symbol."
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:3248
+#: ../src/selection-chemistry.cpp:3258
 msgid "Group to symbol"
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:3267
+#: ../src/selection-chemistry.cpp:3277
 msgid "Select a <b>symbol</b> to extract objects from."
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:3276
+#: ../src/selection-chemistry.cpp:3286
 msgid "Select only one <b>symbol</b> in Symbol dialog to convert to group."
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:3332
+#: ../src/selection-chemistry.cpp:3342
 msgid "Group from symbol"
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:3350
+#: ../src/selection-chemistry.cpp:3360
 msgid "Select <b>object(s)</b> to convert to pattern."
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:3446
+#: ../src/selection-chemistry.cpp:3456
 msgid "Objects to pattern"
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:3462
+#: ../src/selection-chemistry.cpp:3472
 msgid "Select an <b>object with pattern fill</b> to extract objects from."
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:3521
+#: ../src/selection-chemistry.cpp:3531
 msgid "<b>No pattern fills</b> in the selection."
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:3524
+#: ../src/selection-chemistry.cpp:3534
 msgid "Pattern to objects"
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:3610
+#: ../src/selection-chemistry.cpp:3620
 msgid "Select <b>object(s)</b> to make a bitmap copy."
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:3614
+#: ../src/selection-chemistry.cpp:3624
 msgid "Rendering bitmap..."
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:3799
+#: ../src/selection-chemistry.cpp:3809
 msgid "Create bitmap"
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:3824 ../src/selection-chemistry.cpp:3936
+#: ../src/selection-chemistry.cpp:3834 ../src/selection-chemistry.cpp:3946
 msgid "Select <b>object(s)</b> to create clippath or mask from."
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:3910 ../src/ui/dialog/objects.cpp:1956
+#: ../src/selection-chemistry.cpp:3920 ../src/ui/dialog/objects.cpp:1956
 msgid "Create Clip Group"
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:3939
+#: ../src/selection-chemistry.cpp:3949
 msgid "Select mask object and <b>object(s)</b> to apply clippath or mask to."
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:4086
+#: ../src/selection-chemistry.cpp:4096
 msgid "Set clipping path"
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:4088
+#: ../src/selection-chemistry.cpp:4098
 msgid "Set mask"
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:4103
+#: ../src/selection-chemistry.cpp:4113
 msgid "Select <b>object(s)</b> to remove clippath or mask from."
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:4219
+#: ../src/selection-chemistry.cpp:4229
 msgid "Release clipping path"
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:4221
+#: ../src/selection-chemistry.cpp:4231
 msgid "Release mask"
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:4240
+#: ../src/selection-chemistry.cpp:4250
 msgid "Select <b>object(s)</b> to fit canvas to."
 msgstr ""
 
 #. Fit Page
-#: ../src/selection-chemistry.cpp:4260 ../src/verbs.cpp:3018
+#: ../src/selection-chemistry.cpp:4270 ../src/verbs.cpp:3018
 msgid "Fit Page to Selection"
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:4289 ../src/verbs.cpp:3020
+#: ../src/selection-chemistry.cpp:4299 ../src/verbs.cpp:3020
 msgid "Fit Page to Drawing"
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:4310
+#: ../src/selection-chemistry.cpp:4320
 msgid "Fit Page to Selection or Drawing"
 msgstr ""
 
@@ -12927,8 +12935,8 @@ msgstr ""
 msgid "Keyboard directory (%s) is unavailable."
 msgstr ""
 
-#: ../src/shortcuts.cpp:343 ../src/ui/dialog/export.cpp:1305
-#: ../src/ui/dialog/export.cpp:1339
+#: ../src/shortcuts.cpp:343 ../src/ui/dialog/export.cpp:1306
+#: ../src/ui/dialog/export.cpp:1340
 msgid "Select a filename for exporting"
 msgstr ""
 
@@ -12959,7 +12967,7 @@ msgstr ""
 
 #. Ellipse
 #: ../src/sp-ellipse.cpp:362 ../src/sp-ellipse.cpp:369
-#: ../src/ui/dialog/inkscape-preferences.cpp:421
+#: ../src/ui/dialog/inkscape-preferences.cpp:439
 #: ../src/widgets/pencil-toolbar.cpp:178
 msgid "Ellipse"
 msgstr ""
@@ -13145,12 +13153,12 @@ msgid "<b>Polyline</b>"
 msgstr ""
 
 #. Rectangle
-#: ../src/sp-rect.cpp:197 ../src/ui/dialog/inkscape-preferences.cpp:411
+#: ../src/sp-rect.cpp:197 ../src/ui/dialog/inkscape-preferences.cpp:429
 msgid "Rectangle"
 msgstr ""
 
 #. Spiral
-#: ../src/sp-spiral.cpp:220 ../src/ui/dialog/inkscape-preferences.cpp:429
+#: ../src/sp-spiral.cpp:220 ../src/ui/dialog/inkscape-preferences.cpp:447
 #: ../share/extensions/gcodetools_area.inx.h:16
 msgid "Spiral"
 msgstr ""
@@ -13163,7 +13171,7 @@ msgid "with %3f turns"
 msgstr ""
 
 #. Star
-#: ../src/sp-star.cpp:247 ../src/ui/dialog/inkscape-preferences.cpp:425
+#: ../src/sp-star.cpp:247 ../src/ui/dialog/inkscape-preferences.cpp:443
 #: ../src/widgets/star-toolbar.cpp:469
 msgid "Star"
 msgstr ""
@@ -13498,37 +13506,37 @@ msgstr ""
 msgid "Nothing was copied."
 msgstr ""
 
-#: ../src/ui/clipboard.cpp:393 ../src/ui/clipboard.cpp:607
-#: ../src/ui/clipboard.cpp:636
+#: ../src/ui/clipboard.cpp:393 ../src/ui/clipboard.cpp:608
+#: ../src/ui/clipboard.cpp:637
 msgid "Nothing on the clipboard."
 msgstr ""
 
-#: ../src/ui/clipboard.cpp:451
+#: ../src/ui/clipboard.cpp:452
 msgid "Select <b>object(s)</b> to paste style to."
 msgstr ""
 
-#: ../src/ui/clipboard.cpp:462 ../src/ui/clipboard.cpp:479
+#: ../src/ui/clipboard.cpp:463 ../src/ui/clipboard.cpp:480
 msgid "No style on the clipboard."
 msgstr ""
 
-#: ../src/ui/clipboard.cpp:504
+#: ../src/ui/clipboard.cpp:505
 msgid "Select <b>object(s)</b> to paste size to."
 msgstr ""
 
-#: ../src/ui/clipboard.cpp:511
+#: ../src/ui/clipboard.cpp:512
 msgid "No size on the clipboard."
 msgstr ""
 
-#: ../src/ui/clipboard.cpp:568
+#: ../src/ui/clipboard.cpp:569
 msgid "Select <b>object(s)</b> to paste live path effect to."
 msgstr ""
 
 #. no_effect:
-#: ../src/ui/clipboard.cpp:594
+#: ../src/ui/clipboard.cpp:595
 msgid "No effect on the clipboard."
 msgstr ""
 
-#: ../src/ui/clipboard.cpp:613 ../src/ui/clipboard.cpp:650
+#: ../src/ui/clipboard.cpp:614 ../src/ui/clipboard.cpp:651
 msgid "Clipboard does not contain a path."
 msgstr ""
 
@@ -13639,7 +13647,7 @@ msgid "Rearrange"
 msgstr ""
 
 #: ../src/ui/dialog/align-and-distribute.cpp:941
-#: ../src/widgets/toolbox.cpp:1804
+#: ../src/widgets/toolbox.cpp:1803
 msgid "Nodes"
 msgstr ""
 
@@ -14607,12 +14615,12 @@ msgid "License"
 msgstr ""
 
 #: ../src/ui/dialog/document-metadata.cpp:126
-#: ../src/ui/dialog/document-properties.cpp:1037
+#: ../src/ui/dialog/document-properties.cpp:1054
 msgid "<b>Dublin Core Entities</b>"
 msgstr ""
 
 #: ../src/ui/dialog/document-metadata.cpp:168
-#: ../src/ui/dialog/document-properties.cpp:1099
+#: ../src/ui/dialog/document-properties.cpp:1116
 msgid "<b>License</b>"
 msgstr ""
 
@@ -14847,7 +14855,7 @@ msgstr ""
 msgid "Remove selected grid."
 msgstr ""
 
-#: ../src/ui/dialog/document-properties.cpp:162 ../src/widgets/toolbox.cpp:1911
+#: ../src/ui/dialog/document-properties.cpp:162 ../src/widgets/toolbox.cpp:1910
 msgid "Guides"
 msgstr ""
 
@@ -14879,23 +14887,23 @@ msgstr ""
 msgid "<b>Display</b>"
 msgstr ""
 
-#: ../src/ui/dialog/document-properties.cpp:381
+#: ../src/ui/dialog/document-properties.cpp:398
 msgid "<b>Guides</b>"
 msgstr ""
 
-#: ../src/ui/dialog/document-properties.cpp:399
+#: ../src/ui/dialog/document-properties.cpp:416
 msgid "<b>Snap to objects</b>"
 msgstr ""
 
-#: ../src/ui/dialog/document-properties.cpp:401
+#: ../src/ui/dialog/document-properties.cpp:418
 msgid "<b>Snap to grids</b>"
 msgstr ""
 
-#: ../src/ui/dialog/document-properties.cpp:403
+#: ../src/ui/dialog/document-properties.cpp:420
 msgid "<b>Snap to guides</b>"
 msgstr ""
 
-#: ../src/ui/dialog/document-properties.cpp:405
+#: ../src/ui/dialog/document-properties.cpp:422
 msgid "<b>Miscellaneous</b>"
 msgstr ""
 
@@ -14903,136 +14911,136 @@ msgstr ""
 #. Inkscape::GC::release(defsRepr);
 #. inform the document, so we can undo
 #. Color Management
-#: ../src/ui/dialog/document-properties.cpp:542 ../src/verbs.cpp:3034
+#: ../src/ui/dialog/document-properties.cpp:559 ../src/verbs.cpp:3034
 msgid "Link Color Profile"
 msgstr ""
 
-#: ../src/ui/dialog/document-properties.cpp:654
+#: ../src/ui/dialog/document-properties.cpp:671
 msgid "Remove linked color profile"
 msgstr ""
 
-#: ../src/ui/dialog/document-properties.cpp:673
+#: ../src/ui/dialog/document-properties.cpp:690
 msgid "<b>Linked Color Profiles:</b>"
 msgstr ""
 
-#: ../src/ui/dialog/document-properties.cpp:675
+#: ../src/ui/dialog/document-properties.cpp:692
 msgid "<b>Available Color Profiles:</b>"
 msgstr ""
 
-#: ../src/ui/dialog/document-properties.cpp:677
+#: ../src/ui/dialog/document-properties.cpp:694
 msgid "Link Profile"
 msgstr ""
 
-#: ../src/ui/dialog/document-properties.cpp:680
+#: ../src/ui/dialog/document-properties.cpp:697
 msgid "Unlink Profile"
 msgstr ""
 
-#: ../src/ui/dialog/document-properties.cpp:764
+#: ../src/ui/dialog/document-properties.cpp:781
 msgid "Profile Name"
 msgstr ""
 
-#: ../src/ui/dialog/document-properties.cpp:800
+#: ../src/ui/dialog/document-properties.cpp:817
 msgid "External scripts"
 msgstr ""
 
-#: ../src/ui/dialog/document-properties.cpp:801
+#: ../src/ui/dialog/document-properties.cpp:818
 msgid "Embedded scripts"
 msgstr ""
 
-#: ../src/ui/dialog/document-properties.cpp:806
+#: ../src/ui/dialog/document-properties.cpp:823
 msgid "<b>External script files:</b>"
 msgstr ""
 
-#: ../src/ui/dialog/document-properties.cpp:808
+#: ../src/ui/dialog/document-properties.cpp:825
 msgid "Add the current file name or browse for a file"
 msgstr ""
 
-#: ../src/ui/dialog/document-properties.cpp:811
-#: ../src/ui/dialog/document-properties.cpp:888
+#: ../src/ui/dialog/document-properties.cpp:828
+#: ../src/ui/dialog/document-properties.cpp:905
 #: ../src/ui/widget/selected-style.cpp:357
 msgid "Remove"
 msgstr ""
 
-#: ../src/ui/dialog/document-properties.cpp:875
+#: ../src/ui/dialog/document-properties.cpp:892
 msgid "Filename"
 msgstr ""
 
-#: ../src/ui/dialog/document-properties.cpp:883
+#: ../src/ui/dialog/document-properties.cpp:900
 msgid "<b>Embedded script files:</b>"
 msgstr ""
 
-#: ../src/ui/dialog/document-properties.cpp:885
+#: ../src/ui/dialog/document-properties.cpp:902
 #: ../src/ui/dialog/objects.cpp:1928
 msgid "New"
 msgstr ""
 
-#: ../src/ui/dialog/document-properties.cpp:952
+#: ../src/ui/dialog/document-properties.cpp:969
 msgid "Script id"
 msgstr ""
 
-#: ../src/ui/dialog/document-properties.cpp:958
+#: ../src/ui/dialog/document-properties.cpp:975
 msgid "<b>Content:</b>"
 msgstr ""
 
-#: ../src/ui/dialog/document-properties.cpp:1075
+#: ../src/ui/dialog/document-properties.cpp:1092
 msgid "_Save as default"
 msgstr ""
 
-#: ../src/ui/dialog/document-properties.cpp:1076
+#: ../src/ui/dialog/document-properties.cpp:1093
 msgid "Save this metadata as the default metadata"
 msgstr ""
 
-#: ../src/ui/dialog/document-properties.cpp:1077
+#: ../src/ui/dialog/document-properties.cpp:1094
 msgid "Use _default"
 msgstr ""
 
-#: ../src/ui/dialog/document-properties.cpp:1078
+#: ../src/ui/dialog/document-properties.cpp:1095
 msgid "Use the previously saved default metadata here"
 msgstr ""
 
 #. inform the document, so we can undo
-#: ../src/ui/dialog/document-properties.cpp:1151
+#: ../src/ui/dialog/document-properties.cpp:1168
 msgid "Add external script..."
 msgstr ""
 
-#: ../src/ui/dialog/document-properties.cpp:1190
+#: ../src/ui/dialog/document-properties.cpp:1207
 msgid "Select a script to load"
 msgstr ""
 
 #. inform the document, so we can undo
-#: ../src/ui/dialog/document-properties.cpp:1218
+#: ../src/ui/dialog/document-properties.cpp:1235
 msgid "Add embedded script..."
 msgstr ""
 
 #. inform the document, so we can undo
-#: ../src/ui/dialog/document-properties.cpp:1249
+#: ../src/ui/dialog/document-properties.cpp:1266
 msgid "Remove external script"
 msgstr ""
 
 #. inform the document, so we can undo
-#: ../src/ui/dialog/document-properties.cpp:1278
+#: ../src/ui/dialog/document-properties.cpp:1295
 msgid "Remove embedded script"
 msgstr ""
 
 #. TODO repr->set_content(_EmbeddedContent.get_buffer()->get_text());
 #. inform the document, so we can undo
-#: ../src/ui/dialog/document-properties.cpp:1374
+#: ../src/ui/dialog/document-properties.cpp:1391
 msgid "Edit embedded script"
 msgstr ""
 
-#: ../src/ui/dialog/document-properties.cpp:1458
+#: ../src/ui/dialog/document-properties.cpp:1475
 msgid "<b>Creation</b>"
 msgstr ""
 
-#: ../src/ui/dialog/document-properties.cpp:1459
+#: ../src/ui/dialog/document-properties.cpp:1476
 msgid "<b>Defined grids</b>"
 msgstr ""
 
-#: ../src/ui/dialog/document-properties.cpp:1703
+#: ../src/ui/dialog/document-properties.cpp:1720
 msgid "Remove grid"
 msgstr ""
 
-#: ../src/ui/dialog/document-properties.cpp:1795
+#: ../src/ui/dialog/document-properties.cpp:1812
 msgid "Changed default display unit"
 msgstr ""
 
@@ -15138,9 +15146,9 @@ msgid "_Height:"
 msgstr ""
 
 #: ../src/ui/dialog/export.cpp:304
-#: ../src/ui/dialog/inkscape-preferences.cpp:1493
-#: ../src/ui/dialog/inkscape-preferences.cpp:1497
-#: ../src/ui/dialog/inkscape-preferences.cpp:1521
+#: ../src/ui/dialog/inkscape-preferences.cpp:1515
+#: ../src/ui/dialog/inkscape-preferences.cpp:1519
+#: ../src/ui/dialog/inkscape-preferences.cpp:1543
 msgid "dpi"
 msgstr ""
 
@@ -15167,76 +15175,76 @@ msgstr[1] ""
 msgid "Export in progress"
 msgstr ""
 
-#: ../src/ui/dialog/export.cpp:1022
+#: ../src/ui/dialog/export.cpp:1023
 msgid "No items selected."
 msgstr ""
 
-#: ../src/ui/dialog/export.cpp:1026 ../src/ui/dialog/export.cpp:1028
+#: ../src/ui/dialog/export.cpp:1027 ../src/ui/dialog/export.cpp:1029
 msgid "Exporting %1 files"
 msgstr ""
 
-#: ../src/ui/dialog/export.cpp:1069 ../src/ui/dialog/export.cpp:1071
+#: ../src/ui/dialog/export.cpp:1070 ../src/ui/dialog/export.cpp:1072
 #, c-format
 msgid "Exporting file <b>%s</b>..."
 msgstr ""
 
-#: ../src/ui/dialog/export.cpp:1080 ../src/ui/dialog/export.cpp:1172
+#: ../src/ui/dialog/export.cpp:1081 ../src/ui/dialog/export.cpp:1173
 #, c-format
 msgid "Could not export to filename %s.\n"
 msgstr ""
 
-#: ../src/ui/dialog/export.cpp:1083
+#: ../src/ui/dialog/export.cpp:1084
 #, c-format
 msgid "Could not export to filename <b>%s</b>."
 msgstr ""
 
-#: ../src/ui/dialog/export.cpp:1098
+#: ../src/ui/dialog/export.cpp:1099
 #, c-format
 msgid "Successfully exported <b>%d</b> files from <b>%d</b> selected items."
 msgstr ""
 
-#: ../src/ui/dialog/export.cpp:1109
+#: ../src/ui/dialog/export.cpp:1110
 msgid "You have to enter a filename."
 msgstr ""
 
-#: ../src/ui/dialog/export.cpp:1110
+#: ../src/ui/dialog/export.cpp:1111
 msgid "You have to enter a filename"
 msgstr ""
 
-#: ../src/ui/dialog/export.cpp:1124
+#: ../src/ui/dialog/export.cpp:1125
 msgid "The chosen area to be exported is invalid."
 msgstr ""
 
-#: ../src/ui/dialog/export.cpp:1125
+#: ../src/ui/dialog/export.cpp:1126
 msgid "The chosen area to be exported is invalid"
 msgstr ""
 
-#: ../src/ui/dialog/export.cpp:1140
+#: ../src/ui/dialog/export.cpp:1141
 #, c-format
 msgid "Directory %s does not exist or is not a directory.\n"
 msgstr ""
 
 #. TRANSLATORS: %1 will be the filename, %2 the width, and %3 the height of the image
-#: ../src/ui/dialog/export.cpp:1154 ../src/ui/dialog/export.cpp:1156
+#: ../src/ui/dialog/export.cpp:1155 ../src/ui/dialog/export.cpp:1157
 msgid "Exporting %1 (%2 x %3)"
 msgstr ""
 
-#: ../src/ui/dialog/export.cpp:1183
+#: ../src/ui/dialog/export.cpp:1184
 #, c-format
 msgid "Drawing exported to <b>%s</b>."
 msgstr ""
 
-#: ../src/ui/dialog/export.cpp:1187
+#: ../src/ui/dialog/export.cpp:1188
 msgid "Export aborted."
 msgstr ""
 
-#: ../src/ui/dialog/export.cpp:1308 ../src/ui/interface.cpp:1401
+#: ../src/ui/dialog/export.cpp:1309 ../src/ui/interface.cpp:1401
 #: ../src/widgets/desktop-widget.cpp:1201
 #: ../src/widgets/desktop-widget.cpp:1263
 msgid "_Cancel"
 msgstr ""
 
-#: ../src/ui/dialog/export.cpp:1309 ../src/ui/dialog/input.cpp:1082
+#: ../src/ui/dialog/export.cpp:1310 ../src/ui/dialog/input.cpp:1082
 #: ../src/verbs.cpp:2438 ../src/widgets/desktop-widget.cpp:1202
 msgid "_Save"
 msgstr ""
@@ -16264,7 +16272,7 @@ msgstr ""
 msgid "Search spirals"
 msgstr ""
 
-#: ../src/ui/dialog/find.cpp:103 ../src/widgets/toolbox.cpp:1812
+#: ../src/ui/dialog/find.cpp:103 ../src/widgets/toolbox.cpp:1811
 msgid "Paths"
 msgstr ""
 
@@ -17290,350 +17298,350 @@ msgstr ""
 msgid "Selection only or whole document"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:183
+#: ../src/ui/dialog/inkscape-preferences.cpp:201
 msgid "Show selection cue"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:184
+#: ../src/ui/dialog/inkscape-preferences.cpp:202
 msgid ""
 "Whether selected objects display a selection cue (the same as in selector)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:190
+#: ../src/ui/dialog/inkscape-preferences.cpp:208
 msgid "Enable gradient editing"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:191
+#: ../src/ui/dialog/inkscape-preferences.cpp:209
 msgid "Whether selected objects display gradient editing controls"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:196
+#: ../src/ui/dialog/inkscape-preferences.cpp:214
 msgid "Conversion to guides uses edges instead of bounding box"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:197
+#: ../src/ui/dialog/inkscape-preferences.cpp:215
 msgid ""
 "Converting an object to guides places these along the object's true edges "
 "(imitating the object's shape), not along the bounding box"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:204
+#: ../src/ui/dialog/inkscape-preferences.cpp:222
 msgid "Ctrl+click _dot size:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:204
+#: ../src/ui/dialog/inkscape-preferences.cpp:222
 msgid "times current stroke width"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:205
+#: ../src/ui/dialog/inkscape-preferences.cpp:223
 msgid "Size of dots created with Ctrl+click (relative to current stroke width)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:213
+#: ../src/ui/dialog/inkscape-preferences.cpp:231
 msgid "Base simplify:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:213
+#: ../src/ui/dialog/inkscape-preferences.cpp:231
 msgid "on dynamic LPE simplify"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:214
+#: ../src/ui/dialog/inkscape-preferences.cpp:232
 msgid "Base simplify of dynamic LPE based simplify"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:229
+#: ../src/ui/dialog/inkscape-preferences.cpp:247
 msgid "<b>No objects selected</b> to take the style from."
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:238
+#: ../src/ui/dialog/inkscape-preferences.cpp:256
 msgid ""
 "<b>More than one object selected.</b>  Cannot take style from multiple "
 "objects."
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:274
+#: ../src/ui/dialog/inkscape-preferences.cpp:292
 msgid "Style of new objects"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:276
+#: ../src/ui/dialog/inkscape-preferences.cpp:294
 msgid "Last used style"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:278
+#: ../src/ui/dialog/inkscape-preferences.cpp:296
 msgid "Apply the style you last set on an object"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:283
+#: ../src/ui/dialog/inkscape-preferences.cpp:301
 msgid "This tool's own style:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:287
+#: ../src/ui/dialog/inkscape-preferences.cpp:305
 msgid ""
 "Each tool may store its own style to apply to the newly created objects. Use "
 "the button below to set it."
 msgstr ""
 
 #. style swatch
-#: ../src/ui/dialog/inkscape-preferences.cpp:291
+#: ../src/ui/dialog/inkscape-preferences.cpp:309
 msgid "Take from selection"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:300
+#: ../src/ui/dialog/inkscape-preferences.cpp:318
 msgid "This tool's style of new objects"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:307
+#: ../src/ui/dialog/inkscape-preferences.cpp:325
 msgid "Remember the style of the (first) selected object as this tool's style"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:312
+#: ../src/ui/dialog/inkscape-preferences.cpp:330
 msgid "Tools"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:315
+#: ../src/ui/dialog/inkscape-preferences.cpp:333
 msgid "Bounding box to use"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:316
+#: ../src/ui/dialog/inkscape-preferences.cpp:334
 msgid "Visual bounding box"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:318
+#: ../src/ui/dialog/inkscape-preferences.cpp:336
 msgid "This bounding box includes stroke width, markers, filter margins, etc."
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:319
+#: ../src/ui/dialog/inkscape-preferences.cpp:337
 msgid "Geometric bounding box"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:321
+#: ../src/ui/dialog/inkscape-preferences.cpp:339
 msgid "This bounding box includes only the bare path"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:323
+#: ../src/ui/dialog/inkscape-preferences.cpp:341
 msgid "Conversion to guides"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:324
+#: ../src/ui/dialog/inkscape-preferences.cpp:342
 msgid "Keep objects after conversion to guides"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:326
+#: ../src/ui/dialog/inkscape-preferences.cpp:344
 msgid ""
 "When converting an object to guides, don't delete the object after the "
 "conversion"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:327
+#: ../src/ui/dialog/inkscape-preferences.cpp:345
 msgid "Treat groups as a single object"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:329
+#: ../src/ui/dialog/inkscape-preferences.cpp:347
 msgid ""
 "Treat groups as a single object during conversion to guides rather than "
 "converting each child separately"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:331
+#: ../src/ui/dialog/inkscape-preferences.cpp:349
 msgid "Average all sketches"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:332
+#: ../src/ui/dialog/inkscape-preferences.cpp:350
 msgid "Width is in absolute units"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:333
+#: ../src/ui/dialog/inkscape-preferences.cpp:351
 msgid "Select new path"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:334
+#: ../src/ui/dialog/inkscape-preferences.cpp:352
 msgid "Don't attach connectors to text objects"
 msgstr ""
 
 #. Selector
-#: ../src/ui/dialog/inkscape-preferences.cpp:337
+#: ../src/ui/dialog/inkscape-preferences.cpp:355
 msgid "Selector"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:342
+#: ../src/ui/dialog/inkscape-preferences.cpp:360
 msgid "When transforming, show"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:343
+#: ../src/ui/dialog/inkscape-preferences.cpp:361
 msgid "Objects"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:345
+#: ../src/ui/dialog/inkscape-preferences.cpp:363
 msgid "Show the actual objects when moving or transforming"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:346
+#: ../src/ui/dialog/inkscape-preferences.cpp:364
 msgid "Box outline"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:348
+#: ../src/ui/dialog/inkscape-preferences.cpp:366
 msgid "Show only a box outline of the objects when moving or transforming"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:349
+#: ../src/ui/dialog/inkscape-preferences.cpp:367
 msgid "Per-object selection cue"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:350
+#: ../src/ui/dialog/inkscape-preferences.cpp:368
 msgctxt "Selection cue"
 msgid "None"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:352
+#: ../src/ui/dialog/inkscape-preferences.cpp:370
 msgid "No per-object selection indication"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:353
+#: ../src/ui/dialog/inkscape-preferences.cpp:371
 msgid "Mark"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:355
+#: ../src/ui/dialog/inkscape-preferences.cpp:373
 msgid "Each selected object has a diamond mark in the top left corner"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:356
+#: ../src/ui/dialog/inkscape-preferences.cpp:374
 msgid "Box"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:358
+#: ../src/ui/dialog/inkscape-preferences.cpp:376
 msgid "Each selected object displays its bounding box"
 msgstr ""
 
 #. Node
-#: ../src/ui/dialog/inkscape-preferences.cpp:361
+#: ../src/ui/dialog/inkscape-preferences.cpp:379
 msgid "Node"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:364
+#: ../src/ui/dialog/inkscape-preferences.cpp:382
 msgid "Path outline"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:365
+#: ../src/ui/dialog/inkscape-preferences.cpp:383
 msgid "Path outline color"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:366
+#: ../src/ui/dialog/inkscape-preferences.cpp:384
 msgid "Selects the color used for showing the path outline"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:367
+#: ../src/ui/dialog/inkscape-preferences.cpp:385
 msgid "Always show outline"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:368
+#: ../src/ui/dialog/inkscape-preferences.cpp:386
 msgid "Show outlines for all paths, not only invisible paths"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:369
+#: ../src/ui/dialog/inkscape-preferences.cpp:387
 msgid "Update outline when dragging nodes"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:370
+#: ../src/ui/dialog/inkscape-preferences.cpp:388
 msgid ""
 "Update the outline when dragging or transforming nodes; if this is off, the "
 "outline will only update when completing a drag"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:371
+#: ../src/ui/dialog/inkscape-preferences.cpp:389
 msgid "Update paths when dragging nodes"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:372
+#: ../src/ui/dialog/inkscape-preferences.cpp:390
 msgid ""
 "Update paths when dragging or transforming nodes; if this is off, paths will "
 "only be updated when completing a drag"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:373
+#: ../src/ui/dialog/inkscape-preferences.cpp:391
 msgid "Show path direction on outlines"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:374
+#: ../src/ui/dialog/inkscape-preferences.cpp:392
 msgid ""
 "Visualize the direction of selected paths by drawing small arrows in the "
 "middle of each outline segment"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:375
+#: ../src/ui/dialog/inkscape-preferences.cpp:393
 msgid "Show temporary path outline"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:376
+#: ../src/ui/dialog/inkscape-preferences.cpp:394
 msgid "When hovering over a path, briefly flash its outline"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:377
+#: ../src/ui/dialog/inkscape-preferences.cpp:395
 msgid "Show temporary outline for selected paths"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:378
+#: ../src/ui/dialog/inkscape-preferences.cpp:396
 msgid "Show temporary outline even when a path is selected for editing"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:380
+#: ../src/ui/dialog/inkscape-preferences.cpp:398
 msgid "_Flash time:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:380
+#: ../src/ui/dialog/inkscape-preferences.cpp:398
 msgid ""
 "Specifies how long the path outline will be visible after a mouse-over (in "
 "milliseconds); specify 0 to have the outline shown until mouse leaves the "
 "path"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:381
+#: ../src/ui/dialog/inkscape-preferences.cpp:399
 msgid "Editing preferences"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:382
+#: ../src/ui/dialog/inkscape-preferences.cpp:400
 msgid "Show transform handles for single nodes"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:383
+#: ../src/ui/dialog/inkscape-preferences.cpp:401
 msgid "Show transform handles even when only a single node is selected"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:384
+#: ../src/ui/dialog/inkscape-preferences.cpp:402
 msgid "Deleting nodes preserves shape"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:385
+#: ../src/ui/dialog/inkscape-preferences.cpp:403
 msgid ""
 "Move handles next to deleted nodes to resemble original shape; hold Ctrl to "
 "get the other behavior"
 msgstr ""
 
 #. Tweak
-#: ../src/ui/dialog/inkscape-preferences.cpp:388
+#: ../src/ui/dialog/inkscape-preferences.cpp:406
 msgid "Tweak"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:389
+#: ../src/ui/dialog/inkscape-preferences.cpp:407
 msgid "Object paint style"
 msgstr ""
 
 #. Zoom
-#: ../src/ui/dialog/inkscape-preferences.cpp:394
+#: ../src/ui/dialog/inkscape-preferences.cpp:412
 #: ../src/widgets/desktop-widget.cpp:709
 msgid "Zoom"
 msgstr ""
 
 #. Measure
-#: ../src/ui/dialog/inkscape-preferences.cpp:399 ../src/verbs.cpp:2777
+#: ../src/ui/dialog/inkscape-preferences.cpp:417 ../src/verbs.cpp:2777
 msgctxt "ContextVerb"
 msgid "Measure"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:401
+#: ../src/ui/dialog/inkscape-preferences.cpp:419
 msgid "Ignore first and last points"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:402
+#: ../src/ui/dialog/inkscape-preferences.cpp:420
 msgid ""
 "The start and end of the measurement tool's control line will not be "
 "considered for calculating lengths. Only lengths between actual curve "
@@ -17641,637 +17649,637 @@ msgid ""
 msgstr ""
 
 #. Shapes
-#: ../src/ui/dialog/inkscape-preferences.cpp:405
+#: ../src/ui/dialog/inkscape-preferences.cpp:423
 msgid "Shapes"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:438
+#: ../src/ui/dialog/inkscape-preferences.cpp:456
 msgid "Sketch mode"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:440
+#: ../src/ui/dialog/inkscape-preferences.cpp:458
 msgid ""
 "If on, the sketch result will be the normal average of all sketches made, "
 "instead of averaging the old result with the new sketch"
 msgstr ""
 
 #. Pen
-#: ../src/ui/dialog/inkscape-preferences.cpp:443
+#: ../src/ui/dialog/inkscape-preferences.cpp:461
 #: ../src/ui/dialog/input.cpp:1485
 msgid "Pen"
 msgstr ""
 
 #. Calligraphy
-#: ../src/ui/dialog/inkscape-preferences.cpp:449
+#: ../src/ui/dialog/inkscape-preferences.cpp:467
 msgid "Calligraphy"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:453
+#: ../src/ui/dialog/inkscape-preferences.cpp:471
 msgid ""
 "If on, pen width is in absolute units (px) independent of zoom; otherwise "
 "pen width depends on zoom so that it looks the same at any zoom"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:455
+#: ../src/ui/dialog/inkscape-preferences.cpp:473
 msgid ""
 "If on, each newly created object will be selected (deselecting previous "
 "selection)"
 msgstr ""
 
 #. Text
-#: ../src/ui/dialog/inkscape-preferences.cpp:458 ../src/verbs.cpp:2769
+#: ../src/ui/dialog/inkscape-preferences.cpp:476 ../src/verbs.cpp:2769
 msgctxt "ContextVerb"
 msgid "Text"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:463
+#: ../src/ui/dialog/inkscape-preferences.cpp:481
 msgid "Show font samples in the drop-down list"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:464
+#: ../src/ui/dialog/inkscape-preferences.cpp:482
 msgid ""
 "Show font samples alongside font names in the drop-down list in Text bar"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:466
+#: ../src/ui/dialog/inkscape-preferences.cpp:484
 msgid "Show font substitution warning dialog"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:467
+#: ../src/ui/dialog/inkscape-preferences.cpp:485
 msgid ""
 "Show font substitution warning dialog when requested fonts are not available "
 "on the system"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:470
+#: ../src/ui/dialog/inkscape-preferences.cpp:488
 msgid "Pixel"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:470
+#: ../src/ui/dialog/inkscape-preferences.cpp:488
 msgid "Pica"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:470
+#: ../src/ui/dialog/inkscape-preferences.cpp:488
 msgid "Millimeter"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:470
+#: ../src/ui/dialog/inkscape-preferences.cpp:488
 msgid "Centimeter"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:470
+#: ../src/ui/dialog/inkscape-preferences.cpp:488
 msgid "Inch"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:470
+#: ../src/ui/dialog/inkscape-preferences.cpp:488
 msgid "Em square"
 msgstr ""
 
 #. , _("Ex square"), _("Percent")
 #. , SP_CSS_UNIT_EX, SP_CSS_UNIT_PERCENT
-#: ../src/ui/dialog/inkscape-preferences.cpp:473
+#: ../src/ui/dialog/inkscape-preferences.cpp:491
 msgid "Text units"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:475
+#: ../src/ui/dialog/inkscape-preferences.cpp:493
 msgid "Text size unit type:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:476
+#: ../src/ui/dialog/inkscape-preferences.cpp:494
 msgid "Set the type of unit used in the text toolbar and text dialogs"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:477
+#: ../src/ui/dialog/inkscape-preferences.cpp:495
 msgid "Always output text size in pixels (px)"
 msgstr ""
 
 #. Spray
-#: ../src/ui/dialog/inkscape-preferences.cpp:483
+#: ../src/ui/dialog/inkscape-preferences.cpp:501
 msgid "Spray"
 msgstr ""
 
 #. Eraser
-#: ../src/ui/dialog/inkscape-preferences.cpp:488
+#: ../src/ui/dialog/inkscape-preferences.cpp:506
 msgid "Eraser"
 msgstr ""
 
 #. Paint Bucket
-#: ../src/ui/dialog/inkscape-preferences.cpp:493
+#: ../src/ui/dialog/inkscape-preferences.cpp:511
 msgid "Paint Bucket"
 msgstr ""
 
 #. Gradient
-#: ../src/ui/dialog/inkscape-preferences.cpp:499
+#: ../src/ui/dialog/inkscape-preferences.cpp:517
 #: ../src/widgets/gradient-selector.cpp:144
 #: ../src/widgets/gradient-selector.cpp:295
 msgid "Gradient"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:501
+#: ../src/ui/dialog/inkscape-preferences.cpp:519
 msgid "Prevent sharing of gradient definitions"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:503
+#: ../src/ui/dialog/inkscape-preferences.cpp:521
 msgid ""
 "When on, shared gradient definitions are automatically forked on change; "
 "uncheck to allow sharing of gradient definitions so that editing one object "
 "may affect other objects using the same gradient"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:504
+#: ../src/ui/dialog/inkscape-preferences.cpp:522
 msgid "Use legacy Gradient Editor"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:506
+#: ../src/ui/dialog/inkscape-preferences.cpp:524
 msgid ""
 "When on, the Gradient Edit button in the Fill & Stroke dialog will show the "
 "legacy Gradient Editor dialog, when off the Gradient Tool will be used"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:509
+#: ../src/ui/dialog/inkscape-preferences.cpp:527
 msgid "Linear gradient _angle:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:510
+#: ../src/ui/dialog/inkscape-preferences.cpp:528
 msgid ""
 "Default angle of new linear gradients in degrees (clockwise from horizontal)"
 msgstr ""
 
 #. Dropper
-#: ../src/ui/dialog/inkscape-preferences.cpp:514
+#: ../src/ui/dialog/inkscape-preferences.cpp:532
 msgid "Dropper"
 msgstr ""
 
 #. Connector
-#: ../src/ui/dialog/inkscape-preferences.cpp:519
+#: ../src/ui/dialog/inkscape-preferences.cpp:537
 msgid "Connector"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:522
+#: ../src/ui/dialog/inkscape-preferences.cpp:540
 msgid "If on, connector attachment points will not be shown for text objects"
 msgstr ""
 
 #. LPETool
 #. disabled, because the LPETool is not finished yet.
-#: ../src/ui/dialog/inkscape-preferences.cpp:527
+#: ../src/ui/dialog/inkscape-preferences.cpp:545
 msgid "LPE Tool"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:534
+#: ../src/ui/dialog/inkscape-preferences.cpp:552
 msgid "Interface"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:537
+#: ../src/ui/dialog/inkscape-preferences.cpp:555
 msgid "System default"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:538
+#: ../src/ui/dialog/inkscape-preferences.cpp:556
 msgid "Albanian (sq)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:538
+#: ../src/ui/dialog/inkscape-preferences.cpp:556
 msgid "Amharic (am)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:538
+#: ../src/ui/dialog/inkscape-preferences.cpp:556
 msgid "Arabic (ar)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:538
+#: ../src/ui/dialog/inkscape-preferences.cpp:556
 msgid "Armenian (hy)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:538
+#: ../src/ui/dialog/inkscape-preferences.cpp:556
 msgid "Assamese (as)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:538
+#: ../src/ui/dialog/inkscape-preferences.cpp:556
 msgid "Azerbaijani (az)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:539
+#: ../src/ui/dialog/inkscape-preferences.cpp:557
 msgid "Basque (eu)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:539
+#: ../src/ui/dialog/inkscape-preferences.cpp:557
 msgid "Belarusian (be)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:539
+#: ../src/ui/dialog/inkscape-preferences.cpp:557
 msgid "Bulgarian (bg)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:539
+#: ../src/ui/dialog/inkscape-preferences.cpp:557
 msgid "Bengali (bn)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:539
+#: ../src/ui/dialog/inkscape-preferences.cpp:557
 msgid "Bengali/Bangladesh (bn_BD)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:539
+#: ../src/ui/dialog/inkscape-preferences.cpp:557
 msgid "Bodo (brx)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:539
+#: ../src/ui/dialog/inkscape-preferences.cpp:557
 msgid "Breton (br)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:540
+#: ../src/ui/dialog/inkscape-preferences.cpp:558
 msgid "Catalan (ca)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:540
+#: ../src/ui/dialog/inkscape-preferences.cpp:558
 msgid "Valencian Catalan (ca@valencia)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:540
+#: ../src/ui/dialog/inkscape-preferences.cpp:558
 msgid "Chinese/China (zh_CN)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:540
+#: ../src/ui/dialog/inkscape-preferences.cpp:558
 msgid "Chinese/Taiwan (zh_TW)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:540
+#: ../src/ui/dialog/inkscape-preferences.cpp:558
 msgid "Croatian (hr)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:540
+#: ../src/ui/dialog/inkscape-preferences.cpp:558
 msgid "Czech (cs)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:541
+#: ../src/ui/dialog/inkscape-preferences.cpp:559
 msgid "Danish (da)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:541
+#: ../src/ui/dialog/inkscape-preferences.cpp:559
 msgid "Dogri (doi)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:541
+#: ../src/ui/dialog/inkscape-preferences.cpp:559
 msgid "Dutch (nl)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:541
+#: ../src/ui/dialog/inkscape-preferences.cpp:559
 msgid "Dzongkha (dz)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:542
+#: ../src/ui/dialog/inkscape-preferences.cpp:560
 msgid "German (de)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:542
+#: ../src/ui/dialog/inkscape-preferences.cpp:560
 msgid "Greek (el)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:543
+#: ../src/ui/dialog/inkscape-preferences.cpp:561
 msgid "English (en)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:543
+#: ../src/ui/dialog/inkscape-preferences.cpp:561
 msgid "English/Australia (en_AU)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:543
+#: ../src/ui/dialog/inkscape-preferences.cpp:561
 msgid "English/Canada (en_CA)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:543
+#: ../src/ui/dialog/inkscape-preferences.cpp:561
 msgid "English/Great Britain (en_GB)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:543
+#: ../src/ui/dialog/inkscape-preferences.cpp:561
 msgid "Pig Latin (en_US@piglatin)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:543
+#: ../src/ui/dialog/inkscape-preferences.cpp:561
 msgid "Esperanto (eo)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:543
+#: ../src/ui/dialog/inkscape-preferences.cpp:561
 msgid "Estonian (et)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:544
+#: ../src/ui/dialog/inkscape-preferences.cpp:562
 msgid "Farsi (fa)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:544
+#: ../src/ui/dialog/inkscape-preferences.cpp:562
 msgid "Finnish (fi)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:544
+#: ../src/ui/dialog/inkscape-preferences.cpp:562
 msgid "French (fr)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:545
+#: ../src/ui/dialog/inkscape-preferences.cpp:563
 msgid "Galician (gl)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:545
+#: ../src/ui/dialog/inkscape-preferences.cpp:563
 msgid "Gujarati (gu)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:546
+#: ../src/ui/dialog/inkscape-preferences.cpp:564
 msgid "Hebrew (he)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:546
+#: ../src/ui/dialog/inkscape-preferences.cpp:564
 msgid "Hindi (hi)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:546
+#: ../src/ui/dialog/inkscape-preferences.cpp:564
 msgid "Hungarian (hu)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:547
+#: ../src/ui/dialog/inkscape-preferences.cpp:565
 msgid "Icelandic (is)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:547
+#: ../src/ui/dialog/inkscape-preferences.cpp:565
 msgid "Indonesian (id)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:547
+#: ../src/ui/dialog/inkscape-preferences.cpp:565
 msgid "Irish (ga)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:547
+#: ../src/ui/dialog/inkscape-preferences.cpp:565
 msgid "Italian (it)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:548
+#: ../src/ui/dialog/inkscape-preferences.cpp:566
 msgid "Japanese (ja)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:549
+#: ../src/ui/dialog/inkscape-preferences.cpp:567
 msgid "Kannada (kn)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:549
+#: ../src/ui/dialog/inkscape-preferences.cpp:567
 msgid "Kashmiri in Perso-Arabic script (ks@aran)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:549
+#: ../src/ui/dialog/inkscape-preferences.cpp:567
 msgid "Kashmiri in Devanagari script (ks@deva)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:549
+#: ../src/ui/dialog/inkscape-preferences.cpp:567
 msgid "Khmer (km)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:549
+#: ../src/ui/dialog/inkscape-preferences.cpp:567
 msgid "Kinyarwanda (rw)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:549
+#: ../src/ui/dialog/inkscape-preferences.cpp:567
 msgid "Konkani (kok)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:549
+#: ../src/ui/dialog/inkscape-preferences.cpp:567
 msgid "Konkani in Latin script (kok@latin)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:549
+#: ../src/ui/dialog/inkscape-preferences.cpp:567
 msgid "Korean (ko)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:550
+#: ../src/ui/dialog/inkscape-preferences.cpp:568
 msgid "Latvian (lv)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:550
+#: ../src/ui/dialog/inkscape-preferences.cpp:568
 msgid "Lithuanian (lt)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:551
+#: ../src/ui/dialog/inkscape-preferences.cpp:569
 msgid "Macedonian (mk)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:551
+#: ../src/ui/dialog/inkscape-preferences.cpp:569
 msgid "Maithili (mai)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:551
+#: ../src/ui/dialog/inkscape-preferences.cpp:569
 msgid "Malayalam (ml)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:551
+#: ../src/ui/dialog/inkscape-preferences.cpp:569
 msgid "Manipuri (mni)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:551
+#: ../src/ui/dialog/inkscape-preferences.cpp:569
 msgid "Manipuri in Bengali script (mni@beng)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:551
+#: ../src/ui/dialog/inkscape-preferences.cpp:569
 msgid "Marathi (mr)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:551
+#: ../src/ui/dialog/inkscape-preferences.cpp:569
 msgid "Mongolian (mn)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:552
+#: ../src/ui/dialog/inkscape-preferences.cpp:570
 msgid "Nepali (ne)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:552
+#: ../src/ui/dialog/inkscape-preferences.cpp:570
 msgid "Norwegian Bokmål (nb)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:552
+#: ../src/ui/dialog/inkscape-preferences.cpp:570
 msgid "Norwegian Nynorsk (nn)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:553
+#: ../src/ui/dialog/inkscape-preferences.cpp:571
 msgid "Odia (or)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:554
+#: ../src/ui/dialog/inkscape-preferences.cpp:572
 msgid "Panjabi (pa)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:554
+#: ../src/ui/dialog/inkscape-preferences.cpp:572
 msgid "Polish (pl)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:554
+#: ../src/ui/dialog/inkscape-preferences.cpp:572
 msgid "Portuguese (pt)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:554
+#: ../src/ui/dialog/inkscape-preferences.cpp:572
 msgid "Portuguese/Brazil (pt_BR)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:555
+#: ../src/ui/dialog/inkscape-preferences.cpp:573
 msgid "Romanian (ro)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:555
+#: ../src/ui/dialog/inkscape-preferences.cpp:573
 msgid "Russian (ru)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:556
+#: ../src/ui/dialog/inkscape-preferences.cpp:574
 msgid "Sanskrit (sa)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:556
+#: ../src/ui/dialog/inkscape-preferences.cpp:574
 msgid "Santali (sat)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:556
+#: ../src/ui/dialog/inkscape-preferences.cpp:574
 msgid "Santali in Devanagari script (sat@deva)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:556
+#: ../src/ui/dialog/inkscape-preferences.cpp:574
 msgid "Serbian (sr)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:556
+#: ../src/ui/dialog/inkscape-preferences.cpp:574
 msgid "Serbian in Latin script (sr@latin)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:557
+#: ../src/ui/dialog/inkscape-preferences.cpp:575
 msgid "Sindhi (sd)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:557
+#: ../src/ui/dialog/inkscape-preferences.cpp:575
 msgid "Sindhi in Devanagari script (sd@deva)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:557
+#: ../src/ui/dialog/inkscape-preferences.cpp:575
 msgid "Slovak (sk)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:557
+#: ../src/ui/dialog/inkscape-preferences.cpp:575
 msgid "Slovenian (sl)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:557
+#: ../src/ui/dialog/inkscape-preferences.cpp:575
 msgid "Spanish (es)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:557
+#: ../src/ui/dialog/inkscape-preferences.cpp:575
 msgid "Spanish/Mexico (es_MX)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:557
+#: ../src/ui/dialog/inkscape-preferences.cpp:575
 msgid "Swedish (sv)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:558
+#: ../src/ui/dialog/inkscape-preferences.cpp:576
 msgid "Tamil (ta)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:558
+#: ../src/ui/dialog/inkscape-preferences.cpp:576
 msgid "Telugu (te)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:558
+#: ../src/ui/dialog/inkscape-preferences.cpp:576
 msgid "Thai (th)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:558
+#: ../src/ui/dialog/inkscape-preferences.cpp:576
 msgid "Turkish (tr)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:559
+#: ../src/ui/dialog/inkscape-preferences.cpp:577
 msgid "Ukrainian (uk)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:559
+#: ../src/ui/dialog/inkscape-preferences.cpp:577
 msgid "Urdu (ur)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:560
+#: ../src/ui/dialog/inkscape-preferences.cpp:578
 msgid "Vietnamese (vi)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:612
+#: ../src/ui/dialog/inkscape-preferences.cpp:630
 msgid "Language (requires restart):"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:613
+#: ../src/ui/dialog/inkscape-preferences.cpp:631
 msgid "Set the language for menus and number formats"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:616
+#: ../src/ui/dialog/inkscape-preferences.cpp:634
 msgctxt "Icon size"
 msgid "Larger"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:616
+#: ../src/ui/dialog/inkscape-preferences.cpp:634
 msgctxt "Icon size"
 msgid "Large"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:616
+#: ../src/ui/dialog/inkscape-preferences.cpp:634
 msgctxt "Icon size"
 msgid "Small"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:616
+#: ../src/ui/dialog/inkscape-preferences.cpp:634
 msgctxt "Icon size"
 msgid "Smaller"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:621
+#: ../src/ui/dialog/inkscape-preferences.cpp:639
 msgid "Toolbox icon size:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:622
+#: ../src/ui/dialog/inkscape-preferences.cpp:640
 msgid "Set the size for the tool icons (requires restart)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:625
+#: ../src/ui/dialog/inkscape-preferences.cpp:643
 msgid "Control bar icon size:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:626
+#: ../src/ui/dialog/inkscape-preferences.cpp:644
 msgid ""
 "Set the size for the icons in tools' control bars to use (requires restart)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:629
+#: ../src/ui/dialog/inkscape-preferences.cpp:647
 msgid "Secondary toolbar icon size:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:630
+#: ../src/ui/dialog/inkscape-preferences.cpp:648
 msgid ""
 "Set the size for the icons in secondary toolbars to use (requires restart)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:633
+#: ../src/ui/dialog/inkscape-preferences.cpp:651
 msgid "Work-around color sliders not drawing"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:635
+#: ../src/ui/dialog/inkscape-preferences.cpp:653
 msgid ""
 "When on, will attempt to work around bugs in certain GTK themes drawing "
 "color sliders"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:640
+#: ../src/ui/dialog/inkscape-preferences.cpp:658
 msgid "Clear list"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:643
+#: ../src/ui/dialog/inkscape-preferences.cpp:661
 msgid "Maximum documents in Open _Recent:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:644
+#: ../src/ui/dialog/inkscape-preferences.cpp:662
 msgid ""
 "Set the maximum length of the Open Recent list in the File menu, or clear "
 "the list"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:647
+#: ../src/ui/dialog/inkscape-preferences.cpp:665
 msgid "_Zoom correction factor (in %):"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:648
+#: ../src/ui/dialog/inkscape-preferences.cpp:666
 msgid ""
 "Adjust the slider until the length of the ruler on your screen matches its "
 "real length. This information is used when zooming to 1:1, 1:2, etc., to "
@@ -18279,327 +18287,327 @@ msgid ""
 msgstr ""
 
 #. show infobox
-#: ../src/ui/dialog/inkscape-preferences.cpp:651
+#: ../src/ui/dialog/inkscape-preferences.cpp:669
 msgid "Show filter primitives infobox (requires restart)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:653
+#: ../src/ui/dialog/inkscape-preferences.cpp:671
 msgid ""
 "Show icons and descriptions for the filter primitives available at the "
 "filter effects dialog"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:656
-#: ../src/ui/dialog/inkscape-preferences.cpp:664
+#: ../src/ui/dialog/inkscape-preferences.cpp:674
+#: ../src/ui/dialog/inkscape-preferences.cpp:682
 msgid "Icons only"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:656
-#: ../src/ui/dialog/inkscape-preferences.cpp:664
+#: ../src/ui/dialog/inkscape-preferences.cpp:674
+#: ../src/ui/dialog/inkscape-preferences.cpp:682
 msgid "Text only"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:656
-#: ../src/ui/dialog/inkscape-preferences.cpp:664
+#: ../src/ui/dialog/inkscape-preferences.cpp:674
+#: ../src/ui/dialog/inkscape-preferences.cpp:682
 msgid "Icons and text"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:661
+#: ../src/ui/dialog/inkscape-preferences.cpp:679
 msgid "Dockbar style (requires restart):"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:662
+#: ../src/ui/dialog/inkscape-preferences.cpp:680
 msgid ""
 "Selects whether the vertical bars on the dockbar will show text labels, "
 "icons, or both"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:669
+#: ../src/ui/dialog/inkscape-preferences.cpp:687
 msgid "Switcher style (requires restart):"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:670
+#: ../src/ui/dialog/inkscape-preferences.cpp:688
 msgid ""
 "Selects whether the dockbar switcher will show text labels, icons, or both"
 msgstr ""
 
 #. Windows
-#: ../src/ui/dialog/inkscape-preferences.cpp:674
+#: ../src/ui/dialog/inkscape-preferences.cpp:692
 msgid "Save and restore window geometry for each document"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:675
+#: ../src/ui/dialog/inkscape-preferences.cpp:693
 msgid "Remember and use last window's geometry"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:676
+#: ../src/ui/dialog/inkscape-preferences.cpp:694
 msgid "Don't save window geometry"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:678
+#: ../src/ui/dialog/inkscape-preferences.cpp:696
 msgid "Save and restore dialogs status"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:679
-#: ../src/ui/dialog/inkscape-preferences.cpp:715
+#: ../src/ui/dialog/inkscape-preferences.cpp:697
+#: ../src/ui/dialog/inkscape-preferences.cpp:733
 msgid "Don't save dialogs status"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:681
-#: ../src/ui/dialog/inkscape-preferences.cpp:723
+#: ../src/ui/dialog/inkscape-preferences.cpp:699
+#: ../src/ui/dialog/inkscape-preferences.cpp:741
 msgid "Dockable"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:685
+#: ../src/ui/dialog/inkscape-preferences.cpp:703
 msgid "Native open/save dialogs"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:686
+#: ../src/ui/dialog/inkscape-preferences.cpp:704
 msgid "GTK open/save dialogs"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:688
+#: ../src/ui/dialog/inkscape-preferences.cpp:706
 msgid "Dialogs are hidden in taskbar"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:689
+#: ../src/ui/dialog/inkscape-preferences.cpp:707
 msgid "Save and restore documents viewport"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:690
+#: ../src/ui/dialog/inkscape-preferences.cpp:708
 msgid "Zoom when window is resized"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:691
+#: ../src/ui/dialog/inkscape-preferences.cpp:709
 msgid "Show close button on dialogs"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:692
+#: ../src/ui/dialog/inkscape-preferences.cpp:710
 msgctxt "Dialog on top"
 msgid "None"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:694
+#: ../src/ui/dialog/inkscape-preferences.cpp:712
 msgid "Aggressive"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:697
+#: ../src/ui/dialog/inkscape-preferences.cpp:715
 msgctxt "Window size"
 msgid "Small"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:697
+#: ../src/ui/dialog/inkscape-preferences.cpp:715
 msgctxt "Window size"
 msgid "Large"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:697
+#: ../src/ui/dialog/inkscape-preferences.cpp:715
 msgctxt "Window size"
 msgid "Maximized"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:701
+#: ../src/ui/dialog/inkscape-preferences.cpp:719
 msgid "Default window size:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:702
+#: ../src/ui/dialog/inkscape-preferences.cpp:720
 msgid "Set the default window size"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:705
+#: ../src/ui/dialog/inkscape-preferences.cpp:723
 msgid "Saving window geometry (size and position)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:707
+#: ../src/ui/dialog/inkscape-preferences.cpp:725
 msgid "Let the window manager determine placement of all windows"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:709
+#: ../src/ui/dialog/inkscape-preferences.cpp:727
 msgid ""
 "Remember and use the last window's geometry (saves geometry to user "
 "preferences)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:711
+#: ../src/ui/dialog/inkscape-preferences.cpp:729
 msgid ""
 "Save and restore window geometry for each document (saves geometry in the "
 "document)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:713
+#: ../src/ui/dialog/inkscape-preferences.cpp:731
 msgid "Saving dialogs status"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:717
+#: ../src/ui/dialog/inkscape-preferences.cpp:735
 msgid ""
 "Save and restore dialogs status (the last open windows dialogs are saved "
 "when it closes)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:721
+#: ../src/ui/dialog/inkscape-preferences.cpp:739
 msgid "Dialog behavior (requires restart)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:727
+#: ../src/ui/dialog/inkscape-preferences.cpp:745
 msgid "Desktop integration"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:729
+#: ../src/ui/dialog/inkscape-preferences.cpp:747
 msgid "Use Windows like open and save dialogs"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:731
+#: ../src/ui/dialog/inkscape-preferences.cpp:749
 msgid "Use GTK open and save dialogs "
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:735
+#: ../src/ui/dialog/inkscape-preferences.cpp:753
 msgid "Dialogs on top:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:738
+#: ../src/ui/dialog/inkscape-preferences.cpp:756
 msgid "Dialogs are treated as regular windows"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:740
+#: ../src/ui/dialog/inkscape-preferences.cpp:758
 msgid "Dialogs stay on top of document windows"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:742
+#: ../src/ui/dialog/inkscape-preferences.cpp:760
 msgid "Same as Normal but may work better with some window managers"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:745
+#: ../src/ui/dialog/inkscape-preferences.cpp:763
 msgid "Dialog Transparency"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:747
+#: ../src/ui/dialog/inkscape-preferences.cpp:765
 msgid "_Opacity when focused:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:749
+#: ../src/ui/dialog/inkscape-preferences.cpp:767
 msgid "Opacity when _unfocused:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:751
+#: ../src/ui/dialog/inkscape-preferences.cpp:769
 msgid "_Time of opacity change animation:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:754
+#: ../src/ui/dialog/inkscape-preferences.cpp:772
 msgid "Miscellaneous"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:757
+#: ../src/ui/dialog/inkscape-preferences.cpp:775
 msgid "Whether dialog windows are to be hidden in the window manager taskbar"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:760
+#: ../src/ui/dialog/inkscape-preferences.cpp:778
 msgid ""
 "Zoom drawing when document window is resized, to keep the same area visible "
 "(this is the default which can be changed in any window using the button "
 "above the right scrollbar)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:762
+#: ../src/ui/dialog/inkscape-preferences.cpp:780
 msgid ""
 "Save documents viewport (zoom and panning position). Useful to turn off when "
 "sharing version controlled files."
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:764
+#: ../src/ui/dialog/inkscape-preferences.cpp:782
 msgid "Whether dialog windows have a close button (requires restart)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:765
+#: ../src/ui/dialog/inkscape-preferences.cpp:783
 msgid "Windows"
 msgstr ""
 
 #. Grids
-#: ../src/ui/dialog/inkscape-preferences.cpp:768
+#: ../src/ui/dialog/inkscape-preferences.cpp:786
 msgid "Line color when zooming out"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:771
+#: ../src/ui/dialog/inkscape-preferences.cpp:789
 msgid "The gridlines will be shown in minor grid line color"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:773
+#: ../src/ui/dialog/inkscape-preferences.cpp:791
 msgid "The gridlines will be shown in major grid line color"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:775
+#: ../src/ui/dialog/inkscape-preferences.cpp:793
 msgid "Default grid settings"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:781
-#: ../src/ui/dialog/inkscape-preferences.cpp:806
+#: ../src/ui/dialog/inkscape-preferences.cpp:799
+#: ../src/ui/dialog/inkscape-preferences.cpp:824
 msgid "Grid units:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:786
-#: ../src/ui/dialog/inkscape-preferences.cpp:811
+#: ../src/ui/dialog/inkscape-preferences.cpp:804
+#: ../src/ui/dialog/inkscape-preferences.cpp:829
 msgid "Origin X:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:787
-#: ../src/ui/dialog/inkscape-preferences.cpp:812
+#: ../src/ui/dialog/inkscape-preferences.cpp:805
+#: ../src/ui/dialog/inkscape-preferences.cpp:830
 msgid "Origin Y:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:792
+#: ../src/ui/dialog/inkscape-preferences.cpp:810
 msgid "Spacing X:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:793
-#: ../src/ui/dialog/inkscape-preferences.cpp:815
+#: ../src/ui/dialog/inkscape-preferences.cpp:811
+#: ../src/ui/dialog/inkscape-preferences.cpp:833
 msgid "Spacing Y:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:795
-#: ../src/ui/dialog/inkscape-preferences.cpp:796
-#: ../src/ui/dialog/inkscape-preferences.cpp:820
-#: ../src/ui/dialog/inkscape-preferences.cpp:821
+#: ../src/ui/dialog/inkscape-preferences.cpp:813
+#: ../src/ui/dialog/inkscape-preferences.cpp:814
+#: ../src/ui/dialog/inkscape-preferences.cpp:838
+#: ../src/ui/dialog/inkscape-preferences.cpp:839
 msgid "Minor grid line color:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:796
-#: ../src/ui/dialog/inkscape-preferences.cpp:821
+#: ../src/ui/dialog/inkscape-preferences.cpp:814
+#: ../src/ui/dialog/inkscape-preferences.cpp:839
 msgid "Color used for normal grid lines"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:797
-#: ../src/ui/dialog/inkscape-preferences.cpp:798
-#: ../src/ui/dialog/inkscape-preferences.cpp:822
-#: ../src/ui/dialog/inkscape-preferences.cpp:823
+#: ../src/ui/dialog/inkscape-preferences.cpp:815
+#: ../src/ui/dialog/inkscape-preferences.cpp:816
+#: ../src/ui/dialog/inkscape-preferences.cpp:840
+#: ../src/ui/dialog/inkscape-preferences.cpp:841
 msgid "Major grid line color:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:798
-#: ../src/ui/dialog/inkscape-preferences.cpp:823
+#: ../src/ui/dialog/inkscape-preferences.cpp:816
+#: ../src/ui/dialog/inkscape-preferences.cpp:841
 msgid "Color used for major (highlighted) grid lines"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:800
-#: ../src/ui/dialog/inkscape-preferences.cpp:825
+#: ../src/ui/dialog/inkscape-preferences.cpp:818
+#: ../src/ui/dialog/inkscape-preferences.cpp:843
 msgid "Major grid line every:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:801
+#: ../src/ui/dialog/inkscape-preferences.cpp:819
 msgid "Show dots instead of lines"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:802
+#: ../src/ui/dialog/inkscape-preferences.cpp:820
 msgid "If set, display dots at gridpoints instead of gridlines"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:883
+#: ../src/ui/dialog/inkscape-preferences.cpp:901
 msgid "Input/Output"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:886
+#: ../src/ui/dialog/inkscape-preferences.cpp:904
 msgid "Use current directory for \"Save As ...\""
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:888
+#: ../src/ui/dialog/inkscape-preferences.cpp:906
 msgid ""
 "When this option is on, the \"Save as...\" and \"Save a Copy...\" dialogs "
 "will always open in the directory where the currently open document is; when "
@@ -18607,176 +18615,176 @@ msgid ""
 "it"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:890
+#: ../src/ui/dialog/inkscape-preferences.cpp:908
 msgid "Add label comments to printing output"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:892
+#: ../src/ui/dialog/inkscape-preferences.cpp:910
 msgid ""
 "When on, a comment will be added to the raw print output, marking the "
 "rendered output for an object with its label"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:894
+#: ../src/ui/dialog/inkscape-preferences.cpp:912
 msgid "Add default metadata to new documents"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:896
+#: ../src/ui/dialog/inkscape-preferences.cpp:914
 msgid ""
 "Add default metadata to new documents. Default metadata can be set from "
 "Document Properties->Metadata."
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:900
+#: ../src/ui/dialog/inkscape-preferences.cpp:918
 msgid "_Grab sensitivity:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:900
+#: ../src/ui/dialog/inkscape-preferences.cpp:918
 msgid "pixels (requires restart)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:901
+#: ../src/ui/dialog/inkscape-preferences.cpp:919
 msgid ""
 "How close on the screen you need to be to an object to be able to grab it "
 "with mouse (in screen pixels)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:903
+#: ../src/ui/dialog/inkscape-preferences.cpp:921
 msgid "_Click/drag threshold:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:903
-#: ../src/ui/dialog/inkscape-preferences.cpp:1245
-#: ../src/ui/dialog/inkscape-preferences.cpp:1249
-#: ../src/ui/dialog/inkscape-preferences.cpp:1259
+#: ../src/ui/dialog/inkscape-preferences.cpp:921
+#: ../src/ui/dialog/inkscape-preferences.cpp:1263
+#: ../src/ui/dialog/inkscape-preferences.cpp:1267
+#: ../src/ui/dialog/inkscape-preferences.cpp:1277
 msgid "pixels"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:904
+#: ../src/ui/dialog/inkscape-preferences.cpp:922
 msgid ""
 "Maximum mouse drag (in screen pixels) which is considered a click, not a drag"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:907
+#: ../src/ui/dialog/inkscape-preferences.cpp:925
 msgid "_Handle size:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:908
+#: ../src/ui/dialog/inkscape-preferences.cpp:926
 msgid "Set the relative size of node handles"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:910
+#: ../src/ui/dialog/inkscape-preferences.cpp:928
 msgid "Use pressure-sensitive tablet (requires restart)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:912
+#: ../src/ui/dialog/inkscape-preferences.cpp:930
 msgid ""
 "Use the capabilities of a tablet or other pressure-sensitive device. Disable "
 "this only if you have problems with the tablet (you can still use it as a "
 "mouse)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:914
+#: ../src/ui/dialog/inkscape-preferences.cpp:932
 msgid "Switch tool based on tablet device (requires restart)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:916
+#: ../src/ui/dialog/inkscape-preferences.cpp:934
 msgid ""
 "Change tool as different devices are used on the tablet (pen, eraser, mouse)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:917
+#: ../src/ui/dialog/inkscape-preferences.cpp:935
 msgid "Input devices"
 msgstr ""
 
 #. SVG output options
-#: ../src/ui/dialog/inkscape-preferences.cpp:920
+#: ../src/ui/dialog/inkscape-preferences.cpp:938
 msgid "Use named colors"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:921
+#: ../src/ui/dialog/inkscape-preferences.cpp:939
 msgid ""
 "If set, write the CSS name of the color when available (e.g. 'red' or "
 "'magenta') instead of the numeric value"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:923
+#: ../src/ui/dialog/inkscape-preferences.cpp:941
 msgid "XML formatting"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:925
+#: ../src/ui/dialog/inkscape-preferences.cpp:943
 msgid "Inline attributes"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:926
+#: ../src/ui/dialog/inkscape-preferences.cpp:944
 msgid "Put attributes on the same line as the element tag"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:929
+#: ../src/ui/dialog/inkscape-preferences.cpp:947
 msgid "_Indent, spaces:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:929
+#: ../src/ui/dialog/inkscape-preferences.cpp:947
 msgid ""
 "The number of spaces to use for indenting nested elements; set to 0 for no "
 "indentation"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:931
+#: ../src/ui/dialog/inkscape-preferences.cpp:949
 msgid "Path data"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:934
+#: ../src/ui/dialog/inkscape-preferences.cpp:952
 msgid "Absolute"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:934
+#: ../src/ui/dialog/inkscape-preferences.cpp:952
 msgid "Relative"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:934
-#: ../src/ui/dialog/inkscape-preferences.cpp:1224
+#: ../src/ui/dialog/inkscape-preferences.cpp:952
+#: ../src/ui/dialog/inkscape-preferences.cpp:1242
 msgid "Optimized"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:938
+#: ../src/ui/dialog/inkscape-preferences.cpp:956
 msgid "Path string format:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:938
+#: ../src/ui/dialog/inkscape-preferences.cpp:956
 msgid ""
 "Path data should be written: only with absolute coordinates, only with "
 "relative coordinates, or optimized for string length (mixed absolute and "
 "relative coordinates)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:940
+#: ../src/ui/dialog/inkscape-preferences.cpp:958
 msgid "Force repeat commands"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:941
+#: ../src/ui/dialog/inkscape-preferences.cpp:959
 msgid ""
 "Force repeating of the same path command (for example, 'L 1,2 L 3,4' instead "
 "of 'L 1,2 3,4')"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:943
+#: ../src/ui/dialog/inkscape-preferences.cpp:961
 msgid "Numbers"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:946
+#: ../src/ui/dialog/inkscape-preferences.cpp:964
 msgid "_Numeric precision:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:946
+#: ../src/ui/dialog/inkscape-preferences.cpp:964
 msgid "Significant figures of the values written to the SVG file"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:949
+#: ../src/ui/dialog/inkscape-preferences.cpp:967
 msgid "Minimum _exponent:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:949
+#: ../src/ui/dialog/inkscape-preferences.cpp:967
 msgid ""
 "The smallest number written to SVG is 10 to the power of this exponent; "
 "anything smaller is written as zero"
@@ -18784,56 +18792,56 @@ msgstr ""
 
 #. Code to add controls for attribute checking options
 #. Add incorrect style properties options
-#: ../src/ui/dialog/inkscape-preferences.cpp:954
+#: ../src/ui/dialog/inkscape-preferences.cpp:972
 msgid "Improper Attributes Actions"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:956
-#: ../src/ui/dialog/inkscape-preferences.cpp:964
-#: ../src/ui/dialog/inkscape-preferences.cpp:972
+#: ../src/ui/dialog/inkscape-preferences.cpp:974
+#: ../src/ui/dialog/inkscape-preferences.cpp:982
+#: ../src/ui/dialog/inkscape-preferences.cpp:990
 msgid "Print warnings"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:957
+#: ../src/ui/dialog/inkscape-preferences.cpp:975
 msgid ""
 "Print warning if invalid or non-useful attributes found. Database files "
 "located in inkscape_data_dir/attributes."
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:958
+#: ../src/ui/dialog/inkscape-preferences.cpp:976
 msgid "Remove attributes"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:959
+#: ../src/ui/dialog/inkscape-preferences.cpp:977
 msgid "Delete invalid or non-useful attributes from element tag"
 msgstr ""
 
 #. Add incorrect style properties options
-#: ../src/ui/dialog/inkscape-preferences.cpp:962
+#: ../src/ui/dialog/inkscape-preferences.cpp:980
 msgid "Inappropriate Style Properties Actions"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:965
+#: ../src/ui/dialog/inkscape-preferences.cpp:983
 msgid ""
 "Print warning if inappropriate style properties found (i.e. 'font-family' "
 "set on a <rect>). Database files located in inkscape_data_dir/attributes."
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:966
-#: ../src/ui/dialog/inkscape-preferences.cpp:974
+#: ../src/ui/dialog/inkscape-preferences.cpp:984
+#: ../src/ui/dialog/inkscape-preferences.cpp:992
 msgid "Remove style properties"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:967
+#: ../src/ui/dialog/inkscape-preferences.cpp:985
 msgid "Delete inappropriate style properties"
 msgstr ""
 
 #. Add default or inherited style properties options
-#: ../src/ui/dialog/inkscape-preferences.cpp:970
+#: ../src/ui/dialog/inkscape-preferences.cpp:988
 msgid "Non-useful Style Properties Actions"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:973
+#: ../src/ui/dialog/inkscape-preferences.cpp:991
 msgid ""
 "Print warning if redundant style properties found (i.e. if a property has "
 "the default value and a different value is not inherited or if value is the "
@@ -18841,207 +18849,207 @@ msgid ""
 "attributes."
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:975
+#: ../src/ui/dialog/inkscape-preferences.cpp:993
 msgid "Delete redundant style properties"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:977
+#: ../src/ui/dialog/inkscape-preferences.cpp:995
 msgid "Check Attributes and Style Properties on"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:979
+#: ../src/ui/dialog/inkscape-preferences.cpp:997
 msgid "Reading"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:980
+#: ../src/ui/dialog/inkscape-preferences.cpp:998
 msgid ""
 "Check attributes and style properties on reading in SVG files (including "
 "those internal to Inkscape which will slow down startup)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:981
+#: ../src/ui/dialog/inkscape-preferences.cpp:999
 msgid "Editing"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:982
+#: ../src/ui/dialog/inkscape-preferences.cpp:1000
 msgid ""
 "Check attributes and style properties while editing SVG files (may slow down "
 "Inkscape, mostly useful for debugging)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:983
+#: ../src/ui/dialog/inkscape-preferences.cpp:1001
 msgid "Writing"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:984
+#: ../src/ui/dialog/inkscape-preferences.cpp:1002
 msgid "Check attributes and style properties on writing out SVG files"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:986
+#: ../src/ui/dialog/inkscape-preferences.cpp:1004
 msgid "SVG output"
 msgstr ""
 
 #. TRANSLATORS: see http://www.newsandtech.com/issues/2004/03-04/pt/03-04_rendering.htm
-#: ../src/ui/dialog/inkscape-preferences.cpp:992
+#: ../src/ui/dialog/inkscape-preferences.cpp:1010
 msgid "Perceptual"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:992
+#: ../src/ui/dialog/inkscape-preferences.cpp:1010
 msgid "Relative Colorimetric"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:992
+#: ../src/ui/dialog/inkscape-preferences.cpp:1010
 msgid "Absolute Colorimetric"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:996
+#: ../src/ui/dialog/inkscape-preferences.cpp:1014
 msgid "(Note: Color management has been disabled in this build)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1000
+#: ../src/ui/dialog/inkscape-preferences.cpp:1018
 msgid "Display adjustment"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1010
+#: ../src/ui/dialog/inkscape-preferences.cpp:1028
 #, c-format
 msgid ""
 "The ICC profile to use to calibrate display output.\n"
 "Searched directories:%s"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1011
+#: ../src/ui/dialog/inkscape-preferences.cpp:1029
 msgid "Display profile:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1016
+#: ../src/ui/dialog/inkscape-preferences.cpp:1034
 msgid "Retrieve profile from display"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1019
+#: ../src/ui/dialog/inkscape-preferences.cpp:1037
 msgid "Retrieve profiles from those attached to displays via XICC"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1021
+#: ../src/ui/dialog/inkscape-preferences.cpp:1039
 msgid "Retrieve profiles from those attached to displays"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1026
+#: ../src/ui/dialog/inkscape-preferences.cpp:1044
 msgid "Display rendering intent:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1027
+#: ../src/ui/dialog/inkscape-preferences.cpp:1045
 msgid "The rendering intent to use to calibrate display output"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1029
+#: ../src/ui/dialog/inkscape-preferences.cpp:1047
 msgid "Proofing"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1031
+#: ../src/ui/dialog/inkscape-preferences.cpp:1049
 msgid "Simulate output on screen"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1033
+#: ../src/ui/dialog/inkscape-preferences.cpp:1051
 msgid "Simulates output of target device"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1035
+#: ../src/ui/dialog/inkscape-preferences.cpp:1053
 msgid "Mark out of gamut colors"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1037
+#: ../src/ui/dialog/inkscape-preferences.cpp:1055
 msgid "Highlights colors that are out of gamut for the target device"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1049
+#: ../src/ui/dialog/inkscape-preferences.cpp:1067
 msgid "Out of gamut warning color:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1050
+#: ../src/ui/dialog/inkscape-preferences.cpp:1068
 msgid "Selects the color used for out of gamut warning"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1052
+#: ../src/ui/dialog/inkscape-preferences.cpp:1070
 msgid "Device profile:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1053
+#: ../src/ui/dialog/inkscape-preferences.cpp:1071
 msgid "The ICC profile to use to simulate device output"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1056
+#: ../src/ui/dialog/inkscape-preferences.cpp:1074
 msgid "Device rendering intent:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1057
+#: ../src/ui/dialog/inkscape-preferences.cpp:1075
 msgid "The rendering intent to use to calibrate device output"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1059
+#: ../src/ui/dialog/inkscape-preferences.cpp:1077
 msgid "Black point compensation"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1061
+#: ../src/ui/dialog/inkscape-preferences.cpp:1079
 msgid "Enables black point compensation"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1063
+#: ../src/ui/dialog/inkscape-preferences.cpp:1081
 msgid "Preserve black"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1070
+#: ../src/ui/dialog/inkscape-preferences.cpp:1088
 msgid "(LittleCMS 1.15 or later required)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1072
+#: ../src/ui/dialog/inkscape-preferences.cpp:1090
 msgid "Preserve K channel in CMYK -> CMYK transforms"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1086
+#: ../src/ui/dialog/inkscape-preferences.cpp:1104
 #: ../src/ui/widget/color-icc-selector.cpp:394
 #: ../src/ui/widget/color-icc-selector.cpp:700
 msgid "<none>"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1131
+#: ../src/ui/dialog/inkscape-preferences.cpp:1149
 msgid "Color management"
 msgstr ""
 
 #. Autosave options
-#: ../src/ui/dialog/inkscape-preferences.cpp:1134
+#: ../src/ui/dialog/inkscape-preferences.cpp:1152
 msgid "Enable autosave (requires restart)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1135
+#: ../src/ui/dialog/inkscape-preferences.cpp:1153
 msgid ""
 "Automatically save the current document(s) at a given interval, thus "
 "minimizing loss in case of a crash"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1141
+#: ../src/ui/dialog/inkscape-preferences.cpp:1159
 msgctxt "Filesystem"
 msgid "Autosave _directory:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1141
+#: ../src/ui/dialog/inkscape-preferences.cpp:1159
 msgid ""
 "The directory where autosaves will be written. This should be an absolute "
 "path (starts with / on UNIX or a drive letter such as C: on Windows). "
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1143
+#: ../src/ui/dialog/inkscape-preferences.cpp:1161
 msgid "_Interval (in minutes):"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1143
+#: ../src/ui/dialog/inkscape-preferences.cpp:1161
 msgid "Interval (in minutes) at which document will be autosaved"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1145
+#: ../src/ui/dialog/inkscape-preferences.cpp:1163
 msgid "_Maximum number of autosaves:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1145
+#: ../src/ui/dialog/inkscape-preferences.cpp:1163
 msgid ""
 "Maximum number of autosaved files; use this to limit the storage space used"
 msgstr ""
@@ -19058,508 +19066,508 @@ msgstr ""
 #. _autosave_autosave_interval.signal_changed().connect( sigc::ptr_fun(inkscape_autosave_init), TRUE );
 #.
 #. -----------
-#: ../src/ui/dialog/inkscape-preferences.cpp:1160
+#: ../src/ui/dialog/inkscape-preferences.cpp:1178
 msgid "Autosave"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1164
+#: ../src/ui/dialog/inkscape-preferences.cpp:1182
 msgid "Open Clip Art Library _Server Name:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1165
+#: ../src/ui/dialog/inkscape-preferences.cpp:1183
 msgid ""
 "The server name of the Open Clip Art Library webdav server; it's used by the "
 "Import and Export to OCAL function"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1167
+#: ../src/ui/dialog/inkscape-preferences.cpp:1185
 msgid "Open Clip Art Library _Username:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1168
+#: ../src/ui/dialog/inkscape-preferences.cpp:1186
 msgid "The username used to log into Open Clip Art Library"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1170
+#: ../src/ui/dialog/inkscape-preferences.cpp:1188
 msgid "Open Clip Art Library _Password:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1171
+#: ../src/ui/dialog/inkscape-preferences.cpp:1189
 msgid "The password used to log into Open Clip Art Library"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1172
+#: ../src/ui/dialog/inkscape-preferences.cpp:1190
 msgid "Open Clip Art"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1177
+#: ../src/ui/dialog/inkscape-preferences.cpp:1195
 msgid "Behavior"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1181
+#: ../src/ui/dialog/inkscape-preferences.cpp:1199
 msgid "_Simplification threshold:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1182
+#: ../src/ui/dialog/inkscape-preferences.cpp:1200
 msgid ""
 "How strong is the Node tool's Simplify command by default. If you invoke "
 "this command several times in quick succession, it will act more and more "
 "aggressively; invoking it again after a pause restores the default threshold."
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1184
+#: ../src/ui/dialog/inkscape-preferences.cpp:1202
 msgid "Color stock markers the same color as object"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1185
+#: ../src/ui/dialog/inkscape-preferences.cpp:1203
 msgid "Color custom markers the same color as object"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1186
-#: ../src/ui/dialog/inkscape-preferences.cpp:1406
+#: ../src/ui/dialog/inkscape-preferences.cpp:1204
+#: ../src/ui/dialog/inkscape-preferences.cpp:1424
 msgid "Update marker color when object color changes"
 msgstr ""
 
 #. Selecting options
-#: ../src/ui/dialog/inkscape-preferences.cpp:1189
+#: ../src/ui/dialog/inkscape-preferences.cpp:1207
 msgid "Select in all layers"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1190
+#: ../src/ui/dialog/inkscape-preferences.cpp:1208
 msgid "Select only within current layer"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1191
+#: ../src/ui/dialog/inkscape-preferences.cpp:1209
 msgid "Select in current layer and sublayers"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1192
+#: ../src/ui/dialog/inkscape-preferences.cpp:1210
 msgid "Ignore hidden objects and layers"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1193
+#: ../src/ui/dialog/inkscape-preferences.cpp:1211
 msgid "Ignore locked objects and layers"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1194
+#: ../src/ui/dialog/inkscape-preferences.cpp:1212
 msgid "Deselect upon layer change"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1197
+#: ../src/ui/dialog/inkscape-preferences.cpp:1215
 msgid ""
 "Uncheck this to be able to keep the current objects selected when the "
 "current layer changes"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1199
+#: ../src/ui/dialog/inkscape-preferences.cpp:1217
 msgid "Ctrl+A, Tab, Shift+Tab"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1201
+#: ../src/ui/dialog/inkscape-preferences.cpp:1219
 msgid "Make keyboard selection commands work on objects in all layers"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1203
+#: ../src/ui/dialog/inkscape-preferences.cpp:1221
 msgid "Make keyboard selection commands work on objects in current layer only"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1205
+#: ../src/ui/dialog/inkscape-preferences.cpp:1223
 msgid ""
 "Make keyboard selection commands work on objects in current layer and all "
 "its sublayers"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1207
+#: ../src/ui/dialog/inkscape-preferences.cpp:1225
 msgid ""
 "Uncheck this to be able to select objects that are hidden (either by "
 "themselves or by being in a hidden layer)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1209
+#: ../src/ui/dialog/inkscape-preferences.cpp:1227
 msgid ""
 "Uncheck this to be able to select objects that are locked (either by "
 "themselves or by being in a locked layer)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1211
+#: ../src/ui/dialog/inkscape-preferences.cpp:1229
 msgid "Wrap when cycling objects in z-order"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1213
+#: ../src/ui/dialog/inkscape-preferences.cpp:1231
 msgid "Alt+Scroll Wheel"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1215
+#: ../src/ui/dialog/inkscape-preferences.cpp:1233
 msgid "Wrap around at start and end when cycling objects in z-order"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1217
+#: ../src/ui/dialog/inkscape-preferences.cpp:1235
 msgid "Selecting"
 msgstr ""
 
 #. Transforms options
-#: ../src/ui/dialog/inkscape-preferences.cpp:1220
+#: ../src/ui/dialog/inkscape-preferences.cpp:1238
 #: ../src/widgets/select-toolbar.cpp:564
 msgid "Scale stroke width"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1221
+#: ../src/ui/dialog/inkscape-preferences.cpp:1239
 msgid "Scale rounded corners in rectangles"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1222
+#: ../src/ui/dialog/inkscape-preferences.cpp:1240
 msgid "Transform gradients"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1223
+#: ../src/ui/dialog/inkscape-preferences.cpp:1241
 msgid "Transform patterns"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1225
+#: ../src/ui/dialog/inkscape-preferences.cpp:1243
 msgid "Preserved"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1228
+#: ../src/ui/dialog/inkscape-preferences.cpp:1246
 #: ../src/widgets/select-toolbar.cpp:565
 msgid "When scaling objects, scale the stroke width by the same proportion"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1230
+#: ../src/ui/dialog/inkscape-preferences.cpp:1248
 #: ../src/widgets/select-toolbar.cpp:576
 msgid "When scaling rectangles, scale the radii of rounded corners"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1232
+#: ../src/ui/dialog/inkscape-preferences.cpp:1250
 #: ../src/widgets/select-toolbar.cpp:587
 msgid "Move gradients (in fill or stroke) along with the objects"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1234
+#: ../src/ui/dialog/inkscape-preferences.cpp:1252
 #: ../src/widgets/select-toolbar.cpp:598
 msgid "Move patterns (in fill or stroke) along with the objects"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1235
+#: ../src/ui/dialog/inkscape-preferences.cpp:1253
 msgid "Store transformation"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1237
+#: ../src/ui/dialog/inkscape-preferences.cpp:1255
 msgid ""
 "If possible, apply transformation to objects without adding a transform= "
 "attribute"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1239
+#: ../src/ui/dialog/inkscape-preferences.cpp:1257
 msgid "Always store transformation as a transform= attribute on objects"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1241
+#: ../src/ui/dialog/inkscape-preferences.cpp:1259
 msgid "Transforms"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1245
+#: ../src/ui/dialog/inkscape-preferences.cpp:1263
 msgid "Mouse _wheel scrolls by:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1246
+#: ../src/ui/dialog/inkscape-preferences.cpp:1264
 msgid ""
 "One mouse wheel notch scrolls by this distance in screen pixels "
 "(horizontally with Shift)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1247
+#: ../src/ui/dialog/inkscape-preferences.cpp:1265
 msgid "Ctrl+arrows"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1249
+#: ../src/ui/dialog/inkscape-preferences.cpp:1267
 msgid "Sc_roll by:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1250
+#: ../src/ui/dialog/inkscape-preferences.cpp:1268
 msgid "Pressing Ctrl+arrow key scrolls by this distance (in screen pixels)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1252
+#: ../src/ui/dialog/inkscape-preferences.cpp:1270
 msgid "_Acceleration:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1253
+#: ../src/ui/dialog/inkscape-preferences.cpp:1271
 msgid ""
 "Pressing and holding Ctrl+arrow will gradually speed up scrolling (0 for no "
 "acceleration)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1254
+#: ../src/ui/dialog/inkscape-preferences.cpp:1272
 msgid "Autoscrolling"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1256
+#: ../src/ui/dialog/inkscape-preferences.cpp:1274
 msgid "_Speed:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1257
+#: ../src/ui/dialog/inkscape-preferences.cpp:1275
 msgid ""
 "How fast the canvas autoscrolls when you drag beyond canvas edge (0 to turn "
 "autoscroll off)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1259
+#: ../src/ui/dialog/inkscape-preferences.cpp:1277
 #: ../src/ui/dialog/tracedialog.cpp:522 ../src/ui/dialog/tracedialog.cpp:721
 msgid "_Threshold:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1260
+#: ../src/ui/dialog/inkscape-preferences.cpp:1278
 msgid ""
 "How far (in screen pixels) you need to be from the canvas edge to trigger "
 "autoscroll; positive is outside the canvas, negative is within the canvas"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1261
+#: ../src/ui/dialog/inkscape-preferences.cpp:1279
 msgid "Mouse move pans when Space is pressed"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1263
+#: ../src/ui/dialog/inkscape-preferences.cpp:1281
 msgid "When on, pressing and holding Space and dragging pans canvas"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1264
+#: ../src/ui/dialog/inkscape-preferences.cpp:1282
 msgid "Mouse wheel zooms by default"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1266
+#: ../src/ui/dialog/inkscape-preferences.cpp:1284
 msgid ""
 "When on, mouse wheel zooms without Ctrl and scrolls canvas with Ctrl; when "
 "off, it zooms with Ctrl and scrolls without Ctrl"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1267
+#: ../src/ui/dialog/inkscape-preferences.cpp:1285
 msgid "Scrolling"
 msgstr ""
 
 #. Snapping options
-#: ../src/ui/dialog/inkscape-preferences.cpp:1270
+#: ../src/ui/dialog/inkscape-preferences.cpp:1288
 msgid "Snap indicator"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1272
+#: ../src/ui/dialog/inkscape-preferences.cpp:1290
 msgid "Enable snap indicator"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1274
+#: ../src/ui/dialog/inkscape-preferences.cpp:1292
 msgid "After snapping, a symbol is drawn at the point that has snapped"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1279
+#: ../src/ui/dialog/inkscape-preferences.cpp:1297
 msgid "Snap indicator persistence (in seconds):"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1280
+#: ../src/ui/dialog/inkscape-preferences.cpp:1298
 msgid ""
 "Controls how long the snap indicator message will be shown, before it "
 "disappears"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1282
+#: ../src/ui/dialog/inkscape-preferences.cpp:1300
 msgid "What should snap"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1284
+#: ../src/ui/dialog/inkscape-preferences.cpp:1302
 msgid "Only snap the node closest to the pointer"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1286
+#: ../src/ui/dialog/inkscape-preferences.cpp:1304
 msgid ""
 "Only try to snap the node that is initially closest to the mouse pointer"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1289
+#: ../src/ui/dialog/inkscape-preferences.cpp:1307
 msgid "_Weight factor:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1290
+#: ../src/ui/dialog/inkscape-preferences.cpp:1308
 msgid ""
 "When multiple snap solutions are found, then Inkscape can either prefer the "
 "closest transformation (when set to 0), or prefer the node that was "
 "initially the closest to the pointer (when set to 1)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1292
+#: ../src/ui/dialog/inkscape-preferences.cpp:1310
 msgid "Snap the mouse pointer when dragging a constrained knot"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1294
+#: ../src/ui/dialog/inkscape-preferences.cpp:1312
 msgid ""
 "When dragging a knot along a constraint line, then snap the position of the "
 "mouse pointer instead of snapping the projection of the knot onto the "
 "constraint line"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1296
+#: ../src/ui/dialog/inkscape-preferences.cpp:1314
 msgid "Delayed snap"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1299
+#: ../src/ui/dialog/inkscape-preferences.cpp:1317
 msgid "Delay (in seconds):"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1300
+#: ../src/ui/dialog/inkscape-preferences.cpp:1318
 msgid ""
 "Postpone snapping as long as the mouse is moving, and then wait an "
 "additional fraction of a second. This additional delay is specified here. "
 "When set to zero or to a very small number, snapping will be immediate."
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1302
+#: ../src/ui/dialog/inkscape-preferences.cpp:1320
 msgid "Snapping"
 msgstr ""
 
 #. nudgedistance is limited to 1000 in select-context.cpp: use the same limit here
-#: ../src/ui/dialog/inkscape-preferences.cpp:1307
+#: ../src/ui/dialog/inkscape-preferences.cpp:1325
 msgid "_Arrow keys move by:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1308
+#: ../src/ui/dialog/inkscape-preferences.cpp:1326
 msgid ""
 "Pressing an arrow key moves selected object(s) or node(s) by this distance"
 msgstr ""
 
 #. defaultscale is limited to 1000 in select-context.cpp: use the same limit here
-#: ../src/ui/dialog/inkscape-preferences.cpp:1311
+#: ../src/ui/dialog/inkscape-preferences.cpp:1329
 msgid "> and < _scale by:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1312
+#: ../src/ui/dialog/inkscape-preferences.cpp:1330
 msgid "Pressing > or < scales selection up or down by this increment"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1314
+#: ../src/ui/dialog/inkscape-preferences.cpp:1332
 msgid "_Inset/Outset by:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1315
+#: ../src/ui/dialog/inkscape-preferences.cpp:1333
 msgid "Inset and Outset commands displace the path by this distance"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1316
+#: ../src/ui/dialog/inkscape-preferences.cpp:1334
 msgid "Compass-like display of angles"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1318
+#: ../src/ui/dialog/inkscape-preferences.cpp:1336
 msgid ""
 "When on, angles are displayed with 0 at north, 0 to 360 range, positive "
 "clockwise; otherwise with 0 at east, -180 to 180 range, positive "
 "counterclockwise"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1320
+#: ../src/ui/dialog/inkscape-preferences.cpp:1338
 msgctxt "Rotation angle"
 msgid "None"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1324
+#: ../src/ui/dialog/inkscape-preferences.cpp:1342
 msgid "_Rotation snaps every:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1324
+#: ../src/ui/dialog/inkscape-preferences.cpp:1342
 msgid "degrees"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1325
+#: ../src/ui/dialog/inkscape-preferences.cpp:1343
 msgid ""
 "Rotating with Ctrl pressed snaps every that much degrees; also, pressing "
 "[ or ] rotates by this amount"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1326
+#: ../src/ui/dialog/inkscape-preferences.cpp:1344
 msgid "Relative snapping of guideline angles"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1328
+#: ../src/ui/dialog/inkscape-preferences.cpp:1346
 msgid ""
 "When on, the snap angles when rotating a guideline will be relative to the "
 "original angle"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1330
+#: ../src/ui/dialog/inkscape-preferences.cpp:1348
 msgid "_Zoom in/out by:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1330
+#: ../src/ui/dialog/inkscape-preferences.cpp:1348
 #: ../src/ui/dialog/objects.cpp:1662
 #: ../src/ui/widget/filter-effect-chooser.cpp:27
 msgid "%"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1331
+#: ../src/ui/dialog/inkscape-preferences.cpp:1349
 msgid ""
 "Zoom tool click, +/- keys, and middle click zoom in and out by this "
 "multiplier"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1332
+#: ../src/ui/dialog/inkscape-preferences.cpp:1350
 msgid "Steps"
 msgstr ""
 
 #. Clones options
-#: ../src/ui/dialog/inkscape-preferences.cpp:1335
+#: ../src/ui/dialog/inkscape-preferences.cpp:1353
 msgid "Move in parallel"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1337
+#: ../src/ui/dialog/inkscape-preferences.cpp:1355
 msgid "Stay unmoved"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1339
+#: ../src/ui/dialog/inkscape-preferences.cpp:1357
 msgid "Move according to transform"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1341
+#: ../src/ui/dialog/inkscape-preferences.cpp:1359
 msgid "Are unlinked"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1343
+#: ../src/ui/dialog/inkscape-preferences.cpp:1361
 msgid "Are deleted"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1346
+#: ../src/ui/dialog/inkscape-preferences.cpp:1364
 msgid "Moving original: clones and linked offsets"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1348
+#: ../src/ui/dialog/inkscape-preferences.cpp:1366
 msgid "Clones are translated by the same vector as their original"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1350
+#: ../src/ui/dialog/inkscape-preferences.cpp:1368
 msgid "Clones preserve their positions when their original is moved"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1352
+#: ../src/ui/dialog/inkscape-preferences.cpp:1370
 msgid ""
 "Each clone moves according to the value of its transform= attribute; for "
 "example, a rotated clone will move in a different direction than its original"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1353
+#: ../src/ui/dialog/inkscape-preferences.cpp:1371
 msgid "Deleting original: clones"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1355
+#: ../src/ui/dialog/inkscape-preferences.cpp:1373
 msgid "Orphaned clones are converted to regular objects"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1357
+#: ../src/ui/dialog/inkscape-preferences.cpp:1375
 msgid "Orphaned clones are deleted along with their original"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1359
+#: ../src/ui/dialog/inkscape-preferences.cpp:1377
 msgid "Duplicating original+clones/linked offset"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1361
+#: ../src/ui/dialog/inkscape-preferences.cpp:1379
 msgid "Relink duplicated clones"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1363
+#: ../src/ui/dialog/inkscape-preferences.cpp:1381
 msgid ""
 "When duplicating a selection containing both a clone and its original "
 "(possibly in groups), relink the duplicated clone to the duplicated original "
@@ -19567,493 +19575,507 @@ msgid ""
 msgstr ""
 
 #. TRANSLATORS: Heading for the Inkscape Preferences "Clones" Page
-#: ../src/ui/dialog/inkscape-preferences.cpp:1366
+#: ../src/ui/dialog/inkscape-preferences.cpp:1384
 msgid "Clones"
 msgstr ""
 
 #. Clip paths and masks options
-#: ../src/ui/dialog/inkscape-preferences.cpp:1369
+#: ../src/ui/dialog/inkscape-preferences.cpp:1387
 msgid "When applying, use the topmost selected object as clippath/mask"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1371
+#: ../src/ui/dialog/inkscape-preferences.cpp:1389
 msgid ""
 "Uncheck this to use the bottom selected object as the clipping path or mask"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1372
+#: ../src/ui/dialog/inkscape-preferences.cpp:1390
 msgid "Remove clippath/mask object after applying"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1374
+#: ../src/ui/dialog/inkscape-preferences.cpp:1392
 msgid ""
 "After applying, remove the object used as the clipping path or mask from the "
 "drawing"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1376
+#: ../src/ui/dialog/inkscape-preferences.cpp:1394
 msgid "Before applying"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1378
+#: ../src/ui/dialog/inkscape-preferences.cpp:1396
 msgid "Do not group clipped/masked objects"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1379
+#: ../src/ui/dialog/inkscape-preferences.cpp:1397
 msgid "Put every clipped/masked object in its own group"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1380
+#: ../src/ui/dialog/inkscape-preferences.cpp:1398
 msgid "Put all clipped/masked objects into one group"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1383
+#: ../src/ui/dialog/inkscape-preferences.cpp:1401
 msgid "Apply clippath/mask to every object"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1386
+#: ../src/ui/dialog/inkscape-preferences.cpp:1404
 msgid "Apply clippath/mask to groups containing single object"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1389
+#: ../src/ui/dialog/inkscape-preferences.cpp:1407
 msgid "Apply clippath/mask to group containing all objects"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1391
+#: ../src/ui/dialog/inkscape-preferences.cpp:1409
 msgid "After releasing"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1393
+#: ../src/ui/dialog/inkscape-preferences.cpp:1411
 msgid "Ungroup automatically created groups"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1395
+#: ../src/ui/dialog/inkscape-preferences.cpp:1413
 msgid "Ungroup groups created when setting clip/mask"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1397
+#: ../src/ui/dialog/inkscape-preferences.cpp:1415
 msgid "Clippaths and masks"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1400
+#: ../src/ui/dialog/inkscape-preferences.cpp:1418
 msgid "Stroke Style Markers"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1402
-#: ../src/ui/dialog/inkscape-preferences.cpp:1404
+#: ../src/ui/dialog/inkscape-preferences.cpp:1420
+#: ../src/ui/dialog/inkscape-preferences.cpp:1422
 msgid ""
 "Stroke color same as object, fill color either object fill color or marker "
 "fill color"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1408
+#: ../src/ui/dialog/inkscape-preferences.cpp:1426
 #: ../share/extensions/hershey.inx.h:27
 msgid "Markers"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1411
+#: ../src/ui/dialog/inkscape-preferences.cpp:1429
 msgid "Document cleanup"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1412
-#: ../src/ui/dialog/inkscape-preferences.cpp:1414
+#: ../src/ui/dialog/inkscape-preferences.cpp:1430
+#: ../src/ui/dialog/inkscape-preferences.cpp:1432
 msgid "Remove unused swatches when doing a document cleanup"
 msgstr ""
 
 #. tooltip
-#: ../src/ui/dialog/inkscape-preferences.cpp:1415
+#: ../src/ui/dialog/inkscape-preferences.cpp:1433
 msgid "Cleanup"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1423
+#: ../src/ui/dialog/inkscape-preferences.cpp:1441
 msgid "Number of _Threads:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1423
-#: ../src/ui/dialog/inkscape-preferences.cpp:1963
+#: ../src/ui/dialog/inkscape-preferences.cpp:1441
+#: ../src/ui/dialog/inkscape-preferences.cpp:1985
 msgid "(requires restart)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1424
+#: ../src/ui/dialog/inkscape-preferences.cpp:1442
 msgid "Configure number of processors/threads to use when rendering filters"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1428
+#: ../src/ui/dialog/inkscape-preferences.cpp:1446
 msgid "Rendering _cache size:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1428
+#: ../src/ui/dialog/inkscape-preferences.cpp:1446
 msgctxt "mebibyte (2^20 bytes) abbreviation"
 msgid "MiB"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1428
+#: ../src/ui/dialog/inkscape-preferences.cpp:1446
 msgid ""
 "Set the amount of memory per document which can be used to store rendered "
 "parts of the drawing for later reuse; set to zero to disable caching"
 msgstr ""
 
+#: ../src/ui/dialog/inkscape-preferences.cpp:1450
+msgid "Rendering tile multiplier:"
+msgstr ""
+
+#: ../src/ui/dialog/inkscape-preferences.cpp:1450
+msgid "requires restart"
+msgstr ""
+
+#: ../src/ui/dialog/inkscape-preferences.cpp:1450
+msgid ""
+"Set the relative size of tiles used to render the canvas. The larger the "
+"value, the bigger the tile size."
+msgstr ""
+
 #. blur quality
 #. filter quality
-#: ../src/ui/dialog/inkscape-preferences.cpp:1431
-#: ../src/ui/dialog/inkscape-preferences.cpp:1455
+#: ../src/ui/dialog/inkscape-preferences.cpp:1453
+#: ../src/ui/dialog/inkscape-preferences.cpp:1477
 msgid "Best quality (slowest)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1433
-#: ../src/ui/dialog/inkscape-preferences.cpp:1457
+#: ../src/ui/dialog/inkscape-preferences.cpp:1455
+#: ../src/ui/dialog/inkscape-preferences.cpp:1479
 msgid "Better quality (slower)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1435
-#: ../src/ui/dialog/inkscape-preferences.cpp:1459
+#: ../src/ui/dialog/inkscape-preferences.cpp:1457
+#: ../src/ui/dialog/inkscape-preferences.cpp:1481
 msgid "Average quality"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1437
-#: ../src/ui/dialog/inkscape-preferences.cpp:1461
+#: ../src/ui/dialog/inkscape-preferences.cpp:1459
+#: ../src/ui/dialog/inkscape-preferences.cpp:1483
 msgid "Lower quality (faster)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1439
-#: ../src/ui/dialog/inkscape-preferences.cpp:1463
+#: ../src/ui/dialog/inkscape-preferences.cpp:1461
+#: ../src/ui/dialog/inkscape-preferences.cpp:1485
 msgid "Lowest quality (fastest)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1442
+#: ../src/ui/dialog/inkscape-preferences.cpp:1464
 msgid "Gaussian blur quality for display"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1444
-#: ../src/ui/dialog/inkscape-preferences.cpp:1468
+#: ../src/ui/dialog/inkscape-preferences.cpp:1466
+#: ../src/ui/dialog/inkscape-preferences.cpp:1490
 msgid ""
 "Best quality, but display may be very slow at high zooms (bitmap export "
 "always uses best quality)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1446
-#: ../src/ui/dialog/inkscape-preferences.cpp:1470
+#: ../src/ui/dialog/inkscape-preferences.cpp:1468
+#: ../src/ui/dialog/inkscape-preferences.cpp:1492
 msgid "Better quality, but slower display"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1448
-#: ../src/ui/dialog/inkscape-preferences.cpp:1472
+#: ../src/ui/dialog/inkscape-preferences.cpp:1470
+#: ../src/ui/dialog/inkscape-preferences.cpp:1494
 msgid "Average quality, acceptable display speed"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1450
-#: ../src/ui/dialog/inkscape-preferences.cpp:1474
+#: ../src/ui/dialog/inkscape-preferences.cpp:1472
+#: ../src/ui/dialog/inkscape-preferences.cpp:1496
 msgid "Lower quality (some artifacts), but display is faster"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1452
-#: ../src/ui/dialog/inkscape-preferences.cpp:1476
+#: ../src/ui/dialog/inkscape-preferences.cpp:1474
+#: ../src/ui/dialog/inkscape-preferences.cpp:1498
 msgid "Lowest quality (considerable artifacts), but display is fastest"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1466
+#: ../src/ui/dialog/inkscape-preferences.cpp:1488
 msgid "Filter effects quality for display"
 msgstr ""
 
 #. build custom preferences tab
-#: ../src/ui/dialog/inkscape-preferences.cpp:1478
-#: ../src/ui/dialog/print.cpp:215
+#: ../src/ui/dialog/inkscape-preferences.cpp:1500
+#: ../src/ui/dialog/print.cpp:219
 msgid "Rendering"
 msgstr ""
 
 #. Note: /options/bitmapoversample removed with Cairo renderer
-#: ../src/ui/dialog/inkscape-preferences.cpp:1484 ../src/verbs.cpp:156
+#: ../src/ui/dialog/inkscape-preferences.cpp:1506 ../src/verbs.cpp:156
 #: ../src/widgets/calligraphy-toolbar.cpp:626
 msgid "Edit"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1485
+#: ../src/ui/dialog/inkscape-preferences.cpp:1507
 msgid "Automatically reload bitmaps"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1487
+#: ../src/ui/dialog/inkscape-preferences.cpp:1509
 msgid "Automatically reload linked images when file is changed on disk"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1489
+#: ../src/ui/dialog/inkscape-preferences.cpp:1511
 msgid "_Bitmap editor:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1491
+#: ../src/ui/dialog/inkscape-preferences.cpp:1513
 #: ../share/extensions/guillotine.inx.h:5 ../share/extensions/plotter.inx.h:65
 #: ../share/extensions/print_win32_vector.inx.h:2
 msgid "Export"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1493
+#: ../src/ui/dialog/inkscape-preferences.cpp:1515
 msgid "Default export _resolution:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1494
+#: ../src/ui/dialog/inkscape-preferences.cpp:1516
 msgid "Default bitmap resolution (in dots per inch) in the Export dialog"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1495
+#: ../src/ui/dialog/inkscape-preferences.cpp:1517
 #: ../src/ui/dialog/xml-tree.cpp:921
 msgid "Create"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1497
+#: ../src/ui/dialog/inkscape-preferences.cpp:1519
 msgid "Resolution for Create Bitmap _Copy:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1498
+#: ../src/ui/dialog/inkscape-preferences.cpp:1520
 msgid "Resolution used by the Create Bitmap Copy command"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1501
+#: ../src/ui/dialog/inkscape-preferences.cpp:1523
 msgid "Ask about linking and scaling when importing"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1503
+#: ../src/ui/dialog/inkscape-preferences.cpp:1525
 msgid "Pop-up linking and scaling dialog when importing bitmap image."
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1509
+#: ../src/ui/dialog/inkscape-preferences.cpp:1531
 msgid "Bitmap link:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1516
+#: ../src/ui/dialog/inkscape-preferences.cpp:1538
 msgid "Bitmap scale (image-rendering):"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1521
+#: ../src/ui/dialog/inkscape-preferences.cpp:1543
 msgid "Default _import resolution:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1522
+#: ../src/ui/dialog/inkscape-preferences.cpp:1544
 msgid "Default bitmap resolution (in dots per inch) for bitmap import"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1523
+#: ../src/ui/dialog/inkscape-preferences.cpp:1545
 msgid "Override file resolution"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1525
+#: ../src/ui/dialog/inkscape-preferences.cpp:1547
 msgid "Use default bitmap resolution in favor of information from file"
 msgstr ""
 
 #. rendering outlines for pixmap image tags
-#: ../src/ui/dialog/inkscape-preferences.cpp:1529
+#: ../src/ui/dialog/inkscape-preferences.cpp:1551
 msgid "Images in Outline Mode"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1530
+#: ../src/ui/dialog/inkscape-preferences.cpp:1552
 msgid ""
 "When active will render images while in outline mode instead of a red box "
 "with an x. This is useful for manual tracing."
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1532
+#: ../src/ui/dialog/inkscape-preferences.cpp:1554
 msgid "Bitmaps"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1544
+#: ../src/ui/dialog/inkscape-preferences.cpp:1566
 msgid ""
 "Select a file of predefined shortcuts to use. Any customized shortcuts you "
 "create will be added separately to "
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1547
+#: ../src/ui/dialog/inkscape-preferences.cpp:1569
 msgid "Shortcut file:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1550
+#: ../src/ui/dialog/inkscape-preferences.cpp:1572
 #: ../src/ui/dialog/template-load-tab.cpp:49
 msgid "Search:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1562
+#: ../src/ui/dialog/inkscape-preferences.cpp:1584
 msgid "Shortcut"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1563
+#: ../src/ui/dialog/inkscape-preferences.cpp:1585
 #: ../src/ui/widget/page-sizer.cpp:287
 msgid "Description"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1618
+#: ../src/ui/dialog/inkscape-preferences.cpp:1640
 msgid ""
 "Remove all your customized keyboard shortcuts, and revert to the shortcuts "
 "in the shortcut file listed above"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1622
+#: ../src/ui/dialog/inkscape-preferences.cpp:1644
 msgid "Import ..."
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1622
+#: ../src/ui/dialog/inkscape-preferences.cpp:1644
 msgid "Import custom keyboard shortcuts from a file"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1625
+#: ../src/ui/dialog/inkscape-preferences.cpp:1647
 msgid "Export ..."
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1625
+#: ../src/ui/dialog/inkscape-preferences.cpp:1647
 msgid "Export custom keyboard shortcuts to a file"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1635
+#: ../src/ui/dialog/inkscape-preferences.cpp:1657
 msgid "Keyboard Shortcuts"
 msgstr ""
 
 #. Find this group in the tree
-#: ../src/ui/dialog/inkscape-preferences.cpp:1798
+#: ../src/ui/dialog/inkscape-preferences.cpp:1820
 msgid "Misc"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1904
+#: ../src/ui/dialog/inkscape-preferences.cpp:1926
 msgctxt "Spellchecker language"
 msgid "None"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1925
+#: ../src/ui/dialog/inkscape-preferences.cpp:1947
 msgid "Set the main spell check language"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1928
+#: ../src/ui/dialog/inkscape-preferences.cpp:1950
 msgid "Second language:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1929
+#: ../src/ui/dialog/inkscape-preferences.cpp:1951
 msgid ""
 "Set the second spell check language; checking will only stop on words "
 "unknown in ALL chosen languages"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1932
+#: ../src/ui/dialog/inkscape-preferences.cpp:1954
 msgid "Third language:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1933
+#: ../src/ui/dialog/inkscape-preferences.cpp:1955
 msgid ""
 "Set the third spell check language; checking will only stop on words unknown "
 "in ALL chosen languages"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1935
+#: ../src/ui/dialog/inkscape-preferences.cpp:1957
 msgid "Ignore words with digits"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1937
+#: ../src/ui/dialog/inkscape-preferences.cpp:1959
 msgid "Ignore words containing digits, such as \"R2D2\""
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1939
+#: ../src/ui/dialog/inkscape-preferences.cpp:1961
 msgid "Ignore words in ALL CAPITALS"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1941
+#: ../src/ui/dialog/inkscape-preferences.cpp:1963
 msgid "Ignore words in all capitals, such as \"IUPAC\""
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1943
+#: ../src/ui/dialog/inkscape-preferences.cpp:1965
 msgid "Spellcheck"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1963
+#: ../src/ui/dialog/inkscape-preferences.cpp:1985
 msgid "Latency _skew:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1964
+#: ../src/ui/dialog/inkscape-preferences.cpp:1986
 msgid ""
 "Factor by which the event clock is skewed from the actual time (0.9766 on "
 "some systems)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1966
+#: ../src/ui/dialog/inkscape-preferences.cpp:1988
 msgid "Pre-render named icons"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1968
+#: ../src/ui/dialog/inkscape-preferences.cpp:1990
 msgid ""
 "When on, named icons will be rendered before displaying the ui. This is for "
 "working around bugs in GTK+ named icon notification"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1976
+#: ../src/ui/dialog/inkscape-preferences.cpp:1998
 msgid "System info"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1980
+#: ../src/ui/dialog/inkscape-preferences.cpp:2002
 msgid "User config: "
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1980
+#: ../src/ui/dialog/inkscape-preferences.cpp:2002
 msgid "Location of users configuration"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1984
+#: ../src/ui/dialog/inkscape-preferences.cpp:2006
 msgid "User preferences: "
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1984
+#: ../src/ui/dialog/inkscape-preferences.cpp:2006
 msgid "Location of the users preferences file"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1988
+#: ../src/ui/dialog/inkscape-preferences.cpp:2010
 msgid "User extensions: "
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1988
+#: ../src/ui/dialog/inkscape-preferences.cpp:2010
 msgid "Location of the users extensions"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1992
+#: ../src/ui/dialog/inkscape-preferences.cpp:2014
 msgid "User cache: "
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1992
+#: ../src/ui/dialog/inkscape-preferences.cpp:2014
 msgid "Location of users cache"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:2000
+#: ../src/ui/dialog/inkscape-preferences.cpp:2022
 msgid "Temporary files: "
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:2000
+#: ../src/ui/dialog/inkscape-preferences.cpp:2022
 msgid "Location of the temporary files used for autosave"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:2004
+#: ../src/ui/dialog/inkscape-preferences.cpp:2026
 msgid "Inkscape data: "
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:2004
+#: ../src/ui/dialog/inkscape-preferences.cpp:2026
 msgid "Location of Inkscape data"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:2008
+#: ../src/ui/dialog/inkscape-preferences.cpp:2030
 msgid "Inkscape extensions: "
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:2008
+#: ../src/ui/dialog/inkscape-preferences.cpp:2030
 msgid "Location of the Inkscape extensions"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:2017
+#: ../src/ui/dialog/inkscape-preferences.cpp:2039
 msgid "System data: "
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:2017
+#: ../src/ui/dialog/inkscape-preferences.cpp:2039
 msgid "Locations of system data"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:2041
+#: ../src/ui/dialog/inkscape-preferences.cpp:2063
 msgid "Icon theme: "
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:2041
+#: ../src/ui/dialog/inkscape-preferences.cpp:2063
 msgid "Locations of icon themes"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:2043
+#: ../src/ui/dialog/inkscape-preferences.cpp:2065
 msgid "System"
 msgstr ""
 
@@ -20842,29 +20864,29 @@ msgstr ""
 msgid "Searching clipart..."
 msgstr ""
 
-#: ../src/ui/dialog/ocaldialogs.cpp:1099 ../src/ui/dialog/ocaldialogs.cpp:1120
+#: ../src/ui/dialog/ocaldialogs.cpp:1121
 msgid "Could not connect to the Open Clip Art Library"
 msgstr ""
 
-#: ../src/ui/dialog/ocaldialogs.cpp:1145
+#: ../src/ui/dialog/ocaldialogs.cpp:1146
 msgid "Could not parse search results"
 msgstr ""
 
-#: ../src/ui/dialog/ocaldialogs.cpp:1177
+#: ../src/ui/dialog/ocaldialogs.cpp:1178
 msgid "No clipart named <b>%1</b> was found."
 msgstr ""
 
-#: ../src/ui/dialog/ocaldialogs.cpp:1179
+#: ../src/ui/dialog/ocaldialogs.cpp:1180
 msgid ""
 "Please make sure all keywords are spelled correctly, or try again with "
 "different keywords."
 msgstr ""
 
-#: ../src/ui/dialog/ocaldialogs.cpp:1231
+#: ../src/ui/dialog/ocaldialogs.cpp:1232
 msgid "Search"
 msgstr ""
 
-#: ../src/ui/dialog/ocaldialogs.cpp:1243
+#: ../src/ui/dialog/ocaldialogs.cpp:1244
 msgid "Close"
 msgstr ""
 
@@ -21056,24 +21078,24 @@ msgstr ""
 msgid "Arrange on ellipse"
 msgstr ""
 
-#: ../src/ui/dialog/print.cpp:111
+#: ../src/ui/dialog/print.cpp:115
 msgid "Could not open temporary PNG for bitmap printing"
 msgstr ""
 
-#: ../src/ui/dialog/print.cpp:138
+#: ../src/ui/dialog/print.cpp:142
 msgid "Could not set up Document"
 msgstr ""
 
-#: ../src/ui/dialog/print.cpp:142
+#: ../src/ui/dialog/print.cpp:146
 msgid "Failed to set CairoRenderContext"
 msgstr ""
 
 #. set up dialog title, based on document name
-#: ../src/ui/dialog/print.cpp:180
+#: ../src/ui/dialog/print.cpp:184
 msgid "SVG Document"
 msgstr ""
 
-#: ../src/ui/dialog/print.cpp:181
+#: ../src/ui/dialog/print.cpp:185
 msgid "Print"
 msgstr ""
 
@@ -21314,30 +21336,30 @@ msgstr ""
 msgid "Preview Text:"
 msgstr ""
 
-#: ../src/ui/dialog/swatches.cpp:202 ../src/ui/tools/gradient-tool.cpp:366
+#: ../src/ui/dialog/swatches.cpp:203 ../src/ui/tools/gradient-tool.cpp:366
 #: ../src/ui/tools/gradient-tool.cpp:464 ../src/widgets/gradient-vector.cpp:801
 msgid "Add gradient stop"
 msgstr ""
 
 #. TRANSLATORS: An item in context menu on a colour in the swatches
-#: ../src/ui/dialog/swatches.cpp:257
+#: ../src/ui/dialog/swatches.cpp:258
 msgid "Set fill"
 msgstr ""
 
 #. TRANSLATORS: An item in context menu on a colour in the swatches
-#: ../src/ui/dialog/swatches.cpp:265
+#: ../src/ui/dialog/swatches.cpp:266
 msgid "Set stroke"
 msgstr ""
 
-#: ../src/ui/dialog/swatches.cpp:286
+#: ../src/ui/dialog/swatches.cpp:287
 msgid "Edit..."
 msgstr ""
 
-#: ../src/ui/dialog/swatches.cpp:298
+#: ../src/ui/dialog/swatches.cpp:299
 msgid "Convert"
 msgstr ""
 
-#: ../src/ui/dialog/swatches.cpp:543
+#: ../src/ui/dialog/swatches.cpp:551
 #, c-format
 msgid "Palettes directory (%s) is unavailable."
 msgstr ""
@@ -21446,27 +21468,27 @@ msgid "AaBbCcIiPpQq12369$€¢?.;/()"
 msgstr ""
 
 #. Align buttons
-#: ../src/ui/dialog/text-edit.cpp:97 ../src/widgets/text-toolbar.cpp:1797
-#: ../src/widgets/text-toolbar.cpp:1798
+#: ../src/ui/dialog/text-edit.cpp:97 ../src/widgets/text-toolbar.cpp:1866
+#: ../src/widgets/text-toolbar.cpp:1867
 msgid "Align left"
 msgstr ""
 
-#: ../src/ui/dialog/text-edit.cpp:98 ../src/widgets/text-toolbar.cpp:1805
-#: ../src/widgets/text-toolbar.cpp:1806
+#: ../src/ui/dialog/text-edit.cpp:98 ../src/widgets/text-toolbar.cpp:1874
+#: ../src/widgets/text-toolbar.cpp:1875
 msgid "Align center"
 msgstr ""
 
-#: ../src/ui/dialog/text-edit.cpp:99 ../src/widgets/text-toolbar.cpp:1813
-#: ../src/widgets/text-toolbar.cpp:1814
+#: ../src/ui/dialog/text-edit.cpp:99 ../src/widgets/text-toolbar.cpp:1882
+#: ../src/widgets/text-toolbar.cpp:1883
 msgid "Align right"
 msgstr ""
 
-#: ../src/ui/dialog/text-edit.cpp:100 ../src/widgets/text-toolbar.cpp:1822
+#: ../src/ui/dialog/text-edit.cpp:100 ../src/widgets/text-toolbar.cpp:1891
 msgid "Justify (only flowed text)"
 msgstr ""
 
 #. Direction buttons
-#: ../src/ui/dialog/text-edit.cpp:109 ../src/widgets/text-toolbar.cpp:1857
+#: ../src/ui/dialog/text-edit.cpp:109 ../src/widgets/text-toolbar.cpp:1926
 msgid "Horizontal text"
 msgstr ""
 
@@ -22684,44 +22706,44 @@ msgstr ""
 msgid "Retract handle"
 msgstr ""
 
-#: ../src/ui/tool/transform-handle-set.cpp:203
+#: ../src/ui/tool/transform-handle-set.cpp:208
 msgctxt "Transform handle tip"
 msgid "<b>Shift+Ctrl</b>: scale uniformly about the rotation center"
 msgstr ""
 
-#: ../src/ui/tool/transform-handle-set.cpp:205
+#: ../src/ui/tool/transform-handle-set.cpp:210
 msgctxt "Transform handle tip"
 msgid "<b>Ctrl:</b> scale uniformly"
 msgstr ""
 
-#: ../src/ui/tool/transform-handle-set.cpp:210
+#: ../src/ui/tool/transform-handle-set.cpp:215
 msgctxt "Transform handle tip"
 msgid ""
 "<b>Shift+Alt</b>: scale using an integer ratio about the rotation center"
 msgstr ""
 
-#: ../src/ui/tool/transform-handle-set.cpp:212
+#: ../src/ui/tool/transform-handle-set.cpp:217
 msgctxt "Transform handle tip"
 msgid "<b>Shift</b>: scale from the rotation center"
 msgstr ""
 
-#: ../src/ui/tool/transform-handle-set.cpp:215
+#: ../src/ui/tool/transform-handle-set.cpp:220
 msgctxt "Transform handle tip"
 msgid "<b>Alt</b>: scale using an integer ratio"
 msgstr ""
 
-#: ../src/ui/tool/transform-handle-set.cpp:217
+#: ../src/ui/tool/transform-handle-set.cpp:222
 msgctxt "Transform handle tip"
 msgid "<b>Scale handle</b>: drag to scale the selection"
 msgstr ""
 
-#: ../src/ui/tool/transform-handle-set.cpp:222
+#: ../src/ui/tool/transform-handle-set.cpp:227
 #, c-format
 msgctxt "Transform handle tip"
 msgid "Scale by %.2f%% x %.2f%%"
 msgstr ""
 
-#: ../src/ui/tool/transform-handle-set.cpp:449
+#: ../src/ui/tool/transform-handle-set.cpp:454
 #, c-format
 msgctxt "Transform handle tip"
 msgid ""
@@ -22729,18 +22751,18 @@ msgid ""
 "increments"
 msgstr ""
 
-#: ../src/ui/tool/transform-handle-set.cpp:452
+#: ../src/ui/tool/transform-handle-set.cpp:457
 msgctxt "Transform handle tip"
 msgid "<b>Shift</b>: rotate around the opposite corner"
 msgstr ""
 
-#: ../src/ui/tool/transform-handle-set.cpp:456
+#: ../src/ui/tool/transform-handle-set.cpp:461
 #, c-format
 msgctxt "Transform handle tip"
 msgid "<b>Ctrl</b>: snap angle to %f° increments"
 msgstr ""
 
-#: ../src/ui/tool/transform-handle-set.cpp:458
+#: ../src/ui/tool/transform-handle-set.cpp:463
 msgctxt "Transform handle tip"
 msgid ""
 "<b>Rotation handle</b>: drag to rotate the selection around the rotation "
@@ -22748,13 +22770,13 @@ msgid ""
 msgstr ""
 
 #. event
-#: ../src/ui/tool/transform-handle-set.cpp:463
+#: ../src/ui/tool/transform-handle-set.cpp:468
 #, c-format
 msgctxt "Transform handle tip"
 msgid "Rotate by %.2f°"
 msgstr ""
 
-#: ../src/ui/tool/transform-handle-set.cpp:588
+#: ../src/ui/tool/transform-handle-set.cpp:593
 #, c-format
 msgctxt "Transform handle tip"
 msgid ""
@@ -22762,36 +22784,36 @@ msgid ""
 "increments"
 msgstr ""
 
-#: ../src/ui/tool/transform-handle-set.cpp:591
+#: ../src/ui/tool/transform-handle-set.cpp:596
 msgctxt "Transform handle tip"
 msgid "<b>Shift</b>: skew about the rotation center"
 msgstr ""
 
-#: ../src/ui/tool/transform-handle-set.cpp:595
+#: ../src/ui/tool/transform-handle-set.cpp:600
 #, c-format
 msgctxt "Transform handle tip"
 msgid "<b>Ctrl</b>: snap skew angle to %f° increments"
 msgstr ""
 
-#: ../src/ui/tool/transform-handle-set.cpp:598
+#: ../src/ui/tool/transform-handle-set.cpp:603
 msgctxt "Transform handle tip"
 msgid ""
 "<b>Skew handle</b>: drag to skew (shear) selection about the opposite handle"
 msgstr ""
 
-#: ../src/ui/tool/transform-handle-set.cpp:604
+#: ../src/ui/tool/transform-handle-set.cpp:609
 #, c-format
 msgctxt "Transform handle tip"
 msgid "Skew horizontally by %.2f°"
 msgstr ""
 
-#: ../src/ui/tool/transform-handle-set.cpp:607
+#: ../src/ui/tool/transform-handle-set.cpp:612
 #, c-format
 msgctxt "Transform handle tip"
 msgid "Skew vertically by %.2f°"
 msgstr ""
 
-#: ../src/ui/tool/transform-handle-set.cpp:666
+#: ../src/ui/tool/transform-handle-set.cpp:671
 msgctxt "Transform handle tip"
 msgid "<b>Rotation center</b>: drag to change the origin of transforms"
 msgstr ""
@@ -23553,33 +23575,33 @@ msgstr ""
 msgid "Selection canceled."
 msgstr ""
 
-#: ../src/ui/tools/select-tool.cpp:645
+#: ../src/ui/tools/select-tool.cpp:647
 msgid ""
 "<b>Draw over</b> objects to select them; release <b>Alt</b> to switch to "
 "rubberband selection"
 msgstr ""
 
-#: ../src/ui/tools/select-tool.cpp:647
+#: ../src/ui/tools/select-tool.cpp:649
 msgid ""
 "<b>Drag around</b> objects to select them; press <b>Alt</b> to switch to "
 "touch selection"
 msgstr ""
 
-#: ../src/ui/tools/select-tool.cpp:888
+#: ../src/ui/tools/select-tool.cpp:890
 msgid "<b>Ctrl</b>: click to select in groups; drag to move hor/vert"
 msgstr ""
 
-#: ../src/ui/tools/select-tool.cpp:889
+#: ../src/ui/tools/select-tool.cpp:891
 msgid "<b>Shift</b>: click to toggle select; drag for rubberband selection"
 msgstr ""
 
-#: ../src/ui/tools/select-tool.cpp:890
+#: ../src/ui/tools/select-tool.cpp:892
 msgid ""
 "<b>Alt</b>: click to select under; scroll mouse-wheel to cycle-select; drag "
 "to move selected or select by touch"
 msgstr ""
 
-#: ../src/ui/tools/select-tool.cpp:1098
+#: ../src/ui/tools/select-tool.cpp:1100
 msgid "Selected object is not a group. Cannot enter."
 msgstr ""
 
@@ -23812,7 +23834,7 @@ msgstr[1] ""
 msgid "Type text"
 msgstr ""
 
-#: ../src/ui/tools/tool-base.cpp:705
+#: ../src/ui/tools/tool-base.cpp:708
 msgid "<b>Space+mouse move</b> to pan canvas"
 msgstr ""
 
@@ -23945,18 +23967,18 @@ msgid "Hexadecimal RGBA value of the color"
 msgstr ""
 
 #: ../src/ui/widget/color-icc-selector.cpp:176
-#: ../src/ui/widget/color-scales.cpp:384
+#: ../src/ui/widget/color-scales.cpp:385
 msgid "_R:"
 msgstr ""
 
 #. TYPE_RGB_16
 #: ../src/ui/widget/color-icc-selector.cpp:177
-#: ../src/ui/widget/color-scales.cpp:387
+#: ../src/ui/widget/color-scales.cpp:388
 msgid "_G:"
 msgstr ""
 
 #: ../src/ui/widget/color-icc-selector.cpp:178
-#: ../src/ui/widget/color-scales.cpp:390
+#: ../src/ui/widget/color-scales.cpp:391
 msgid "_B:"
 msgstr ""
 
@@ -23968,26 +23990,26 @@ msgstr ""
 #. TYPE_GRAY_16
 #: ../src/ui/widget/color-icc-selector.cpp:182
 #: ../src/ui/widget/color-icc-selector.cpp:186
-#: ../src/ui/widget/color-scales.cpp:410
+#: ../src/ui/widget/color-scales.cpp:411
 msgid "_H:"
 msgstr ""
 
 #. TYPE_HSV_16
 #: ../src/ui/widget/color-icc-selector.cpp:183
 #: ../src/ui/widget/color-icc-selector.cpp:188
-#: ../src/ui/widget/color-scales.cpp:413
+#: ../src/ui/widget/color-scales.cpp:414
 msgid "_S:"
 msgstr ""
 
 #. TYPE_HLS_16
 #: ../src/ui/widget/color-icc-selector.cpp:187
-#: ../src/ui/widget/color-scales.cpp:416
+#: ../src/ui/widget/color-scales.cpp:417
 msgid "_L:"
 msgstr ""
 
 #: ../src/ui/widget/color-icc-selector.cpp:190
 #: ../src/ui/widget/color-icc-selector.cpp:195
-#: ../src/ui/widget/color-scales.cpp:438
+#: ../src/ui/widget/color-scales.cpp:439
 msgid "_C:"
 msgstr ""
 
@@ -23995,18 +24017,18 @@ msgstr ""
 #. TYPE_CMY_16
 #: ../src/ui/widget/color-icc-selector.cpp:191
 #: ../src/ui/widget/color-icc-selector.cpp:196
-#: ../src/ui/widget/color-scales.cpp:441
+#: ../src/ui/widget/color-scales.cpp:442
 msgid "_M:"
 msgstr ""
 
 #: ../src/ui/widget/color-icc-selector.cpp:192
 #: ../src/ui/widget/color-icc-selector.cpp:197
-#: ../src/ui/widget/color-scales.cpp:444
+#: ../src/ui/widget/color-scales.cpp:445
 msgid "_Y:"
 msgstr ""
 
 #: ../src/ui/widget/color-icc-selector.cpp:193
-#: ../src/ui/widget/color-scales.cpp:447
+#: ../src/ui/widget/color-scales.cpp:448
 msgid "_K:"
 msgstr ""
 
@@ -24024,17 +24046,17 @@ msgstr ""
 
 #. Label
 #: ../src/ui/widget/color-icc-selector.cpp:496
-#: ../src/ui/widget/color-scales.cpp:393 ../src/ui/widget/color-scales.cpp:419
-#: ../src/ui/widget/color-scales.cpp:450
+#: ../src/ui/widget/color-scales.cpp:394 ../src/ui/widget/color-scales.cpp:420
+#: ../src/ui/widget/color-scales.cpp:451
 #: ../src/ui/widget/color-wheel-selector.cpp:83
 msgid "_A:"
 msgstr ""
 
 #: ../src/ui/widget/color-icc-selector.cpp:513
 #: ../src/ui/widget/color-icc-selector.cpp:524
-#: ../src/ui/widget/color-scales.cpp:394 ../src/ui/widget/color-scales.cpp:395
-#: ../src/ui/widget/color-scales.cpp:420 ../src/ui/widget/color-scales.cpp:421
-#: ../src/ui/widget/color-scales.cpp:451 ../src/ui/widget/color-scales.cpp:452
+#: ../src/ui/widget/color-scales.cpp:395 ../src/ui/widget/color-scales.cpp:396
+#: ../src/ui/widget/color-scales.cpp:421 ../src/ui/widget/color-scales.cpp:422
+#: ../src/ui/widget/color-scales.cpp:452 ../src/ui/widget/color-scales.cpp:453
 #: ../src/ui/widget/color-wheel-selector.cpp:112
 #: ../src/ui/widget/color-wheel-selector.cpp:142
 msgid "Alpha (opacity)"
@@ -24450,7 +24472,10 @@ msgid "Scale _y:"
 msgstr ""
 
 #: ../src/ui/widget/page-sizer.cpp:245
-msgid "Scale Y"
+msgid ""
+"While SVG allows non-uniform scaling it is recommended to use only uniform "
+"scaling in Inkscape. To set a non-uniform scaling, set the 'viewBox' "
+"directly."
 msgstr ""
 
 #: ../src/ui/widget/page-sizer.cpp:323
@@ -24484,30 +24509,23 @@ msgid ""
 "is no selection"
 msgstr ""
 
-#: ../src/ui/widget/page-sizer.cpp:479
-msgid ""
-"While SVG allows non-uniform scaling it is recommended to use only uniform "
-"scaling in Inkscape. To set a non-uniform scaling, set the 'viewBox' "
-"directly."
-msgstr ""
-
-#: ../src/ui/widget/page-sizer.cpp:483
+#: ../src/ui/widget/page-sizer.cpp:478
 msgid "_Viewbox..."
 msgstr ""
 
-#: ../src/ui/widget/page-sizer.cpp:590
+#: ../src/ui/widget/page-sizer.cpp:585
 msgid "Set page size"
 msgstr ""
 
-#: ../src/ui/widget/page-sizer.cpp:836
+#: ../src/ui/widget/page-sizer.cpp:831
 msgid "User units per "
 msgstr ""
 
-#: ../src/ui/widget/page-sizer.cpp:932
+#: ../src/ui/widget/page-sizer.cpp:927
 msgid "Set page scale"
 msgstr ""
 
-#: ../src/ui/widget/page-sizer.cpp:958
+#: ../src/ui/widget/page-sizer.cpp:953
 msgid "Set 'viewBox'"
 msgstr ""
 
@@ -27410,15 +27428,19 @@ msgstr ""
 msgid "Center on horizontal and vertical axis"
 msgstr ""
 
-#: ../src/widgets/arc-toolbar.cpp:129
+#: ../src/widgets/arc-toolbar.cpp:143
+msgid "Change arc"
+msgstr ""
+
+#: ../src/widgets/arc-toolbar.cpp:209
 msgid "Arc: Change start/end"
 msgstr ""
 
-#: ../src/widgets/arc-toolbar.cpp:191
+#: ../src/widgets/arc-toolbar.cpp:271
 msgid "Arc: Change open/closed"
 msgstr ""
 
-#: ../src/widgets/arc-toolbar.cpp:280 ../src/widgets/arc-toolbar.cpp:310
+#: ../src/widgets/arc-toolbar.cpp:385 ../src/widgets/arc-toolbar.cpp:424
 #: ../src/widgets/rect-toolbar.cpp:260 ../src/widgets/rect-toolbar.cpp:299
 #: ../src/widgets/spiral-toolbar.cpp:210 ../src/widgets/spiral-toolbar.cpp:234
 #: ../src/widgets/star-toolbar.cpp:382 ../src/widgets/star-toolbar.cpp:444
@@ -27427,50 +27449,83 @@ msgstr ""
 
 #. FIXME: implement averaging of all parameters for multiple selected
 #. gtk_label_set_markup(GTK_LABEL(l), _("<b>Average:</b>"));
-#: ../src/widgets/arc-toolbar.cpp:283 ../src/widgets/arc-toolbar.cpp:294
+#: ../src/widgets/arc-toolbar.cpp:388 ../src/widgets/arc-toolbar.cpp:405
 #: ../src/widgets/rect-toolbar.cpp:268 ../src/widgets/rect-toolbar.cpp:286
 #: ../src/widgets/spiral-toolbar.cpp:212 ../src/widgets/spiral-toolbar.cpp:223
 #: ../src/widgets/star-toolbar.cpp:384
 msgid "<b>Change:</b>"
 msgstr ""
 
-#: ../src/widgets/arc-toolbar.cpp:319
+#: ../src/widgets/arc-toolbar.cpp:435 ../src/widgets/rect-toolbar.cpp:351
+msgid "Horizontal radius"
+msgstr ""
+
+#: ../src/widgets/arc-toolbar.cpp:435 ../src/widgets/rect-toolbar.cpp:351
+msgid "Rx:"
+msgstr ""
+
+#: ../src/widgets/arc-toolbar.cpp:435
+msgid "Horizontal radius of the circle, ellipse, or arc"
+msgstr ""
+
+#: ../src/widgets/arc-toolbar.cpp:452 ../src/widgets/rect-toolbar.cpp:366
+msgid "Vertical radius"
+msgstr ""
+
+#: ../src/widgets/arc-toolbar.cpp:452 ../src/widgets/rect-toolbar.cpp:366
+msgid "Ry:"
+msgstr ""
+
+#: ../src/widgets/arc-toolbar.cpp:452
+msgid "Vertical radius of the circle, ellipse, or arc"
+msgstr ""
+
+#. Add the units menu.
+#: ../src/widgets/arc-toolbar.cpp:466 ../src/widgets/lpe-toolbar.cpp:387
+#: ../src/widgets/node-toolbar.cpp:613
+#: ../src/widgets/paintbucket-toolbar.cpp:168
+#: ../src/widgets/rect-toolbar.cpp:378 ../src/widgets/select-toolbar.cpp:530
+#: ../src/widgets/text-toolbar.cpp:2108
+msgid "Units"
+msgstr ""
+
+#: ../src/widgets/arc-toolbar.cpp:473
 msgid "Start:"
 msgstr ""
 
-#: ../src/widgets/arc-toolbar.cpp:320
+#: ../src/widgets/arc-toolbar.cpp:474
 msgid "The angle (in degrees) from the horizontal to the arc's start point"
 msgstr ""
 
-#: ../src/widgets/arc-toolbar.cpp:332
+#: ../src/widgets/arc-toolbar.cpp:486
 msgid "End:"
 msgstr ""
 
-#: ../src/widgets/arc-toolbar.cpp:333
+#: ../src/widgets/arc-toolbar.cpp:487
 msgid "The angle (in degrees) from the horizontal to the arc's end point"
 msgstr ""
 
-#: ../src/widgets/arc-toolbar.cpp:349
+#: ../src/widgets/arc-toolbar.cpp:503
 msgid "Closed arc"
 msgstr ""
 
-#: ../src/widgets/arc-toolbar.cpp:350
+#: ../src/widgets/arc-toolbar.cpp:504
 msgid "Switch to segment (closed shape with two radii)"
 msgstr ""
 
-#: ../src/widgets/arc-toolbar.cpp:356
+#: ../src/widgets/arc-toolbar.cpp:510
 msgid "Open Arc"
 msgstr ""
 
-#: ../src/widgets/arc-toolbar.cpp:357
+#: ../src/widgets/arc-toolbar.cpp:511
 msgid "Switch to arc (unclosed shape)"
 msgstr ""
 
-#: ../src/widgets/arc-toolbar.cpp:380
+#: ../src/widgets/arc-toolbar.cpp:534
 msgid "Make whole"
 msgstr ""
 
-#: ../src/widgets/arc-toolbar.cpp:381
+#: ../src/widgets/arc-toolbar.cpp:535
 msgid "Make the shape a whole ellipse, not arc or segment"
 msgstr ""
 
@@ -28133,8 +28188,8 @@ msgstr ""
 msgid "Set pattern on stroke"
 msgstr ""
 
-#: ../src/widgets/font-selector.cpp:120 ../src/widgets/text-toolbar.cpp:1318
-#: ../src/widgets/text-toolbar.cpp:1723
+#: ../src/widgets/font-selector.cpp:120 ../src/widgets/text-toolbar.cpp:1378
+#: ../src/widgets/text-toolbar.cpp:1792
 msgid "Font size"
 msgstr ""
 
@@ -28458,14 +28513,6 @@ msgstr ""
 msgid "Display measuring info for selected items"
 msgstr ""
 
-#. Add the units menu.
-#: ../src/widgets/lpe-toolbar.cpp:387 ../src/widgets/node-toolbar.cpp:613
-#: ../src/widgets/paintbucket-toolbar.cpp:168
-#: ../src/widgets/rect-toolbar.cpp:378 ../src/widgets/select-toolbar.cpp:530
-#: ../src/widgets/text-toolbar.cpp:1993
-msgid "Units"
-msgstr ""
-
 #: ../src/widgets/lpe-toolbar.cpp:397
 msgid "Open LPE dialog"
 msgstr ""
@@ -28506,7 +28553,7 @@ msgstr ""
 msgid "Compute max length."
 msgstr ""
 
-#: ../src/widgets/measure-toolbar.cpp:274 ../src/widgets/text-toolbar.cpp:1726
+#: ../src/widgets/measure-toolbar.cpp:274 ../src/widgets/text-toolbar.cpp:1795
 msgid "Font Size"
 msgstr ""
 
@@ -29200,23 +29247,7 @@ msgid "not rounded"
 msgstr ""
 
 #: ../src/widgets/rect-toolbar.cpp:351
-msgid "Horizontal radius"
-msgstr ""
-
-#: ../src/widgets/rect-toolbar.cpp:351
-msgid "Rx:"
-msgstr ""
-
-#: ../src/widgets/rect-toolbar.cpp:351
 msgid "Horizontal radius of rounded corners"
-msgstr ""
-
-#: ../src/widgets/rect-toolbar.cpp:366
-msgid "Vertical radius"
-msgstr ""
-
-#: ../src/widgets/rect-toolbar.cpp:366
-msgid "Ry:"
 msgstr ""
 
 #: ../src/widgets/rect-toolbar.cpp:366
@@ -30017,313 +30048,343 @@ msgstr ""
 msgid "Text: Change font family"
 msgstr ""
 
-#: ../src/widgets/text-toolbar.cpp:274
+#: ../src/widgets/text-toolbar.cpp:275
 msgid "Text: Change font size"
 msgstr ""
 
-#: ../src/widgets/text-toolbar.cpp:310
+#: ../src/widgets/text-toolbar.cpp:320
 msgid "Text: Change font style"
 msgstr ""
 
-#: ../src/widgets/text-toolbar.cpp:345
+#: ../src/widgets/text-toolbar.cpp:359
 msgid "Text: Unset line height."
 msgstr ""
 
-#: ../src/widgets/text-toolbar.cpp:422
+#: ../src/widgets/text-toolbar.cpp:436
 msgid "Text: Change superscript or subscript"
 msgstr ""
 
-#: ../src/widgets/text-toolbar.cpp:565
+#: ../src/widgets/text-toolbar.cpp:579
 msgid "Text: Change alignment"
 msgstr ""
 
-#: ../src/widgets/text-toolbar.cpp:668
+#: ../src/widgets/text-toolbar.cpp:682
 msgid "Text: Change line-height"
 msgstr ""
 
-#: ../src/widgets/text-toolbar.cpp:824
+#: ../src/widgets/text-toolbar.cpp:838
 msgid "Text: Change line-height unit"
 msgstr ""
 
-#: ../src/widgets/text-toolbar.cpp:873
+#: ../src/widgets/text-toolbar.cpp:887
 msgid "Text: Change word-spacing"
 msgstr ""
 
-#: ../src/widgets/text-toolbar.cpp:913
+#: ../src/widgets/text-toolbar.cpp:927
 msgid "Text: Change letter-spacing"
 msgstr ""
 
-#: ../src/widgets/text-toolbar.cpp:951
+#: ../src/widgets/text-toolbar.cpp:965
 msgid "Text: Change dx (kern)"
 msgstr ""
 
-#: ../src/widgets/text-toolbar.cpp:985
+#: ../src/widgets/text-toolbar.cpp:999
 msgid "Text: Change dy"
 msgstr ""
 
-#: ../src/widgets/text-toolbar.cpp:1020
+#: ../src/widgets/text-toolbar.cpp:1034
 msgid "Text: Change rotate"
 msgstr ""
 
-#: ../src/widgets/text-toolbar.cpp:1073
+#: ../src/widgets/text-toolbar.cpp:1087
 msgid "Text: Change writing mode"
 msgstr ""
 
-#: ../src/widgets/text-toolbar.cpp:1127
+#: ../src/widgets/text-toolbar.cpp:1141
 msgid "Text: Change orientation"
 msgstr ""
 
-#: ../src/widgets/text-toolbar.cpp:1656
+#: ../src/widgets/text-toolbar.cpp:1188
+msgid "Text: Change direction"
+msgstr ""
+
+#: ../src/widgets/text-toolbar.cpp:1725
 msgid "Font Family"
 msgstr ""
 
-#: ../src/widgets/text-toolbar.cpp:1657
+#: ../src/widgets/text-toolbar.cpp:1726
 msgid "Select Font Family (Alt-X to access)"
 msgstr ""
 
 #. Focus widget
 #. Enable entry completion
-#: ../src/widgets/text-toolbar.cpp:1667
+#: ../src/widgets/text-toolbar.cpp:1736
 msgid "Select all text with this font-family"
 msgstr ""
 
-#: ../src/widgets/text-toolbar.cpp:1671
+#: ../src/widgets/text-toolbar.cpp:1740
 msgid "Font not found on system"
 msgstr ""
 
-#: ../src/widgets/text-toolbar.cpp:1748
+#: ../src/widgets/text-toolbar.cpp:1817
 msgid "Font Style"
 msgstr ""
 
-#: ../src/widgets/text-toolbar.cpp:1749
+#: ../src/widgets/text-toolbar.cpp:1818
 msgid "Font style"
 msgstr ""
 
 #. Name
-#: ../src/widgets/text-toolbar.cpp:1766
+#: ../src/widgets/text-toolbar.cpp:1835
 msgid "Toggle Superscript"
 msgstr ""
 
 #. Label
-#: ../src/widgets/text-toolbar.cpp:1767
+#: ../src/widgets/text-toolbar.cpp:1836
 msgid "Toggle superscript"
 msgstr ""
 
 #. Name
-#: ../src/widgets/text-toolbar.cpp:1779
+#: ../src/widgets/text-toolbar.cpp:1848
 msgid "Toggle Subscript"
 msgstr ""
 
 #. Label
-#: ../src/widgets/text-toolbar.cpp:1780
+#: ../src/widgets/text-toolbar.cpp:1849
 msgid "Toggle subscript"
 msgstr ""
 
-#: ../src/widgets/text-toolbar.cpp:1821
+#: ../src/widgets/text-toolbar.cpp:1890
 msgid "Justify"
 msgstr ""
 
 #. Name
-#: ../src/widgets/text-toolbar.cpp:1828
+#: ../src/widgets/text-toolbar.cpp:1897
 msgid "Alignment"
 msgstr ""
 
 #. Label
-#: ../src/widgets/text-toolbar.cpp:1829
+#: ../src/widgets/text-toolbar.cpp:1898
 msgid "Text alignment"
 msgstr ""
 
-#: ../src/widgets/text-toolbar.cpp:1856
+#: ../src/widgets/text-toolbar.cpp:1925
 msgid "Horizontal"
 msgstr ""
 
-#: ../src/widgets/text-toolbar.cpp:1863
+#: ../src/widgets/text-toolbar.cpp:1932
 msgid "Vertical — RL"
 msgstr ""
 
-#: ../src/widgets/text-toolbar.cpp:1864
+#: ../src/widgets/text-toolbar.cpp:1933
 msgid "Vertical text — lines: right to left"
 msgstr ""
 
-#: ../src/widgets/text-toolbar.cpp:1870
+#: ../src/widgets/text-toolbar.cpp:1939
 msgid "Vertical — LR"
 msgstr ""
 
-#: ../src/widgets/text-toolbar.cpp:1871
+#: ../src/widgets/text-toolbar.cpp:1940
 msgid "Vertical text — lines: left to right"
 msgstr ""
 
 #. Name
-#: ../src/widgets/text-toolbar.cpp:1876
+#: ../src/widgets/text-toolbar.cpp:1945
 msgid "Writing mode"
 msgstr ""
 
 #. Label
-#: ../src/widgets/text-toolbar.cpp:1877
+#: ../src/widgets/text-toolbar.cpp:1946
 msgid "Block progression"
 msgstr ""
 
-#: ../src/widgets/text-toolbar.cpp:1906
+#: ../src/widgets/text-toolbar.cpp:1975
 msgid "Auto glyph orientation"
 msgstr ""
 
-#: ../src/widgets/text-toolbar.cpp:1913
+#: ../src/widgets/text-toolbar.cpp:1982
 msgid "Upright"
 msgstr ""
 
-#: ../src/widgets/text-toolbar.cpp:1914
+#: ../src/widgets/text-toolbar.cpp:1983
 msgid "Upright glyph orientation"
 msgstr ""
 
-#: ../src/widgets/text-toolbar.cpp:1921
+#: ../src/widgets/text-toolbar.cpp:1990
 msgid "Sideways"
 msgstr ""
 
-#: ../src/widgets/text-toolbar.cpp:1922
+#: ../src/widgets/text-toolbar.cpp:1991
 msgid "Sideways glyph orientation"
 msgstr ""
 
 #. Name
-#: ../src/widgets/text-toolbar.cpp:1928
+#: ../src/widgets/text-toolbar.cpp:1997
 msgid "Text orientation"
 msgstr ""
 
 #. Label
-#: ../src/widgets/text-toolbar.cpp:1929
+#: ../src/widgets/text-toolbar.cpp:1998
 msgid "Text (glyph) orientation in vertical text."
 msgstr ""
 
+#: ../src/widgets/text-toolbar.cpp:2028
+msgid "LTR"
+msgstr ""
+
+#: ../src/widgets/text-toolbar.cpp:2029
+msgid "Left to right text"
+msgstr ""
+
+#: ../src/widgets/text-toolbar.cpp:2036
+msgid "RTL"
+msgstr ""
+
+#: ../src/widgets/text-toolbar.cpp:2037
+msgid "Right to left text"
+msgstr ""
+
+#. Name
+#: ../src/widgets/text-toolbar.cpp:2043
+msgid "Text direction"
+msgstr ""
+
+#. Label
+#: ../src/widgets/text-toolbar.cpp:2044
+msgid "Text direction for normally horizontal text."
+msgstr ""
+
 #. Drop down menu
-#: ../src/widgets/text-toolbar.cpp:1962
+#: ../src/widgets/text-toolbar.cpp:2077
 msgid "Smaller spacing"
 msgstr ""
 
-#: ../src/widgets/text-toolbar.cpp:1962 ../src/widgets/text-toolbar.cpp:2001
-#: ../src/widgets/text-toolbar.cpp:2032
+#: ../src/widgets/text-toolbar.cpp:2077 ../src/widgets/text-toolbar.cpp:2116
+#: ../src/widgets/text-toolbar.cpp:2147
 msgctxt "Text tool"
 msgid "Normal"
 msgstr ""
 
-#: ../src/widgets/text-toolbar.cpp:1962
+#: ../src/widgets/text-toolbar.cpp:2077
 msgid "Larger spacing"
 msgstr ""
 
 #. name
-#: ../src/widgets/text-toolbar.cpp:1967
+#: ../src/widgets/text-toolbar.cpp:2082
 msgid "Line Height"
 msgstr ""
 
 #. label
-#: ../src/widgets/text-toolbar.cpp:1968
+#: ../src/widgets/text-toolbar.cpp:2083
 msgid "Line:"
 msgstr ""
 
 #. short label
-#: ../src/widgets/text-toolbar.cpp:1969
+#: ../src/widgets/text-toolbar.cpp:2084
 msgid "Spacing between baselines (times font size)"
 msgstr ""
 
 #. Drop down menu
-#: ../src/widgets/text-toolbar.cpp:2001 ../src/widgets/text-toolbar.cpp:2032
+#: ../src/widgets/text-toolbar.cpp:2116 ../src/widgets/text-toolbar.cpp:2147
 msgid "Negative spacing"
 msgstr ""
 
-#: ../src/widgets/text-toolbar.cpp:2001 ../src/widgets/text-toolbar.cpp:2032
+#: ../src/widgets/text-toolbar.cpp:2116 ../src/widgets/text-toolbar.cpp:2147
 msgid "Positive spacing"
 msgstr ""
 
 #. name
-#: ../src/widgets/text-toolbar.cpp:2006
+#: ../src/widgets/text-toolbar.cpp:2121
 msgid "Word spacing"
 msgstr ""
 
 #. label
-#: ../src/widgets/text-toolbar.cpp:2007
+#: ../src/widgets/text-toolbar.cpp:2122
 msgid "Word:"
 msgstr ""
 
 #. short label
-#: ../src/widgets/text-toolbar.cpp:2008
+#: ../src/widgets/text-toolbar.cpp:2123
 msgid "Spacing between words (px)"
 msgstr ""
 
 #. name
-#: ../src/widgets/text-toolbar.cpp:2037
+#: ../src/widgets/text-toolbar.cpp:2152
 msgid "Letter spacing"
 msgstr ""
 
 #. label
-#: ../src/widgets/text-toolbar.cpp:2038
+#: ../src/widgets/text-toolbar.cpp:2153
 msgid "Letter:"
 msgstr ""
 
 #. short label
-#: ../src/widgets/text-toolbar.cpp:2039
+#: ../src/widgets/text-toolbar.cpp:2154
 msgid "Spacing between letters (px)"
 msgstr ""
 
 #. name
-#: ../src/widgets/text-toolbar.cpp:2068
+#: ../src/widgets/text-toolbar.cpp:2183
 msgid "Kerning"
 msgstr ""
 
 #. label
-#: ../src/widgets/text-toolbar.cpp:2069
+#: ../src/widgets/text-toolbar.cpp:2184
 msgid "Kern:"
 msgstr ""
 
 #. short label
-#: ../src/widgets/text-toolbar.cpp:2070
+#: ../src/widgets/text-toolbar.cpp:2185
 msgid "Horizontal kerning (px)"
 msgstr ""
 
 #. name
-#: ../src/widgets/text-toolbar.cpp:2099
+#: ../src/widgets/text-toolbar.cpp:2214
 msgid "Vertical Shift"
 msgstr ""
 
 #. label
-#: ../src/widgets/text-toolbar.cpp:2100
+#: ../src/widgets/text-toolbar.cpp:2215
 msgid "Vert:"
 msgstr ""
 
 #. short label
-#: ../src/widgets/text-toolbar.cpp:2101
+#: ../src/widgets/text-toolbar.cpp:2216
 msgid "Vertical shift (px)"
 msgstr ""
 
 #. name
-#: ../src/widgets/text-toolbar.cpp:2130
+#: ../src/widgets/text-toolbar.cpp:2245
 msgid "Letter rotation"
 msgstr ""
 
 #. label
-#: ../src/widgets/text-toolbar.cpp:2131
+#: ../src/widgets/text-toolbar.cpp:2246
 msgid "Rot:"
 msgstr ""
 
 #. short label
-#: ../src/widgets/text-toolbar.cpp:2132
+#: ../src/widgets/text-toolbar.cpp:2247
 msgid "Character rotation (degrees)"
 msgstr ""
 
 #. Name
-#: ../src/widgets/text-toolbar.cpp:2156
+#: ../src/widgets/text-toolbar.cpp:2271
 msgid "Unset line height"
 msgstr ""
 
 #. Label
-#: ../src/widgets/text-toolbar.cpp:2157
+#: ../src/widgets/text-toolbar.cpp:2272
 msgid "If enabled, line height is set on part of selection. Click to unset."
 msgstr ""
 
 #. Name
-#: ../src/widgets/text-toolbar.cpp:2169
+#: ../src/widgets/text-toolbar.cpp:2284
 msgid "Show outer style"
 msgstr ""
 
 #. Label
-#: ../src/widgets/text-toolbar.cpp:2170
+#: ../src/widgets/text-toolbar.cpp:2285
 msgid ""
 "Show style of outermost text element. The 'font-size' and 'line-height' "
 "values of the outermost text element determine the minimum line spacing in "
@@ -30374,131 +30435,131 @@ msgstr ""
 msgid "Style of Paint Bucket fill objects"
 msgstr ""
 
-#: ../src/widgets/toolbox.cpp:1758
+#: ../src/widgets/toolbox.cpp:1757
 msgid "Bounding box"
 msgstr ""
 
-#: ../src/widgets/toolbox.cpp:1758
+#: ../src/widgets/toolbox.cpp:1757
 msgid "Snap bounding boxes"
 msgstr ""
 
-#: ../src/widgets/toolbox.cpp:1767
+#: ../src/widgets/toolbox.cpp:1766
 msgid "Bounding box edges"
 msgstr ""
 
-#: ../src/widgets/toolbox.cpp:1767
+#: ../src/widgets/toolbox.cpp:1766
 msgid "Snap to edges of a bounding box"
 msgstr ""
 
-#: ../src/widgets/toolbox.cpp:1776
+#: ../src/widgets/toolbox.cpp:1775
 msgid "Bounding box corners"
 msgstr ""
 
-#: ../src/widgets/toolbox.cpp:1776
+#: ../src/widgets/toolbox.cpp:1775
 msgid "Snap bounding box corners"
 msgstr ""
 
-#: ../src/widgets/toolbox.cpp:1785
+#: ../src/widgets/toolbox.cpp:1784
 msgid "BBox Edge Midpoints"
 msgstr ""
 
-#: ../src/widgets/toolbox.cpp:1785
+#: ../src/widgets/toolbox.cpp:1784
 msgid "Snap midpoints of bounding box edges"
 msgstr ""
 
-#: ../src/widgets/toolbox.cpp:1795
+#: ../src/widgets/toolbox.cpp:1794
 msgid "BBox Centers"
 msgstr ""
 
-#: ../src/widgets/toolbox.cpp:1795
+#: ../src/widgets/toolbox.cpp:1794
 msgid "Snapping centers of bounding boxes"
 msgstr ""
 
-#: ../src/widgets/toolbox.cpp:1804
+#: ../src/widgets/toolbox.cpp:1803
 msgid "Snap nodes, paths, and handles"
 msgstr ""
 
-#: ../src/widgets/toolbox.cpp:1812
+#: ../src/widgets/toolbox.cpp:1811
 msgid "Snap to paths"
 msgstr ""
 
-#: ../src/widgets/toolbox.cpp:1821
+#: ../src/widgets/toolbox.cpp:1820
 msgid "Path intersections"
 msgstr ""
 
-#: ../src/widgets/toolbox.cpp:1821
+#: ../src/widgets/toolbox.cpp:1820
 msgid "Snap to path intersections"
 msgstr ""
 
-#: ../src/widgets/toolbox.cpp:1830
+#: ../src/widgets/toolbox.cpp:1829
 msgid "To nodes"
 msgstr ""
 
-#: ../src/widgets/toolbox.cpp:1830
+#: ../src/widgets/toolbox.cpp:1829
 msgid "Snap cusp nodes, incl. rectangle corners"
 msgstr ""
 
-#: ../src/widgets/toolbox.cpp:1839
+#: ../src/widgets/toolbox.cpp:1838
 msgid "Smooth nodes"
 msgstr ""
 
-#: ../src/widgets/toolbox.cpp:1839
+#: ../src/widgets/toolbox.cpp:1838
 msgid "Snap smooth nodes, incl. quadrant points of ellipses"
 msgstr ""
 
-#: ../src/widgets/toolbox.cpp:1848
+#: ../src/widgets/toolbox.cpp:1847
 msgid "Line Midpoints"
 msgstr ""
 
-#: ../src/widgets/toolbox.cpp:1848
+#: ../src/widgets/toolbox.cpp:1847
 msgid "Snap midpoints of line segments"
 msgstr ""
 
-#: ../src/widgets/toolbox.cpp:1857
+#: ../src/widgets/toolbox.cpp:1856
 msgid "Others"
 msgstr ""
 
-#: ../src/widgets/toolbox.cpp:1857
+#: ../src/widgets/toolbox.cpp:1856
 msgid "Snap other points (centers, guide origins, gradient handles, etc.)"
 msgstr ""
 
-#: ../src/widgets/toolbox.cpp:1865
+#: ../src/widgets/toolbox.cpp:1864
 msgid "Object Centers"
 msgstr ""
 
-#: ../src/widgets/toolbox.cpp:1865
+#: ../src/widgets/toolbox.cpp:1864
 msgid "Snap centers of objects"
 msgstr ""
 
-#: ../src/widgets/toolbox.cpp:1874
+#: ../src/widgets/toolbox.cpp:1873
 msgid "Rotation Centers"
 msgstr ""
 
-#: ../src/widgets/toolbox.cpp:1874
+#: ../src/widgets/toolbox.cpp:1873
 msgid "Snap an item's rotation center"
 msgstr ""
 
-#: ../src/widgets/toolbox.cpp:1883
+#: ../src/widgets/toolbox.cpp:1882
 msgid "Text baseline"
 msgstr ""
 
-#: ../src/widgets/toolbox.cpp:1883
+#: ../src/widgets/toolbox.cpp:1882
 msgid "Snap text anchors and baselines"
 msgstr ""
 
-#: ../src/widgets/toolbox.cpp:1893
+#: ../src/widgets/toolbox.cpp:1892
 msgid "Page border"
 msgstr ""
 
-#: ../src/widgets/toolbox.cpp:1893
+#: ../src/widgets/toolbox.cpp:1892
 msgid "Snap to the page border"
 msgstr ""
 
-#: ../src/widgets/toolbox.cpp:1902
+#: ../src/widgets/toolbox.cpp:1901
 msgid "Snap to grids"
 msgstr ""
 
-#: ../src/widgets/toolbox.cpp:1911
+#: ../src/widgets/toolbox.cpp:1910
 msgid "Snap guides"
 msgstr ""
 
@@ -30778,7 +30839,7 @@ msgid ""
 "option"
 msgstr ""
 
-#: ../share/extensions/dxf_outlines.py:357
+#: ../share/extensions/dxf_outlines.py:364
 #, python-format
 msgid "Warning: Layer '%s' not found!"
 msgstr ""

--- a/master/de.po
+++ b/master/de.po
@@ -22,7 +22,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: inkscape\n"
 "Report-Msgid-Bugs-To: inkscape-devel@lists.sourceforge.net\n"
-"POT-Creation-Date: 2017-07-30 23:09+0200\n"
+"POT-Creation-Date: 2018-01-29 21:05+0100\n"
 "PO-Revision-Date: 2017-08-05 00:39+0100\n"
 "Last-Translator: Eduard Braun <eduard.braun2@gmx.de>\n"
 "Language-Team: German <kde-i18n-de@kde.org>\n"
@@ -347,7 +347,7 @@ msgstr "Simuliere Ölgemälde"
 
 #. Pencil
 #: ../share/filters/filters.svg.h:78
-#: ../src/ui/dialog/inkscape-preferences.cpp:419
+#: ../src/ui/dialog/inkscape-preferences.cpp:459
 msgid "Pencil"
 msgstr "Malwerkzeug (Freihand)"
 
@@ -1144,7 +1144,7 @@ msgstr "Schwarzlicht"
 #: ../share/extensions/color_removered.inx.h:2
 #: ../share/extensions/color_replace.inx.h:6
 #: ../share/extensions/color_rgbbarrel.inx.h:2
-#: ../share/extensions/interp_att_g.inx.h:21
+#: ../share/extensions/interp_att_g.inx.h:24
 msgid "Color"
 msgstr "Farbe"
 
@@ -4477,16 +4477,16 @@ msgstr "Ohne Ebenen, leer"
 
 #. 3D box
 #: ../src/box3d.cpp:251 ../src/box3d.cpp:1305
-#: ../src/ui/dialog/inkscape-preferences.cpp:402
+#: ../src/ui/dialog/inkscape-preferences.cpp:442
 msgid "3D Box"
 msgstr "3D-Box"
 
-#: ../src/color-profile.cpp:897 ../src/color-profile.cpp:914
+#: ../src/color-profile.cpp:913 ../src/color-profile.cpp:930
 msgid "(invalid UTF-8 string)"
 msgstr "(ungültiger UTF-8 string)"
 
 # CHECK
-#: ../src/color-profile.cpp:899
+#: ../src/color-profile.cpp:915
 msgctxt "Profile name"
 msgid "None"
 msgstr "Kein"
@@ -4521,102 +4521,102 @@ msgstr "Hilfslinie löschen"
 msgid "<b>Guideline</b>: %s"
 msgstr "<b>Hilfslinie</b>: %s"
 
-#: ../src/desktop.cpp:766
+#: ../src/desktop.cpp:760
 #, fuzzy
 msgid "No previous transform."
 msgstr "Kein vorheriger Zoomfaktor."
 
-#: ../src/desktop.cpp:789
+#: ../src/desktop.cpp:783
 #, fuzzy
 msgid "No next transform."
 msgstr "Transformationen zurücksetzen"
 
-#: ../src/display/canvas-axonomgrid.cpp:325 ../src/display/canvas-grid.cpp:683
+#: ../src/display/canvas-axonomgrid.cpp:325 ../src/display/canvas-grid.cpp:680
 msgid "Grid _units:"
 msgstr "Gitter-Raster_einheiten:"
 
-#: ../src/display/canvas-axonomgrid.cpp:327 ../src/display/canvas-grid.cpp:685
+#: ../src/display/canvas-axonomgrid.cpp:327 ../src/display/canvas-grid.cpp:682
 msgid "_Origin X:"
 msgstr "_Ursprung X:"
 
-#: ../src/display/canvas-axonomgrid.cpp:327 ../src/display/canvas-grid.cpp:685
-#: ../src/ui/dialog/inkscape-preferences.cpp:777
-#: ../src/ui/dialog/inkscape-preferences.cpp:802
+#: ../src/display/canvas-axonomgrid.cpp:327 ../src/display/canvas-grid.cpp:682
+#: ../src/ui/dialog/inkscape-preferences.cpp:832
+#: ../src/ui/dialog/inkscape-preferences.cpp:857
 msgid "X coordinate of grid origin"
 msgstr "X-Koordinate des Gitterursprungs"
 
-#: ../src/display/canvas-axonomgrid.cpp:330 ../src/display/canvas-grid.cpp:688
+#: ../src/display/canvas-axonomgrid.cpp:330 ../src/display/canvas-grid.cpp:685
 msgid "O_rigin Y:"
 msgstr "U_rsprung Y:"
 
-#: ../src/display/canvas-axonomgrid.cpp:330 ../src/display/canvas-grid.cpp:688
-#: ../src/ui/dialog/inkscape-preferences.cpp:778
-#: ../src/ui/dialog/inkscape-preferences.cpp:803
+#: ../src/display/canvas-axonomgrid.cpp:330 ../src/display/canvas-grid.cpp:685
+#: ../src/ui/dialog/inkscape-preferences.cpp:833
+#: ../src/ui/dialog/inkscape-preferences.cpp:858
 msgid "Y coordinate of grid origin"
 msgstr "Y-Koordinate des Gitterursprungs"
 
-#: ../src/display/canvas-axonomgrid.cpp:333 ../src/display/canvas-grid.cpp:694
+#: ../src/display/canvas-axonomgrid.cpp:333 ../src/display/canvas-grid.cpp:691
 msgid "Spacing _Y:"
 msgstr "Abstand _Y:"
 
 #: ../src/display/canvas-axonomgrid.cpp:333
-#: ../src/ui/dialog/inkscape-preferences.cpp:806
+#: ../src/ui/dialog/inkscape-preferences.cpp:861
 msgid "Base length of z-axis"
 msgstr "Basislänge der Z-Achse"
 
 #: ../src/display/canvas-axonomgrid.cpp:336
-#: ../src/ui/dialog/inkscape-preferences.cpp:809
+#: ../src/ui/dialog/inkscape-preferences.cpp:864
 #: ../src/widgets/box3d-toolbar.cpp:301
 msgid "Angle X:"
 msgstr "Winkel X:"
 
 #: ../src/display/canvas-axonomgrid.cpp:336
-#: ../src/ui/dialog/inkscape-preferences.cpp:809
+#: ../src/ui/dialog/inkscape-preferences.cpp:864
 msgid "Angle of x-axis"
 msgstr "Winkel der X-Achse"
 
 #: ../src/display/canvas-axonomgrid.cpp:338
-#: ../src/ui/dialog/inkscape-preferences.cpp:810
+#: ../src/ui/dialog/inkscape-preferences.cpp:865
 #: ../src/widgets/box3d-toolbar.cpp:380
 msgid "Angle Z:"
 msgstr "Winkel Z:"
 
 #: ../src/display/canvas-axonomgrid.cpp:338
-#: ../src/ui/dialog/inkscape-preferences.cpp:810
+#: ../src/ui/dialog/inkscape-preferences.cpp:865
 msgid "Angle of z-axis"
 msgstr "Winkel der Z-Achse"
 
-#: ../src/display/canvas-axonomgrid.cpp:342 ../src/display/canvas-grid.cpp:699
+#: ../src/display/canvas-axonomgrid.cpp:342 ../src/display/canvas-grid.cpp:696
 msgid "Minor grid line _color:"
 msgstr "Nebengitterlinienfarbe:"
 
-#: ../src/display/canvas-axonomgrid.cpp:342 ../src/display/canvas-grid.cpp:699
-#: ../src/ui/dialog/inkscape-preferences.cpp:761
+#: ../src/display/canvas-axonomgrid.cpp:342 ../src/display/canvas-grid.cpp:696
+#: ../src/ui/dialog/inkscape-preferences.cpp:816
 msgid "Minor grid line color"
 msgstr "Nebengitterlinienfarbe:"
 
-#: ../src/display/canvas-axonomgrid.cpp:342 ../src/display/canvas-grid.cpp:699
+#: ../src/display/canvas-axonomgrid.cpp:342 ../src/display/canvas-grid.cpp:696
 msgid "Color of the minor grid lines"
 msgstr "Farbe der Nebengitterlinien"
 
-#: ../src/display/canvas-axonomgrid.cpp:347 ../src/display/canvas-grid.cpp:704
+#: ../src/display/canvas-axonomgrid.cpp:347 ../src/display/canvas-grid.cpp:701
 msgid "Ma_jor grid line color:"
 msgstr "Farbe der _dicken Gitterlinien:"
 
-#: ../src/display/canvas-axonomgrid.cpp:347 ../src/display/canvas-grid.cpp:704
-#: ../src/ui/dialog/inkscape-preferences.cpp:763
+#: ../src/display/canvas-axonomgrid.cpp:347 ../src/display/canvas-grid.cpp:701
+#: ../src/ui/dialog/inkscape-preferences.cpp:818
 msgid "Major grid line color"
 msgstr "Farbe der dicken Gitterlinien"
 
-#: ../src/display/canvas-axonomgrid.cpp:348 ../src/display/canvas-grid.cpp:705
+#: ../src/display/canvas-axonomgrid.cpp:348 ../src/display/canvas-grid.cpp:702
 msgid "Color of the major (highlighted) grid lines"
 msgstr "Farbe der dicken (hervorgehobenen) Gitterlinien"
 
-#: ../src/display/canvas-axonomgrid.cpp:352 ../src/display/canvas-grid.cpp:709
+#: ../src/display/canvas-axonomgrid.cpp:352 ../src/display/canvas-grid.cpp:706
 msgid "_Major grid line every:"
 msgstr "D_icke Gitterlinien alle:"
 
-#: ../src/display/canvas-axonomgrid.cpp:352 ../src/display/canvas-grid.cpp:709
+#: ../src/display/canvas-axonomgrid.cpp:352 ../src/display/canvas-grid.cpp:706
 msgid "lines"
 msgstr "Linien"
 
@@ -4628,15 +4628,15 @@ msgstr "Rechteckiges Gitter"
 msgid "Axonometric grid"
 msgstr "Axonometrisches Gitter"
 
-#: ../src/display/canvas-grid.cpp:242
+#: ../src/display/canvas-grid.cpp:239
 msgid "Create new grid"
 msgstr "Neues Gitter erzeugen"
 
-#: ../src/display/canvas-grid.cpp:308
+#: ../src/display/canvas-grid.cpp:305
 msgid "_Enabled"
 msgstr "Aktivi_ert"
 
-#: ../src/display/canvas-grid.cpp:309
+#: ../src/display/canvas-grid.cpp:306
 msgid ""
 "Determines whether to snap to this grid or not. Can be 'on' for invisible "
 "grids."
@@ -4644,11 +4644,11 @@ msgstr ""
 "Legt fest, ob an diesem Raster eingerastet werden soll. Kann auch für "
 "unsichtbare Gitter aktiviert werden."
 
-#: ../src/display/canvas-grid.cpp:313
+#: ../src/display/canvas-grid.cpp:310
 msgid "Snap to visible _grid lines only"
 msgstr "Nur an sichtbaren _Gitternlinien einrasten"
 
-#: ../src/display/canvas-grid.cpp:314
+#: ../src/display/canvas-grid.cpp:311
 msgid ""
 "When zoomed out, not all grid lines will be displayed. Only the visible ones "
 "will be snapped to"
@@ -4656,11 +4656,11 @@ msgstr ""
 "Nicht alle Gitterlinien werden dargestellt, wenn stark heraus gezoomt wird. "
 "Nur an sichtbaren Linien wird eingerastet."
 
-#: ../src/display/canvas-grid.cpp:318
+#: ../src/display/canvas-grid.cpp:315
 msgid "_Visible"
 msgstr "Sichtbar"
 
-#: ../src/display/canvas-grid.cpp:319
+#: ../src/display/canvas-grid.cpp:316
 msgid ""
 "Determines whether the grid is displayed or not. Objects are still snapped "
 "to invisible grids."
@@ -4668,25 +4668,25 @@ msgstr ""
 "Legt fest, ob das Raster angezeigt werden soll. Objekte rasten auch an "
 "unsichtbaren Gittern ein."
 
-#: ../src/display/canvas-grid.cpp:691
+#: ../src/display/canvas-grid.cpp:688
 msgid "Spacing _X:"
 msgstr "Abstand _X:"
 
-#: ../src/display/canvas-grid.cpp:691
-#: ../src/ui/dialog/inkscape-preferences.cpp:783
+#: ../src/display/canvas-grid.cpp:688
+#: ../src/ui/dialog/inkscape-preferences.cpp:838
 msgid "Distance between vertical grid lines"
 msgstr "Abstand der vertikalen Gitterlinien"
 
-#: ../src/display/canvas-grid.cpp:694
-#: ../src/ui/dialog/inkscape-preferences.cpp:784
+#: ../src/display/canvas-grid.cpp:691
+#: ../src/ui/dialog/inkscape-preferences.cpp:839
 msgid "Distance between horizontal grid lines"
 msgstr "Abstand der horizontalen Gitterlinien"
 
-#: ../src/display/canvas-grid.cpp:726
+#: ../src/display/canvas-grid.cpp:723
 msgid "_Show dots instead of lines"
 msgstr "Punkte anstatt Linien verwenden"
 
-#: ../src/display/canvas-grid.cpp:727
+#: ../src/display/canvas-grid.cpp:724
 msgid "If set, displays dots at gridpoints instead of gridlines"
 msgstr ""
 "Wenn aktiviert, werden Punkte an Gitterüberschneidungen anstelle von "
@@ -4839,11 +4839,11 @@ msgstr "Mittelpunkt des Objektrahmens"
 msgid "Bounding box side midpoint"
 msgstr "Mittelpunkt der Objektrahmenlinie"
 
-#: ../src/display/snap-indicator.cpp:196 ../src/ui/tool/node.cpp:1473
+#: ../src/display/snap-indicator.cpp:196 ../src/ui/tool/node.cpp:1468
 msgid "Smooth node"
 msgstr "Glatter Knoten"
 
-#: ../src/display/snap-indicator.cpp:199 ../src/ui/tool/node.cpp:1472
+#: ../src/display/snap-indicator.cpp:199 ../src/ui/tool/node.cpp:1467
 msgid "Cusp node"
 msgstr "Spitzer Knoten"
 
@@ -4899,35 +4899,35 @@ msgstr "Mehrfaches der Gitterweite"
 msgid " to "
 msgstr " an "
 
-#: ../src/document.cpp:553
+#: ../src/document.cpp:555
 #, c-format
 msgid "New document %d"
 msgstr "Neues Dokument %d"
 
-#: ../src/document.cpp:558
+#: ../src/document.cpp:560
 #, c-format
 msgid "Memory document %d"
 msgstr "Dokument im Speicher %d"
 
-#: ../src/document.cpp:587
+#: ../src/document.cpp:589
 msgid "Memory document %1"
 msgstr "Dokument im Speicher %1"
 
-#: ../src/document.cpp:886
+#: ../src/document.cpp:888
 #, c-format
 msgid "Unnamed document %d"
 msgstr "Unbenanntes Dokument %d"
 
-#: ../src/event-log.cpp:181
+#: ../src/event-log.cpp:179
 msgid "[Unchanged]"
 msgstr "[Unverändert]"
 
 #. Edit
-#: ../src/event-log.cpp:367 ../src/event-log.cpp:370 ../src/verbs.cpp:2595
+#: ../src/event-log.cpp:365 ../src/event-log.cpp:368 ../src/verbs.cpp:2625
 msgid "_Undo"
 msgstr "_Rückgängig"
 
-#: ../src/event-log.cpp:377 ../src/event-log.cpp:381 ../src/verbs.cpp:2597
+#: ../src/event-log.cpp:375 ../src/event-log.cpp:379 ../src/verbs.cpp:2627
 msgid "_Redo"
 msgstr "_Wiederherstellen"
 
@@ -4955,12 +4955,12 @@ msgstr "  Beschreibung: "
 msgid " (No preferences)"
 msgstr " (Keine Einstellungen)"
 
-#: ../src/extension/effect.h:70 ../src/verbs.cpp:2367
+#: ../src/extension/effect.h:70 ../src/verbs.cpp:2397
 msgid "Extensions"
 msgstr "Erweiterungen"
 
 #. \FIXME change this
-#. This is some filler text, needs to change before relase
+#. This is some filler text, needs to change before release
 #: ../src/extension/error-file.cpp:54
 msgid ""
 "<span weight=\"bold\" size=\"larger\">One or more extensions failed to load</"
@@ -4982,14 +4982,14 @@ msgstr ""
 msgid "Show dialog on startup"
 msgstr "Dialog bei Programmstart anzeigen"
 
-#: ../src/extension/execution-env.cpp:133
+#: ../src/extension/execution-env.cpp:134
 #, c-format
 msgid "'%s' working, please wait..."
 msgstr "„%s“ arbeitet, bitte warten..."
 
 #. static int i = 0;
 #. std::cout << "Checking module[" << i++ << "]: " << name << std::endl;
-#: ../src/extension/extension.cpp:262
+#: ../src/extension/extension.cpp:259
 msgid ""
 "  This is caused by an improper .inx file for this extension.  An improper ."
 "inx file could have been caused by a faulty installation of Inkscape."
@@ -4998,71 +4998,71 @@ msgstr ""
 "verursacht. Eine fehlerhafte „.inx“-Datei kann Folge einer Fehlinstallation "
 "von Inkscape sein."
 
-#: ../src/extension/extension.cpp:272
+#: ../src/extension/extension.cpp:269
 msgid "the extension is designed for Windows only."
 msgstr "diese Erweiterung nur für Windows entwickelt wurde."
 
-#: ../src/extension/extension.cpp:277
+#: ../src/extension/extension.cpp:274
 msgid "an ID was not defined for it."
 msgstr "hierfür keine ID definiert wurde."
 
-#: ../src/extension/extension.cpp:281
+#: ../src/extension/extension.cpp:278
 msgid "there was no name defined for it."
 msgstr "hierfür kein Name definiert wurde."
 
-#: ../src/extension/extension.cpp:285
+#: ../src/extension/extension.cpp:282
 msgid "the XML description of it got lost."
 msgstr "die zugehörige XML-Beschreibung nicht auffindbar ist."
 
-#: ../src/extension/extension.cpp:289
+#: ../src/extension/extension.cpp:286
 msgid "no implementation was defined for the extension."
 msgstr "für diese Erweiterung keine Implementierung existiert."
 
 #. std::cout << "Failed: " << *(_deps[i]) << std::endl;
-#: ../src/extension/extension.cpp:296
+#: ../src/extension/extension.cpp:293
 msgid "a dependency was not met."
 msgstr "eine Abhängigkeit nicht aufgelöst werden konnte."
 
-#: ../src/extension/extension.cpp:316
+#: ../src/extension/extension.cpp:313
 msgid "Extension \""
 msgstr "Erweiterung „"
 
-#: ../src/extension/extension.cpp:316
+#: ../src/extension/extension.cpp:313
 msgid "\" failed to load because "
 msgstr "“: Laden fehlgeschlagen, da "
 
-#: ../src/extension/extension.cpp:665
+#: ../src/extension/extension.cpp:659
 #, c-format
 msgid "Could not create extension error log file '%s'"
 msgstr ""
 "Fehlerprotokolldatei für Erweiterungen „%s“ konnte nicht erzeugt werden."
 
-#: ../src/extension/extension.cpp:777
+#: ../src/extension/extension.cpp:769
 #: ../share/extensions/webslicer_create_rect.inx.h:2
 msgid "Name:"
 msgstr "Name:"
 
-#: ../src/extension/extension.cpp:778
+#: ../src/extension/extension.cpp:770
 msgid "ID:"
 msgstr "Kennung:"
 
-#: ../src/extension/extension.cpp:779
+#: ../src/extension/extension.cpp:771
 msgid "State:"
 msgstr "Status:"
 
-#: ../src/extension/extension.cpp:779
+#: ../src/extension/extension.cpp:771
 msgid "Loaded"
 msgstr "Geladen"
 
-#: ../src/extension/extension.cpp:779
+#: ../src/extension/extension.cpp:771
 msgid "Unloaded"
 msgstr "Nicht geladen"
 
-#: ../src/extension/extension.cpp:779
+#: ../src/extension/extension.cpp:771
 msgid "Deactivated"
 msgstr "Deaktiviert"
 
-#: ../src/extension/extension.cpp:810
+#: ../src/extension/extension.cpp:802
 msgid ""
 "Currently there is no help available for this Extension.  Please look on the "
 "Inkscape website or ask on the mailing lists if you have questions regarding "
@@ -5072,7 +5072,12 @@ msgstr ""
 "Inkscape-Webseite oder wenden Sie sich an die Mailingliste, wenn Sie Fragen "
 "zu dieser Erweiterung haben."
 
-#: ../src/extension/implementation/script.cpp:1094
+#: ../src/extension/implementation/script.cpp:746
+#, fuzzy
+msgid "The output from the extension could not be parsed."
+msgstr "Die Einstellungsdatei %s konnte nicht gelesen werden."
+
+#: ../src/extension/implementation/script.cpp:1110
 msgid ""
 "Inkscape has received additional data from the script executed.  The script "
 "did not return an error, but this may indicate the results will not be as "
@@ -5093,9 +5098,9 @@ msgstr "Adaptiver Schwellwert"
 #: ../src/ui/dialog/lpe-powerstroke-properties.cpp:61
 #: ../src/ui/dialog/object-attributes.cpp:65
 #: ../src/ui/dialog/object-attributes.cpp:74
-#: ../src/ui/widget/page-sizer.cpp:232
-#: ../src/widgets/calligraphy-toolbar.cpp:430
-#: ../src/widgets/eraser-toolbar.cpp:187 ../src/widgets/spray-toolbar.cpp:297
+#: ../src/ui/widget/page-sizer.cpp:234
+#: ../src/widgets/calligraphy-toolbar.cpp:401
+#: ../src/widgets/eraser-toolbar.cpp:191 ../src/widgets/spray-toolbar.cpp:297
 #: ../src/widgets/tweak-toolbar.cpp:128 ../share/extensions/foldablebox.inx.h:2
 msgid "Width:"
 msgstr "Breite:"
@@ -5105,12 +5110,12 @@ msgstr "Breite:"
 #: ../src/extension/internal/bitmap/sample.cpp:42
 #: ../src/ui/dialog/object-attributes.cpp:66
 #: ../src/ui/dialog/object-attributes.cpp:75
-#: ../src/ui/widget/page-sizer.cpp:233 ../share/extensions/foldablebox.inx.h:3
+#: ../src/ui/widget/page-sizer.cpp:235 ../share/extensions/foldablebox.inx.h:3
 msgid "Height:"
 msgstr "Höhe:"
 
 #: ../src/extension/internal/bitmap/adaptiveThreshold.cpp:43
-#: ../src/widgets/measure-toolbar.cpp:328
+#: ../src/widgets/measure-toolbar.cpp:346
 #: ../share/extensions/printing_marks.inx.h:12
 msgid "Offset:"
 msgstr "Versatz:"
@@ -5169,8 +5174,8 @@ msgstr "Rauschen hinzufügen"
 #: ../src/extension/internal/filter/color.h:1660
 #: ../src/extension/internal/filter/distort.h:69
 #: ../src/extension/internal/filter/morphology.h:60 ../src/rdf.cpp:244
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2748
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2828
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2765
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2845
 #: ../src/ui/dialog/object-attributes.cpp:46
 #: ../share/extensions/jessyInk_effects.inx.h:5
 #: ../share/extensions/jessyInk_export.inx.h:3
@@ -5222,7 +5227,7 @@ msgstr "Unschärfe"
 #: ../src/extension/internal/bitmap/oilPaint.cpp:39
 #: ../src/extension/internal/bitmap/sharpen.cpp:40
 #: ../src/extension/internal/bitmap/unsharpmask.cpp:43
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2800
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2817
 msgid "Radius:"
 msgstr "Radius:"
 
@@ -5360,7 +5365,7 @@ msgstr "Rotiere Farbpalette"
 #: ../src/extension/internal/bitmap/cycleColormap.cpp:39
 #: ../src/extension/internal/bitmap/spread.cpp:39
 #: ../src/extension/internal/bitmap/unsharpmask.cpp:45
-#: ../src/widgets/spray-toolbar.cpp:411
+#: ../src/widgets/spray-toolbar.cpp:409
 msgid "Amount:"
 msgstr "Menge:"
 
@@ -5546,13 +5551,13 @@ msgstr "Ausgewählte Bitmap(s) wie mit Ölfarbe gemalt aussehen lassen"
 #: ../src/extension/internal/filter/transparency.h:279
 #: ../src/ui/dialog/clonetiler.cpp:791 ../src/ui/dialog/clonetiler.cpp:922
 #: ../src/widgets/tweak-toolbar.cpp:334
-#: ../share/extensions/interp_att_g.inx.h:18
+#: ../share/extensions/interp_att_g.inx.h:20
 msgid "Opacity"
 msgstr "Deckkraft"
 
 #: ../src/extension/internal/bitmap/opacity.cpp:40
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2790
-#: ../src/ui/dialog/objects.cpp:1650 ../src/widgets/dropper-toolbar.cpp:83
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2807
+#: ../src/widgets/dropper-toolbar.cpp:83
 msgid "Opacity:"
 msgstr "Deckkraft:"
 
@@ -5724,130 +5729,130 @@ msgstr "Anzahl der geschrumpften/erweiterten Kopien des Objekts"
 msgid "Generate from Path"
 msgstr "Aus Pfad erzeugen"
 
-#: ../src/extension/internal/cairo-ps-out.cpp:327
+#: ../src/extension/internal/cairo-ps-out.cpp:330
 #: ../share/extensions/ps_input.inx.h:3
 msgid "PostScript"
 msgstr "PostScript"
 
-#: ../src/extension/internal/cairo-ps-out.cpp:329
-#: ../src/extension/internal/cairo-ps-out.cpp:371
+#: ../src/extension/internal/cairo-ps-out.cpp:332
+#: ../src/extension/internal/cairo-ps-out.cpp:374
 msgid "Restrict to PS level:"
 msgstr "PostScript Level einschränken"
 
-#: ../src/extension/internal/cairo-ps-out.cpp:330
-#: ../src/extension/internal/cairo-ps-out.cpp:372
+#: ../src/extension/internal/cairo-ps-out.cpp:333
+#: ../src/extension/internal/cairo-ps-out.cpp:375
 msgid "PostScript level 3"
 msgstr "PostScript Level 3"
 
-#: ../src/extension/internal/cairo-ps-out.cpp:331
-#: ../src/extension/internal/cairo-ps-out.cpp:373
-msgid "PostScript level 2"
-msgstr "PostScript Level 2"
-
-#: ../src/extension/internal/cairo-ps-out.cpp:333
-#: ../src/extension/internal/cairo-ps-out.cpp:375
-#: ../src/extension/internal/cairo-renderer-pdf-out.cpp:250
-msgid "Text output options:"
-msgstr "Einstellungen für Textausgabe:"
-
 #: ../src/extension/internal/cairo-ps-out.cpp:334
 #: ../src/extension/internal/cairo-ps-out.cpp:376
-#: ../src/extension/internal/cairo-renderer-pdf-out.cpp:251
-msgid "Embed fonts"
-msgstr "Schriftarten einbetten"
-
-#: ../src/extension/internal/cairo-ps-out.cpp:335
-#: ../src/extension/internal/cairo-ps-out.cpp:377
-#: ../src/extension/internal/cairo-renderer-pdf-out.cpp:252
-msgid "Convert text to paths"
-msgstr "Texte in Pfade umwandeln"
+msgid "PostScript level 2"
+msgstr "PostScript Level 2"
 
 #: ../src/extension/internal/cairo-ps-out.cpp:336
 #: ../src/extension/internal/cairo-ps-out.cpp:378
 #: ../src/extension/internal/cairo-renderer-pdf-out.cpp:253
-msgid "Omit text in PDF and create LaTeX file"
-msgstr "Text in PDF weglassen und LaTeX Datei erstellen"
+msgid "Text output options:"
+msgstr "Einstellungen für Textausgabe:"
+
+#: ../src/extension/internal/cairo-ps-out.cpp:337
+#: ../src/extension/internal/cairo-ps-out.cpp:379
+#: ../src/extension/internal/cairo-renderer-pdf-out.cpp:254
+msgid "Embed fonts"
+msgstr "Schriftarten einbetten"
 
 #: ../src/extension/internal/cairo-ps-out.cpp:338
 #: ../src/extension/internal/cairo-ps-out.cpp:380
 #: ../src/extension/internal/cairo-renderer-pdf-out.cpp:255
-msgid "Rasterize filter effects"
-msgstr "Filtereffekte in Raster umwandeln"
+msgid "Convert text to paths"
+msgstr "Texte in Pfade umwandeln"
 
 #: ../src/extension/internal/cairo-ps-out.cpp:339
 #: ../src/extension/internal/cairo-ps-out.cpp:381
 #: ../src/extension/internal/cairo-renderer-pdf-out.cpp:256
-msgid "Resolution for rasterization (dpi):"
-msgstr "Auflösung des Rasters (dpi)"
-
-#: ../src/extension/internal/cairo-ps-out.cpp:340
-#: ../src/extension/internal/cairo-ps-out.cpp:382
-msgid "Output page size"
-msgstr "Seitengröße der Ausgabe"
+msgid "Omit text in PDF and create LaTeX file"
+msgstr "Text in PDF weglassen und LaTeX Datei erstellen"
 
 #: ../src/extension/internal/cairo-ps-out.cpp:341
 #: ../src/extension/internal/cairo-ps-out.cpp:383
 #: ../src/extension/internal/cairo-renderer-pdf-out.cpp:258
-msgid "Use document's page size"
-msgstr "Seitengröße des Dokuments verwenden"
+msgid "Rasterize filter effects"
+msgstr "Filtereffekte in Raster umwandeln"
 
 #: ../src/extension/internal/cairo-ps-out.cpp:342
 #: ../src/extension/internal/cairo-ps-out.cpp:384
 #: ../src/extension/internal/cairo-renderer-pdf-out.cpp:259
-msgid "Use exported object's size"
-msgstr "Größe des exportierten Objekts verwenden"
+msgid "Resolution for rasterization (dpi):"
+msgstr "Auflösung des Rasters (dpi)"
+
+#: ../src/extension/internal/cairo-ps-out.cpp:343
+#: ../src/extension/internal/cairo-ps-out.cpp:385
+msgid "Output page size"
+msgstr "Seitengröße der Ausgabe"
 
 #: ../src/extension/internal/cairo-ps-out.cpp:344
+#: ../src/extension/internal/cairo-ps-out.cpp:386
 #: ../src/extension/internal/cairo-renderer-pdf-out.cpp:261
-msgid "Bleed/margin (mm):"
-msgstr "Beschnittzugabe/Rand (mm):"
+msgid "Use document's page size"
+msgstr "Seitengröße des Dokuments verwenden"
 
 #: ../src/extension/internal/cairo-ps-out.cpp:345
 #: ../src/extension/internal/cairo-ps-out.cpp:387
 #: ../src/extension/internal/cairo-renderer-pdf-out.cpp:262
+msgid "Use exported object's size"
+msgstr "Größe des exportierten Objekts verwenden"
+
+#: ../src/extension/internal/cairo-ps-out.cpp:347
+#: ../src/extension/internal/cairo-renderer-pdf-out.cpp:264
+msgid "Bleed/margin (mm):"
+msgstr "Beschnittzugabe/Rand (mm):"
+
+#: ../src/extension/internal/cairo-ps-out.cpp:348
+#: ../src/extension/internal/cairo-ps-out.cpp:390
+#: ../src/extension/internal/cairo-renderer-pdf-out.cpp:265
 msgid "Limit export to the object with ID:"
 msgstr "Export beschränken auf das Objekt mit ID"
 
-#: ../src/extension/internal/cairo-ps-out.cpp:349
+#: ../src/extension/internal/cairo-ps-out.cpp:352
 #: ../share/extensions/ps_input.inx.h:2
 msgid "PostScript (*.ps)"
 msgstr "PostScript (*.ps)"
 
-#: ../src/extension/internal/cairo-ps-out.cpp:350
+#: ../src/extension/internal/cairo-ps-out.cpp:353
 msgid "PostScript File"
 msgstr "Postscript-Datei"
 
-#: ../src/extension/internal/cairo-ps-out.cpp:369
+#: ../src/extension/internal/cairo-ps-out.cpp:372
 #: ../share/extensions/eps_input.inx.h:3
 msgid "Encapsulated PostScript"
 msgstr "Encapsulated Postscript"
 
-#: ../src/extension/internal/cairo-ps-out.cpp:386
+#: ../src/extension/internal/cairo-ps-out.cpp:389
 msgid "Bleed/margin (mm)"
 msgstr "Beschnittzugabe/Rand (mm)"
 
-#: ../src/extension/internal/cairo-ps-out.cpp:391
+#: ../src/extension/internal/cairo-ps-out.cpp:394
 #: ../share/extensions/eps_input.inx.h:2
 msgid "Encapsulated PostScript (*.eps)"
 msgstr "Encapsulated Postscript (*.eps)"
 
-#: ../src/extension/internal/cairo-ps-out.cpp:392
+#: ../src/extension/internal/cairo-ps-out.cpp:395
 msgid "Encapsulated PostScript File"
 msgstr "Encapsulated-Postscript-Datei"
 
-#: ../src/extension/internal/cairo-renderer-pdf-out.cpp:244
+#: ../src/extension/internal/cairo-renderer-pdf-out.cpp:247
 msgid "Restrict to PDF version:"
 msgstr "Auf PDF-Version einschränken:"
 
-#: ../src/extension/internal/cairo-renderer-pdf-out.cpp:246
+#: ../src/extension/internal/cairo-renderer-pdf-out.cpp:249
 msgid "PDF 1.5"
 msgstr "PDF 1.5"
 
-#: ../src/extension/internal/cairo-renderer-pdf-out.cpp:248
+#: ../src/extension/internal/cairo-renderer-pdf-out.cpp:251
 msgid "PDF 1.4"
 msgstr "PDF 1.4"
 
-#: ../src/extension/internal/cairo-renderer-pdf-out.cpp:257
+#: ../src/extension/internal/cairo-renderer-pdf-out.cpp:260
 msgid "Output page size:"
 msgstr "Seitengröße der Ausgabe:"
 
@@ -5887,17 +5892,17 @@ msgstr "von %i"
 #: ../src/extension/internal/vsd-input.cpp:150
 #: ../src/extension/prefdialog.cpp:74
 #: ../src/ui/dialog/calligraphic-profile-rename.cpp:50
-#: ../src/ui/dialog/export.cpp:915 ../src/ui/dialog/export.cpp:1299
-#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:738
-#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:1052
-#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:1599
+#: ../src/ui/dialog/export.cpp:912 ../src/ui/dialog/export.cpp:1296
+#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:728
+#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:1042
+#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:1602
 #: ../src/ui/dialog/guides.cpp:161 ../src/ui/dialog/layer-properties.cpp:42
 #: ../src/ui/dialog/livepatheffect-add.cpp:26
 #: ../src/ui/dialog/lpe-fillet-chamfer-properties.cpp:33
 #: ../src/ui/dialog/lpe-powerstroke-properties.cpp:39
-#: ../src/ui/dialog/ocaldialogs.cpp:1089 ../src/ui/interface.cpp:1406
-#: ../src/widgets/desktop-widget.cpp:1089
-#: ../src/widgets/desktop-widget.cpp:1151
+#: ../src/ui/dialog/ocaldialogs.cpp:1090 ../src/ui/interface.cpp:1368
+#: ../src/widgets/desktop-widget.cpp:1102
+#: ../src/widgets/desktop-widget.cpp:1164
 msgid "_Cancel"
 msgstr "_Abbrechen"
 
@@ -5912,7 +5917,7 @@ msgstr "_OK"
 #. Fill in the template
 #: ../src/extension/internal/cdr-input.cpp:220
 #: ../src/extension/internal/vsd-input.cpp:221
-#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:427
+#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:423
 msgid "No preview"
 msgstr "Keine Vorschau"
 
@@ -6126,7 +6131,7 @@ msgstr "Hervorhebungsfarbe"
 #: ../src/extension/internal/filter/transparency.h:214
 #: ../src/extension/internal/filter/transparency.h:287
 #: ../src/extension/internal/filter/transparency.h:349
-#: ../src/ui/dialog/inkscape-preferences.cpp:1774
+#: ../src/ui/dialog/inkscape-preferences.cpp:1835
 #, c-format
 msgid "Filters"
 msgstr "Filter"
@@ -6236,7 +6241,7 @@ msgstr "Abdunkeln"
 #: ../src/extension/internal/filter/color.h:1669
 #: ../src/extension/internal/filter/paint.h:703
 #: ../src/extension/internal/filter/transparency.h:62
-#: ../src/filter-enums.cpp:54 ../src/ui/dialog/input.cpp:367
+#: ../src/filter-enums.cpp:54 ../src/ui/dialog/input.cpp:368
 msgid "Screen"
 msgstr "Negativ multiplizieren"
 
@@ -6338,7 +6343,7 @@ msgstr "Mischmodus:"
 #: ../src/extension/internal/filter/textures.h:77
 #: ../src/extension/internal/filter/transparency.h:61
 #: ../src/filter-enums.cpp:52 ../src/live_effects/lpe-copy_rotate.cpp:34
-#: ../src/ui/dialog/inkscape-preferences.cpp:684
+#: ../src/ui/dialog/inkscape-preferences.cpp:735
 msgid "Normal"
 msgstr "Normal"
 
@@ -6377,7 +6382,7 @@ msgstr "Stoß-Quelle"
 #: ../src/extension/internal/filter/transparency.h:132
 #: ../src/filter-enums.cpp:128 ../src/ui/tools/flood-tool.cpp:82
 #: ../src/ui/widget/color-icc-selector.cpp:154
-#: ../src/ui/widget/color-scales.cpp:356 ../src/ui/widget/color-scales.cpp:357
+#: ../src/ui/widget/color-scales.cpp:367 ../src/ui/widget/color-scales.cpp:368
 msgid "Red"
 msgstr "Rot"
 
@@ -6389,7 +6394,7 @@ msgstr "Rot"
 #: ../src/extension/internal/filter/transparency.h:133
 #: ../src/filter-enums.cpp:129 ../src/ui/tools/flood-tool.cpp:83
 #: ../src/ui/widget/color-icc-selector.cpp:155
-#: ../src/ui/widget/color-scales.cpp:359 ../src/ui/widget/color-scales.cpp:360
+#: ../src/ui/widget/color-scales.cpp:370 ../src/ui/widget/color-scales.cpp:371
 msgid "Green"
 msgstr "Grün"
 
@@ -6401,7 +6406,7 @@ msgstr "Grün"
 #: ../src/extension/internal/filter/transparency.h:134
 #: ../src/filter-enums.cpp:130 ../src/ui/tools/flood-tool.cpp:84
 #: ../src/ui/widget/color-icc-selector.cpp:156
-#: ../src/ui/widget/color-scales.cpp:362 ../src/ui/widget/color-scales.cpp:363
+#: ../src/ui/widget/color-scales.cpp:373 ../src/ui/widget/color-scales.cpp:374
 #: ../share/extensions/nicechart.inx.h:34
 msgid "Blue"
 msgstr "Blau"
@@ -6424,9 +6429,9 @@ msgstr "Diffuses Licht"
 
 #: ../src/extension/internal/filter/bumps.h:98
 #: ../src/extension/internal/filter/bumps.h:329
-#: ../src/ui/tools/measure-tool.cpp:1212 ../src/ui/widget/page-sizer.cpp:233
-#: ../src/widgets/rect-toolbar.cpp:330
-#: ../share/extensions/interp_att_g.inx.h:13
+#: ../src/ui/tools/measure-tool.cpp:1226 ../src/ui/widget/page-sizer.cpp:235
+#: ../src/widgets/rect-toolbar.cpp:336
+#: ../share/extensions/interp_att_g.inx.h:15
 msgid "Height"
 msgstr "Höhe"
 
@@ -6440,15 +6445,15 @@ msgstr "Höhe"
 #: ../src/extension/internal/filter/paint.h:707
 #: ../src/ui/tools/flood-tool.cpp:87
 #: ../src/ui/widget/color-icc-selector.cpp:165
-#: ../src/ui/widget/color-scales.cpp:388 ../src/ui/widget/color-scales.cpp:389
+#: ../src/ui/widget/color-scales.cpp:403 ../src/ui/widget/color-scales.cpp:404
 #: ../src/widgets/tweak-toolbar.cpp:318
 msgid "Lightness"
 msgstr "Helligkeit"
 
 #: ../src/extension/internal/filter/bumps.h:100
 #: ../src/extension/internal/filter/bumps.h:331
-#: ../src/live_effects/lpe-measure-line.cpp:56
-#: ../src/widgets/measure-toolbar.cpp:302
+#: ../src/live_effects/lpe-measure-segments.cpp:61
+#: ../src/widgets/measure-toolbar.cpp:320
 msgid "Precision"
 msgstr "Genauigkeit"
 
@@ -6465,7 +6470,7 @@ msgid "Distant"
 msgstr "Entfernt"
 
 #: ../src/extension/internal/filter/bumps.h:106
-#: ../src/ui/dialog/inkscape-preferences.cpp:456
+#: ../src/ui/dialog/inkscape-preferences.cpp:499
 msgid "Point"
 msgstr "Punkt"
 
@@ -6479,13 +6484,13 @@ msgstr "Optionen für entfernte Lichtquelle"
 
 #: ../src/extension/internal/filter/bumps.h:110
 #: ../src/extension/internal/filter/bumps.h:332
-#: ../src/ui/dialog/filter-effects-dialog.cpp:1172
+#: ../src/ui/dialog/filter-effects-dialog.cpp:1178
 msgid "Azimuth"
 msgstr "Azimut"
 
 #: ../src/extension/internal/filter/bumps.h:111
 #: ../src/extension/internal/filter/bumps.h:333
-#: ../src/ui/dialog/filter-effects-dialog.cpp:1173
+#: ../src/ui/dialog/filter-effects-dialog.cpp:1179
 msgid "Elevation"
 msgstr "Anhebung"
 
@@ -6554,7 +6559,7 @@ msgstr "Hintergrund:"
 
 #: ../src/extension/internal/filter/bumps.h:322
 #: ../src/extension/internal/filter/transparency.h:57
-#: ../src/filter-enums.cpp:30 ../src/sp-image.cpp:506
+#: ../src/filter-enums.cpp:30 ../src/sp-image.cpp:491
 msgid "Image"
 msgstr "Bild"
 
@@ -6636,11 +6641,12 @@ msgstr "Kanalfarbe"
 #: ../src/extension/internal/filter/color.h:157
 #: ../src/extension/internal/filter/color.h:332
 #: ../src/extension/internal/filter/paint.h:87 ../src/filter-enums.cpp:66
-#: ../src/ui/dialog/inkscape-preferences.cpp:976
+#: ../src/ui/dialog/inkscape-preferences.cpp:1031
 #: ../src/ui/tools/flood-tool.cpp:86
 #: ../src/ui/widget/color-icc-selector.cpp:161
 #: ../src/ui/widget/color-icc-selector.cpp:166
-#: ../src/ui/widget/color-scales.cpp:385 ../src/ui/widget/color-scales.cpp:386
+#: ../src/ui/widget/color-scales.cpp:399 ../src/ui/widget/color-scales.cpp:400
+#: ../src/ui/widget/color-scales.cpp:435 ../src/ui/widget/color-scales.cpp:436
 #: ../src/widgets/tweak-toolbar.cpp:302
 msgid "Saturation"
 msgstr "Sättigung"
@@ -6747,19 +6753,19 @@ msgstr "Identität"
 
 #: ../src/extension/internal/filter/color.h:503
 #: ../src/extension/internal/filter/paint.h:498 ../src/filter-enums.cpp:111
-#: ../src/ui/dialog/filter-effects-dialog.cpp:1028
+#: ../src/ui/dialog/filter-effects-dialog.cpp:1034
 msgid "Table"
 msgstr "Tabelle"
 
 #: ../src/extension/internal/filter/color.h:504
 #: ../src/extension/internal/filter/paint.h:499 ../src/filter-enums.cpp:112
-#: ../src/ui/dialog/filter-effects-dialog.cpp:1031
+#: ../src/ui/dialog/filter-effects-dialog.cpp:1037
 msgid "Discrete"
 msgstr "Getrennt"
 
 #: ../src/extension/internal/filter/color.h:505 ../src/filter-enums.cpp:113
 #: ../src/live_effects/lpe-interpolate_points.cpp:24
-#: ../src/live_effects/lpe-powerstroke.cpp:122
+#: ../src/live_effects/lpe-powerstroke.cpp:125
 msgid "Linear"
 msgstr "Linear"
 
@@ -6818,21 +6824,21 @@ msgstr "Kanal extrahieren"
 #: ../src/extension/internal/filter/color.h:715
 #: ../src/ui/widget/color-icc-selector.cpp:168
 #: ../src/ui/widget/color-icc-selector.cpp:173
-#: ../src/ui/widget/color-scales.cpp:410 ../src/ui/widget/color-scales.cpp:411
+#: ../src/ui/widget/color-scales.cpp:465 ../src/ui/widget/color-scales.cpp:466
 msgid "Cyan"
 msgstr "Zyan"
 
 #: ../src/extension/internal/filter/color.h:716
 #: ../src/ui/widget/color-icc-selector.cpp:169
 #: ../src/ui/widget/color-icc-selector.cpp:174
-#: ../src/ui/widget/color-scales.cpp:413 ../src/ui/widget/color-scales.cpp:414
+#: ../src/ui/widget/color-scales.cpp:468 ../src/ui/widget/color-scales.cpp:469
 msgid "Magenta"
 msgstr "Magenta"
 
 #: ../src/extension/internal/filter/color.h:717
 #: ../src/ui/widget/color-icc-selector.cpp:170
 #: ../src/ui/widget/color-icc-selector.cpp:175
-#: ../src/ui/widget/color-scales.cpp:416 ../src/ui/widget/color-scales.cpp:417
+#: ../src/ui/widget/color-scales.cpp:471 ../src/ui/widget/color-scales.cpp:472
 msgid "Yellow"
 msgstr "Gelb"
 
@@ -6858,13 +6864,13 @@ msgstr "Ausblenden zu:"
 
 #: ../src/extension/internal/filter/color.h:819
 #: ../src/ui/widget/color-icc-selector.cpp:171
-#: ../src/ui/widget/color-scales.cpp:419 ../src/ui/widget/color-scales.cpp:420
-#: ../src/ui/widget/selected-style.cpp:279
+#: ../src/ui/widget/color-scales.cpp:474 ../src/ui/widget/color-scales.cpp:475
+#: ../src/ui/widget/selected-style.cpp:277
 msgid "Black"
 msgstr "Schwarz"
 
 #: ../src/extension/internal/filter/color.h:820
-#: ../src/ui/widget/selected-style.cpp:275
+#: ../src/ui/widget/selected-style.cpp:273
 msgid "White"
 msgstr "Weiß"
 
@@ -6887,7 +6893,7 @@ msgid "Customize greyscale components"
 msgstr "Anpassen der Graustufen-Komponenten"
 
 #: ../src/extension/internal/filter/color.h:980
-#: ../src/ui/widget/selected-style.cpp:271
+#: ../src/ui/widget/selected-style.cpp:269
 msgid "Invert"
 msgstr "Invertieren"
 
@@ -6941,11 +6947,11 @@ msgstr "Schatten"
 
 #: ../src/extension/internal/filter/color.h:1119
 #: ../src/extension/internal/filter/paint.h:356 ../src/filter-enums.cpp:33
-#: ../src/live_effects/effect.cpp:140
+#: ../src/live_effects/effect.cpp:145
 #: ../src/live_effects/lpe-transform_2pts.cpp:38
-#: ../src/ui/dialog/filter-effects-dialog.cpp:1025
-#: ../src/widgets/gradient-toolbar.cpp:1160
-#: ../src/widgets/measure-toolbar.cpp:328
+#: ../src/ui/dialog/filter-effects-dialog.cpp:1031
+#: ../src/widgets/gradient-toolbar.cpp:1049
+#: ../src/widgets/measure-toolbar.cpp:346
 msgid "Offset"
 msgstr "Versatz"
 
@@ -6975,9 +6981,9 @@ msgstr "Rot-Versatz:"
 #: ../src/extension/internal/filter/color.h:1382
 #: ../src/extension/internal/filter/color.h:1385
 #: ../src/extension/internal/filter/color.h:1388
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2804
-#: ../src/ui/dialog/input.cpp:1442 ../src/ui/dialog/layers.cpp:919
-#: ../src/ui/widget/page-sizer.cpp:230
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2821
+#: ../src/ui/dialog/input.cpp:1443 ../src/ui/dialog/layers.cpp:927
+#: ../src/ui/widget/page-sizer.cpp:232
 msgid "X"
 msgstr "X"
 
@@ -6989,8 +6995,8 @@ msgstr "X"
 #: ../src/extension/internal/filter/color.h:1383
 #: ../src/extension/internal/filter/color.h:1386
 #: ../src/extension/internal/filter/color.h:1389
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2808
-#: ../src/ui/dialog/input.cpp:1442 ../src/ui/widget/page-sizer.cpp:231
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2825
+#: ../src/ui/dialog/input.cpp:1443 ../src/ui/widget/page-sizer.cpp:233
 msgid "Y"
 msgstr "Y:"
 
@@ -7127,7 +7133,7 @@ msgstr "Out"
 
 #: ../src/extension/internal/filter/distort.h:77
 #: ../src/extension/internal/filter/textures.h:75
-#: ../src/ui/widget/selected-style.cpp:123
+#: ../src/ui/widget/selected-style.cpp:122
 #: ../src/ui/widget/style-swatch.cpp:116
 msgid "Stroke:"
 msgstr "Kontur:"
@@ -7203,7 +7209,7 @@ msgid "Blur and displace edges of shapes and pictures"
 msgstr "verwischt und versetzt Kanten von Formen und Bildern"
 
 #: ../src/extension/internal/filter/distort.h:190
-#: ../src/live_effects/effect.cpp:114
+#: ../src/live_effects/effect.cpp:117
 msgid "Roughen"
 msgstr "Aufrauen"
 
@@ -7275,16 +7281,16 @@ msgid "Open"
 msgstr "Öffnen"
 
 #: ../src/extension/internal/filter/morphology.h:65
-#: ../src/ui/tools/measure-tool.cpp:1218 ../src/ui/widget/page-sizer.cpp:232
-#: ../src/widgets/rect-toolbar.cpp:313 ../src/widgets/spray-toolbar.cpp:297
+#: ../src/ui/tools/measure-tool.cpp:1232 ../src/ui/widget/page-sizer.cpp:234
+#: ../src/widgets/rect-toolbar.cpp:319 ../src/widgets/spray-toolbar.cpp:297
 #: ../src/widgets/tweak-toolbar.cpp:128
-#: ../share/extensions/interp_att_g.inx.h:12
+#: ../share/extensions/interp_att_g.inx.h:14
 msgid "Width"
 msgstr "Breite"
 
 #: ../src/extension/internal/filter/morphology.h:69
 #: ../src/extension/internal/filter/morphology.h:190
-#: ../src/ui/dialog/export.cpp:155
+#: ../src/ui/dialog/export.cpp:151
 msgid "Antialiasing"
 msgstr "Kantenglättung"
 
@@ -7505,7 +7511,7 @@ msgid "Clean-up"
 msgstr "Bereinigen"
 
 #: ../src/extension/internal/filter/paint.h:238
-#: ../src/ui/tools/measure-tool.cpp:1189 ../share/extensions/measure.inx.h:17
+#: ../src/ui/tools/measure-tool.cpp:1204 ../share/extensions/measure.inx.h:17
 msgid "Length"
 msgstr "Länge"
 
@@ -7516,7 +7522,7 @@ msgstr "Konvertiere Bild in eine Gravur aus vertikalen und horizontalen Linien"
 # not sure here -cm-
 #: ../src/extension/internal/filter/paint.h:331
 #: ../src/ui/dialog/align-and-distribute.cpp:1060
-#: ../src/widgets/desktop-widget.cpp:1988
+#: ../src/widgets/desktop-widget.cpp:2001
 msgid "Drawing"
 msgstr "Zeichnung"
 
@@ -7525,7 +7531,7 @@ msgstr "Zeichnung"
 #: ../src/extension/internal/filter/paint.h:496
 #: ../src/extension/internal/filter/paint.h:590
 #: ../src/extension/internal/filter/paint.h:976
-#: ../src/live_effects/effect.cpp:108 ../src/splivarot.cpp:2366
+#: ../src/live_effects/effect.cpp:111 ../src/splivarot.cpp:2370
 msgid "Simplify"
 msgstr "Vereinfachen"
 
@@ -7598,12 +7604,13 @@ msgstr "Kontrastiert"
 
 #: ../src/extension/internal/filter/paint.h:591
 #: ../src/live_effects/lpe-jointype.cpp:52
+#: ../src/live_effects/lpe-measure-segments.cpp:67
 msgid "Line width"
 msgstr "Linienstärke"
 
 #: ../src/extension/internal/filter/paint.h:593
 #: ../src/extension/internal/filter/paint.h:861
-#: ../src/ui/widget/filter-effect-chooser.cpp:21
+#: ../src/ui/widget/filter-effect-chooser.cpp:23
 msgid "Blend mode:"
 msgstr "Mischmodus:"
 
@@ -7805,15 +7812,14 @@ msgid "Source:"
 msgstr "Quelle:"
 
 #: ../src/extension/internal/filter/transparency.h:56
-#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:1540
+#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:1543
 msgid "Background"
 msgstr "Hintergrund"
 
 #: ../src/extension/internal/filter/transparency.h:59
 #: ../src/live_effects/lpe-fillet-chamfer.cpp:40
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2745
-#: ../src/ui/dialog/input.cpp:920 ../src/widgets/eraser-toolbar.cpp:165
-#: ../src/widgets/pencil-toolbar.cpp:138 ../src/widgets/spray-toolbar.cpp:389
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2762
+#: ../src/ui/dialog/input.cpp:921 ../src/widgets/pencil-toolbar.cpp:159
 #: ../src/widgets/tweak-toolbar.cpp:254 ../share/extensions/extrude.inx.h:2
 #: ../share/extensions/triangle.inx.h:8
 msgid "Mode:"
@@ -7860,17 +7866,17 @@ msgstr "Ausschneiden"
 msgid "Repaint anything visible monochrome"
 msgstr "Alles Sichtbare schwarzweiß nachmalen"
 
-#: ../src/extension/internal/gdkpixbuf-input.cpp:193
+#: ../src/extension/internal/gdkpixbuf-input.cpp:189
 #, c-format
 msgid "%s bitmap image import"
 msgstr "%s Bitmap-Bildimport"
 
-#: ../src/extension/internal/gdkpixbuf-input.cpp:200
+#: ../src/extension/internal/gdkpixbuf-input.cpp:196
 #, c-format
 msgid "Image Import Type:"
 msgstr "Art des Bildimports:"
 
-#: ../src/extension/internal/gdkpixbuf-input.cpp:200
+#: ../src/extension/internal/gdkpixbuf-input.cpp:196
 #, c-format
 msgid ""
 "Embed results in stand-alone, larger SVG files. Link references a file "
@@ -7881,24 +7887,24 @@ msgstr ""
 "auf eine externe Bilddatei verwiesen wird. In diesem Fall müssen ggf. später "
 "alle Dateien gemeinsam verschoben oder kopiert werden."
 
-#: ../src/extension/internal/gdkpixbuf-input.cpp:201
-#: ../src/ui/dialog/inkscape-preferences.cpp:1491
+#: ../src/extension/internal/gdkpixbuf-input.cpp:197
+#: ../src/ui/dialog/inkscape-preferences.cpp:1552
 #, c-format
 msgid "Embed"
 msgstr "Einbetten"
 
-#: ../src/extension/internal/gdkpixbuf-input.cpp:202 ../src/sp-anchor.cpp:141
-#: ../src/ui/dialog/inkscape-preferences.cpp:1491
+#: ../src/extension/internal/gdkpixbuf-input.cpp:198 ../src/sp-anchor.cpp:141
+#: ../src/ui/dialog/inkscape-preferences.cpp:1552
 #, c-format
 msgid "Link"
 msgstr "Verknüpfen"
 
-#: ../src/extension/internal/gdkpixbuf-input.cpp:205
+#: ../src/extension/internal/gdkpixbuf-input.cpp:201
 #, c-format
 msgid "Image DPI:"
 msgstr "Auflösung des Bildes (DPI):"
 
-#: ../src/extension/internal/gdkpixbuf-input.cpp:205
+#: ../src/extension/internal/gdkpixbuf-input.cpp:201
 #, c-format
 msgid ""
 "Take information from file or use default bitmap import resolution as "
@@ -7907,22 +7913,22 @@ msgstr ""
 "Information aus Datei auslesen oder die in den Einstellungen definierte "
 "Standardauflösung für den Bitmap-Import verwenden."
 
-#: ../src/extension/internal/gdkpixbuf-input.cpp:206
+#: ../src/extension/internal/gdkpixbuf-input.cpp:202
 #, c-format
 msgid "From file"
 msgstr "Aus Datei"
 
-#: ../src/extension/internal/gdkpixbuf-input.cpp:207
+#: ../src/extension/internal/gdkpixbuf-input.cpp:203
 #, c-format
 msgid "Default import resolution"
 msgstr "Standard-Importauflösung"
 
-#: ../src/extension/internal/gdkpixbuf-input.cpp:210
+#: ../src/extension/internal/gdkpixbuf-input.cpp:206
 #, c-format
 msgid "Image Rendering Mode:"
 msgstr "Darstellungsmethode (Rasterbilder):"
 
-#: ../src/extension/internal/gdkpixbuf-input.cpp:210
+#: ../src/extension/internal/gdkpixbuf-input.cpp:206
 #, c-format
 msgid ""
 "When an image is upscaled, apply smoothing or keep blocky (pixelated). (Will "
@@ -7931,32 +7937,32 @@ msgstr ""
 "Beim Vergrößern des Bildes die Kanten glätten oder pixelig lassen. "
 "(Funktioniert nicht in allen Browsern.)"
 
-#: ../src/extension/internal/gdkpixbuf-input.cpp:211
-#: ../src/ui/dialog/inkscape-preferences.cpp:1498
+#: ../src/extension/internal/gdkpixbuf-input.cpp:207
+#: ../src/ui/dialog/inkscape-preferences.cpp:1559
 #, c-format
 msgid "None (auto)"
 msgstr "Keine (automatisch)"
 
-#: ../src/extension/internal/gdkpixbuf-input.cpp:212
-#: ../src/ui/dialog/inkscape-preferences.cpp:1498
+#: ../src/extension/internal/gdkpixbuf-input.cpp:208
+#: ../src/ui/dialog/inkscape-preferences.cpp:1559
 #, c-format
 msgid "Smooth (optimizeQuality)"
 msgstr "Glätten (verbesserte Qualität)"
 
-#: ../src/extension/internal/gdkpixbuf-input.cpp:213
-#: ../src/ui/dialog/inkscape-preferences.cpp:1498
+#: ../src/extension/internal/gdkpixbuf-input.cpp:209
+#: ../src/ui/dialog/inkscape-preferences.cpp:1559
 #, c-format
 msgid "Blocky (optimizeSpeed)"
 msgstr "Pixelig (verbesserte Geschwindigkeit)"
 
-#: ../src/extension/internal/gdkpixbuf-input.cpp:216
+#: ../src/extension/internal/gdkpixbuf-input.cpp:212
 #, c-format
 msgid "Hide the dialog next time and always apply the same actions."
 msgstr ""
 "Dialog beim nächsten Mal nicht mehr anzeigen und immer diese Einstellungen "
 "anwenden."
 
-#: ../src/extension/internal/gdkpixbuf-input.cpp:216
+#: ../src/extension/internal/gdkpixbuf-input.cpp:212
 #, c-format
 msgid "Don't ask again"
 msgstr "Nicht wieder nachfragen"
@@ -7973,7 +7979,7 @@ msgstr "GIMP-Farbverlauf (*.ggr)"
 msgid "Gradients used in GIMP"
 msgstr "Farbverläufe von GIMP"
 
-#: ../src/extension/internal/grid.cpp:199 ../src/ui/widget/panel.cpp:112
+#: ../src/extension/internal/grid.cpp:199 ../src/ui/dialog/swatches.cpp:708
 msgid "Grid"
 msgstr "Gitter"
 
@@ -7998,7 +8004,7 @@ msgid "Vertical Offset:"
 msgstr "Vertikaler Versatz:"
 
 #: ../src/extension/internal/grid.cpp:209
-#: ../src/ui/dialog/inkscape-preferences.cpp:1512
+#: ../src/ui/dialog/inkscape-preferences.cpp:1573
 #: ../share/extensions/draw_from_triangle.inx.h:58
 #: ../share/extensions/eqtexsvg.inx.h:4 ../share/extensions/foldablebox.inx.h:9
 #: ../share/extensions/frame.inx.h:2 ../share/extensions/funcplot.inx.h:38
@@ -8029,8 +8035,8 @@ msgstr "Rendern"
 
 #: ../src/extension/internal/grid.cpp:210
 #: ../src/ui/dialog/document-properties.cpp:147
-#: ../src/ui/dialog/inkscape-preferences.cpp:818
-#: ../src/widgets/toolbox.cpp:1389
+#: ../src/ui/dialog/inkscape-preferences.cpp:873
+#: ../src/widgets/toolbox.cpp:1392
 msgid "Grids"
 msgstr "Gitter"
 
@@ -8066,15 +8072,15 @@ msgstr "LaTeX-PSTricks-Datei"
 msgid "LaTeX Print"
 msgstr "LaTeX-Druck"
 
-#: ../src/extension/internal/odf.cpp:2138
+#: ../src/extension/internal/odf.cpp:2135
 msgid "OpenDocument Drawing Output"
 msgstr "OpenDocument-Zeichnungsausgabe"
 
-#: ../src/extension/internal/odf.cpp:2143
+#: ../src/extension/internal/odf.cpp:2140
 msgid "OpenDocument drawing (*.odg)"
 msgstr "OpenDocument-Zeichnung (*.odg)"
 
-#: ../src/extension/internal/odf.cpp:2144
+#: ../src/extension/internal/odf.cpp:2141
 msgid "OpenDocument drawing file"
 msgstr "OpenDocument-Zeichnungsdatei"
 
@@ -8202,29 +8208,29 @@ msgctxt "PDF input precision"
 msgid "very fine"
 msgstr "sehr fein"
 
-#: ../src/extension/internal/pdfinput/pdf-input.cpp:943
+#: ../src/extension/internal/pdfinput/pdf-input.cpp:949
 msgid "PDF Input"
 msgstr "PDF einlesen"
 
-#: ../src/extension/internal/pdfinput/pdf-input.cpp:948
+#: ../src/extension/internal/pdfinput/pdf-input.cpp:954
 #, fuzzy
 msgid "Portable Document Format (*.pdf)"
 msgstr "Adobe Portable Document Format"
 
-#: ../src/extension/internal/pdfinput/pdf-input.cpp:949
+#: ../src/extension/internal/pdfinput/pdf-input.cpp:955
 #, fuzzy
 msgid "Portable Document Format"
 msgstr "Adobe Portable Document Format"
 
-#: ../src/extension/internal/pdfinput/pdf-input.cpp:956
+#: ../src/extension/internal/pdfinput/pdf-input.cpp:962
 msgid "AI Input"
 msgstr "AI einlesen"
 
-#: ../src/extension/internal/pdfinput/pdf-input.cpp:961
+#: ../src/extension/internal/pdfinput/pdf-input.cpp:967
 msgid "Adobe Illustrator 9.0 and above (*.ai)"
 msgstr "Adobe Illustrator 9.0 und neuer (*.ai)"
 
-#: ../src/extension/internal/pdfinput/pdf-input.cpp:962
+#: ../src/extension/internal/pdfinput/pdf-input.cpp:968
 msgid "Open files saved in Adobe Illustrator 9.0 and newer versions"
 msgstr "Mit Adobe Illustrator 9.0 oder neuer gespeicherte Dateien öffnen"
 
@@ -8240,39 +8246,39 @@ msgstr "PovRay (*.pov) (nur Pfade und Formen)"
 msgid "PovRay Raytracer File"
 msgstr "PovRay-Raytracer-Datei"
 
-#: ../src/extension/internal/svg.cpp:122
+#: ../src/extension/internal/svg.cpp:121
 msgid "SVG Input"
 msgstr "SVG einlesen"
 
-#: ../src/extension/internal/svg.cpp:127
+#: ../src/extension/internal/svg.cpp:126
 msgid "Scalable Vector Graphic (*.svg)"
 msgstr "Skalierbare Vektorgrafik (*.svg)"
 
-#: ../src/extension/internal/svg.cpp:128
+#: ../src/extension/internal/svg.cpp:127
 msgid "Inkscape native file format and W3C standard"
 msgstr "Inkscapes natürliches Dateiformat und W3C-Standard"
 
-#: ../src/extension/internal/svg.cpp:136
+#: ../src/extension/internal/svg.cpp:135
 msgid "SVG Output Inkscape"
 msgstr "SVG-Ausgabe, Inkscape"
 
-#: ../src/extension/internal/svg.cpp:141
+#: ../src/extension/internal/svg.cpp:140
 msgid "Inkscape SVG (*.svg)"
 msgstr "Inkscape-SVG (*.svg)"
 
-#: ../src/extension/internal/svg.cpp:142
+#: ../src/extension/internal/svg.cpp:141
 msgid "SVG format with Inkscape extensions"
 msgstr "SVG-Format mit Inkscape-Erweiterungen"
 
-#: ../src/extension/internal/svg.cpp:150 ../share/extensions/scour.inx.h:19
+#: ../src/extension/internal/svg.cpp:149 ../share/extensions/scour.inx.h:19
 msgid "SVG Output"
 msgstr "SVG-Ausgabe"
 
-#: ../src/extension/internal/svg.cpp:155
+#: ../src/extension/internal/svg.cpp:154
 msgid "Plain SVG (*.svg)"
 msgstr "Normales SVG (*.svg)"
 
-#: ../src/extension/internal/svg.cpp:156
+#: ../src/extension/internal/svg.cpp:155
 msgid "Scalable Vector Graphics format as defined by the W3C"
 msgstr "Scalable-Vector-Graphics-Format wie vom W3C definiert"
 
@@ -8389,10 +8395,8 @@ msgstr "WordPerfect-Grafik (*.wpg)"
 msgid "Vector graphics format used by Corel WordPerfect"
 msgstr "Vektorgrafikformat von Corel WordPerfect"
 
-#: ../src/extension/prefdialog.cpp:74 ../src/ui/dialog/aboutbox.cpp:102
-#: ../src/ui/dialog/knot-properties.cpp:44 ../src/ui/dialog/panel-dialog.h:168
-#: ../src/ui/dialog/panel-dialog.h:217 ../src/ui/dialog/text-edit.cpp:64
-#: ../src/verbs.cpp:2588
+#: ../src/extension/prefdialog.cpp:74 ../src/ui/dialog/knot-properties.cpp:44
+#: ../src/ui/dialog/text-edit.cpp:64 ../src/verbs.cpp:2618
 msgid "_Close"
 msgstr "S_chließen"
 
@@ -8401,11 +8405,11 @@ msgstr "S_chließen"
 msgid "_Apply"
 msgstr "An_wenden"
 
-#: ../src/extension/prefdialog.cpp:249
+#: ../src/extension/prefdialog.cpp:253
 msgid "Live preview"
 msgstr "Vorschau"
 
-#: ../src/extension/prefdialog.cpp:249
+#: ../src/extension/prefdialog.cpp:253
 msgid "Is the effect previewed live on canvas?"
 msgstr "Ist die Vorschau des Effekts auf der Arbeitsfläche aktiv?"
 
@@ -8420,44 +8424,44 @@ msgstr ""
 msgid "Convert legacy Inkscape file"
 msgstr "Umwandeln in invertierte Abrundung"
 
-#: ../src/file-update.cpp:325
+#: ../src/file-update.cpp:326
 msgid ""
 "was created in an older version of Inkscape (90 DPI) and we need to make it "
 "compatible with newer versions (96 DPI). Tell us about this file:\n"
 msgstr ""
 
-#: ../src/file-update.cpp:333
+#: ../src/file-update.cpp:334
 msgid ""
 "This file contains digital artwork for screen display. <b>(Choose if "
 "unsure.)</b>"
 msgstr ""
 
-#: ../src/file-update.cpp:336
+#: ../src/file-update.cpp:337
 msgid "This file is intended for physical output, such as paper or 3D prints."
 msgstr ""
 
-#: ../src/file-update.cpp:338
+#: ../src/file-update.cpp:339
 msgid ""
 "The appearance of elements such as clips, masks, filters, and clones\n"
 "is most important. <b>(Choose if unsure.)</b>"
 msgstr ""
 
-#: ../src/file-update.cpp:342
+#: ../src/file-update.cpp:343
 msgid ""
 "The accuracy of the physical unit size and position values of objects\n"
 "in the file is most important. (Experimental.)"
 msgstr ""
 
-#: ../src/file-update.cpp:344
+#: ../src/file-update.cpp:345
 #, fuzzy
 msgid "Create a backup file in same directory."
 msgstr "Erstelle Sicherheitskopie (im selben Verzeichnis)"
 
-#: ../src/file-update.cpp:345
+#: ../src/file-update.cpp:346
 msgid "More details..."
 msgstr ""
 
-#: ../src/file-update.cpp:348
+#: ../src/file-update.cpp:349
 msgid ""
 "<small>We've updated Inkscape to follow the CSS standard of 96 DPI for "
 "better browser compatibility; we used to use 90 DPI. Digital artwork for "
@@ -8477,73 +8481,73 @@ msgid ""
 "printing.)\n"
 "\n"
 "More information about this change are available in the <a href='https://"
-"inkscape.org/en/learn/faq#todo-todo-todo'>Inkscape FAQ</a></small>"
+"inkscape.org/en/learn/faq#dpi_change'>Inkscape FAQ</a></small>"
 msgstr ""
 
-#: ../src/file-update.cpp:391
+#: ../src/file-update.cpp:392
 #, fuzzy
 msgid "OK"
 msgstr "_OK"
 
 #. Look for SPNamedView and SPDefs loop
 #. desktop->getDocument()->ensureUpToDate();  // Does not update box3d!
-#: ../src/file-update.cpp:613
+#: ../src/file-update.cpp:614
 msgid "Update Document"
 msgstr "Dokument aktualisieren"
 
-#: ../src/file.cpp:165
+#: ../src/file.cpp:161
 msgid "default.svg"
 msgstr "default.de.svg"
 
-#: ../src/file.cpp:281 ../src/main-cmdlinexact.cpp:174
+#: ../src/file.cpp:282 ../src/main-cmdlinexact.cpp:174
 msgid "Broken links have been changed to point to existing files."
 msgstr ""
 "Defekte Verknüpfungen wurden geändert, um auf vorhandene Dateien zu "
 "verweisen."
 
-#: ../src/file.cpp:292 ../src/file.cpp:1347
+#: ../src/file.cpp:293 ../src/file.cpp:1287
 #, c-format
 msgid "Failed to load the requested file %s"
 msgstr "Laden der gewünschten Datei %s fehlgeschlagen"
 
-#: ../src/file.cpp:318
+#: ../src/file.cpp:319
 msgid "Document not saved yet.  Cannot revert."
 msgstr "Dokument noch nicht gespeichtert. Kann nicht zurücksetzen."
 
-#: ../src/file.cpp:324
+#: ../src/file.cpp:325
 msgid "Changes will be lost! Are you sure you want to reload document %1?"
 msgstr ""
 "Änderungen gehen verloren! Sind Sie sicher, dass Sie das Dokument %1 erneut "
 "laden möchten?"
 
-#: ../src/file.cpp:350
+#: ../src/file.cpp:351
 msgid "Document reverted."
 msgstr "Dokument zurückgesetzt."
 
-#: ../src/file.cpp:352
+#: ../src/file.cpp:353
 msgid "Document not reverted."
 msgstr "Dokument nicht zurückgesetzt."
 
-#: ../src/file.cpp:502
+#: ../src/file.cpp:503
 msgid "Select file to open"
 msgstr "Wählen Sie die zu öffnende Datei"
 
-#: ../src/file.cpp:584
+#: ../src/file.cpp:585
 msgid "Clean up document"
 msgstr "Dokument bereinigen"
 
-#: ../src/file.cpp:591
+#: ../src/file.cpp:592
 #, c-format
 msgid "Removed <b>%i</b> unused definition in &lt;defs&gt;."
 msgid_plural "Removed <b>%i</b> unused definitions in &lt;defs&gt;."
 msgstr[0] "<b>%i</b> überflüssiges Element aus &lt;defs&gt; entfernt."
 msgstr[1] "<b>%i</b> überflüssige Elemente aus &lt;defs&gt; entfernt."
 
-#: ../src/file.cpp:596
+#: ../src/file.cpp:597
 msgid "No unused definitions in &lt;defs&gt;."
 msgstr "Keine überflüssigen Elemente in &lt;defs&gt;."
 
-#: ../src/file.cpp:630
+#: ../src/file.cpp:631
 #, c-format
 msgid ""
 "No Inkscape extension found to save document (%s).  This may have been "
@@ -8552,12 +8556,13 @@ msgstr ""
 "Keine vorhandene Erweiterung von Inkscape kann das Dokument (%s) sichern. "
 "Dies Ursache dafür ist möglicherweise eine unbekannte Dateinamenendung."
 
-#: ../src/file.cpp:631 ../src/file.cpp:641 ../src/file.cpp:650
-#: ../src/file.cpp:657 ../src/file.cpp:663
+#: ../src/file.cpp:632 ../src/file.cpp:642 ../src/file.cpp:651
+#: ../src/file.cpp:658 ../src/file.cpp:663 ../src/file.cpp:675
+#: ../src/file.cpp:685
 msgid "Document not saved."
 msgstr "Dokument wurde nicht gespeichert."
 
-#: ../src/file.cpp:640
+#: ../src/file.cpp:641
 #, c-format
 msgid ""
 "File %s is write protected. Please remove write protection and try again."
@@ -8565,54 +8570,70 @@ msgstr ""
 "Datei %s ist schreibgeschützt! Bitte entfernen Sie den Schreibschutz und "
 "versuchen es dann erneut."
 
-#: ../src/file.cpp:649
+#: ../src/file.cpp:650 ../src/file.cpp:684
 #, c-format
 msgid "File %s could not be saved."
 msgstr "Datei %s konnte nicht gespeichert werden."
 
-#: ../src/file.cpp:682 ../src/file.cpp:684
+#: ../src/file.cpp:662
+#, c-format
+msgid ""
+"File could not be saved:\n"
+"No object with ID '%s' found."
+msgstr ""
+
+#: ../src/file.cpp:672
+#, c-format
+msgid ""
+"File %s could not be saved.\n"
+"\n"
+"The following additional information was returned by the output extension:\n"
+"'%s'"
+msgstr ""
+
+#: ../src/file.cpp:707 ../src/file.cpp:709
 msgid "Document saved."
 msgstr "Dokument wurde gespeichert."
 
 #. We are saving for the first time; create a unique default filename
-#: ../src/file.cpp:827 ../src/file.cpp:1506
+#: ../src/file.cpp:767 ../src/file.cpp:1446
 msgid "drawing"
 msgstr "Zeichnung"
 
-#: ../src/file.cpp:832
+#: ../src/file.cpp:772
 msgid "drawing-%1"
 msgstr "Zeichnung-%1"
 
-#: ../src/file.cpp:849
+#: ../src/file.cpp:789
 msgid "Select file to save a copy to"
 msgstr "Datei wählen, in die eine Kopie gespeichert werden soll"
 
-#: ../src/file.cpp:851
+#: ../src/file.cpp:791
 msgid "Select file to save to"
 msgstr "Datei wählen, in die gespeichert werden soll"
 
-#: ../src/file.cpp:956 ../src/file.cpp:958
+#: ../src/file.cpp:896 ../src/file.cpp:898
 msgid "No changes need to be saved."
 msgstr "Es müssen keine Änderungen gespeichert werden."
 
-#: ../src/file.cpp:977
+#: ../src/file.cpp:917
 msgid "Saving document..."
 msgstr "Dokument wird gespeichert..."
 
-#: ../src/file.cpp:1344 ../src/ui/dialog/inkscape-preferences.cpp:1485
-#: ../src/ui/dialog/ocaldialogs.cpp:1091
+#: ../src/file.cpp:1284 ../src/ui/dialog/inkscape-preferences.cpp:1546
+#: ../src/ui/dialog/ocaldialogs.cpp:1092
 msgid "Import"
 msgstr "Importieren"
 
-#: ../src/file.cpp:1394
+#: ../src/file.cpp:1334
 msgid "Select file to import"
 msgstr "Wählen Sie die zu importierende Datei"
 
-#: ../src/file.cpp:1527
+#: ../src/file.cpp:1467
 msgid "Select file to export to"
 msgstr "Wählen Sie die Datei, in die exportiert werden soll"
 
-#: ../src/file.cpp:1780
+#: ../src/file.cpp:1720
 msgid "Import Clip Art"
 msgstr "Importiere Clipart"
 
@@ -8708,7 +8729,8 @@ msgstr "Exklusiv-Oder (Ausschluss)"
 #: ../src/filter-enums.cpp:65 ../src/ui/tools/flood-tool.cpp:85
 #: ../src/ui/widget/color-icc-selector.cpp:160
 #: ../src/ui/widget/color-icc-selector.cpp:164
-#: ../src/ui/widget/color-scales.cpp:382 ../src/ui/widget/color-scales.cpp:383
+#: ../src/ui/widget/color-scales.cpp:394 ../src/ui/widget/color-scales.cpp:395
+#: ../src/ui/widget/color-scales.cpp:430 ../src/ui/widget/color-scales.cpp:431
 #: ../src/widgets/tweak-toolbar.cpp:286
 msgid "Hue"
 msgstr "Farbton"
@@ -8748,7 +8770,7 @@ msgstr "Leeren"
 msgid "Copy"
 msgstr "Kopieren"
 
-#: ../src/filter-enums.cpp:97 ../src/ui/dialog/filedialogimpl-gtkmm.cpp:1560
+#: ../src/filter-enums.cpp:97 ../src/ui/dialog/filedialogimpl-gtkmm.cpp:1563
 msgid "Destination"
 msgstr "Ziel"
 
@@ -8777,7 +8799,7 @@ msgid "Arithmetic"
 msgstr "Arithmetisch"
 
 #: ../src/filter-enums.cpp:120 ../src/selection-chemistry.cpp:544
-#: ../src/ui/dialog/objects.cpp:1919
+#: ../src/ui/dialog/objects.cpp:1881
 msgid "Duplicate"
 msgstr "Duplizieren"
 
@@ -8815,15 +8837,15 @@ msgstr "Punktförmige Lichtquelle"
 msgid "Spot Light"
 msgstr "Spotlight"
 
-#: ../src/gradient-chemistry.cpp:1613
+#: ../src/gradient-chemistry.cpp:1606
 msgid "Invert gradient colors"
 msgstr "Farbverlauf invertieren"
 
-#: ../src/gradient-chemistry.cpp:1640
+#: ../src/gradient-chemistry.cpp:1633
 msgid "Reverse gradient"
 msgstr "Farbverlauf umkehren"
 
-#: ../src/gradient-chemistry.cpp:1654 ../src/widgets/gradient-selector.cpp:207
+#: ../src/gradient-chemistry.cpp:1647 ../src/widgets/gradient-selector.cpp:207
 msgid "Delete swatch"
 msgstr "Zwischenfarbe löschen"
 
@@ -8894,7 +8916,7 @@ msgstr "Farbverlaufs-Anfasser vereinigen"
 msgid "Move gradient handle"
 msgstr "Farbverlaufs-Anfasser verschieben"
 
-#: ../src/gradient-drag.cpp:1182 ../src/widgets/gradient-vector.cpp:798
+#: ../src/gradient-drag.cpp:1182 ../src/widgets/gradient-vector.cpp:777
 msgid "Delete gradient stop"
 msgstr "Zwischenfarbe des Farbverlaufs löschen"
 
@@ -8957,46 +8979,46 @@ msgstr "Farbverlaufs-Anfasser verschieben"
 msgid "Move gradient mid stop(s)"
 msgstr "Zwischenfarbe(n) des Farbverlaufs verschieben"
 
-#: ../src/gradient-drag.cpp:3104
+#: ../src/gradient-drag.cpp:3102
 msgid "Delete gradient stop(s)"
 msgstr "Zwischenfarbe(n) des Farbverlaufs löschen"
 
-#: ../src/inkscape.cpp:224
+#: ../src/inkscape.cpp:226
 msgid "Autosave failed! Cannot open directory %1."
 msgstr "Autospeicherung fehlgeschlagen! Kann Verzeichnis %1 nicht öffnen."
 
-#: ../src/inkscape.cpp:240
+#: ../src/inkscape.cpp:242
 msgid "Autosaving documents..."
 msgstr "Dokument wird automatisch gespeichert..."
 
-#: ../src/inkscape.cpp:308
+#: ../src/inkscape.cpp:310
 msgid "Autosave failed! Could not find inkscape extension to save document."
 msgstr ""
 "Automatisches Speichern fehlgeschlagen! Inkscape-Erweiterung zum Speichern "
 "konnte nicht gefunden werden."
 
-#: ../src/inkscape.cpp:311 ../src/inkscape.cpp:318
+#: ../src/inkscape.cpp:313 ../src/inkscape.cpp:320
 #, c-format
 msgid "Autosave failed! File %s could not be saved."
 msgstr ""
 "Automatisches Speichern fehlgeschlagen! Datei %s konnte nicht gespeichert "
 "werden."
 
-#: ../src/inkscape.cpp:333
+#: ../src/inkscape.cpp:335
 msgid "Autosave complete."
 msgstr "Automatisches Speichern abgeschlossen."
 
-#: ../src/inkscape.cpp:647
+#: ../src/inkscape.cpp:667 ../src/ui/dialog/symbols.cpp:648
 msgid "Untitled document"
 msgstr "Unbenanntes Dokument"
 
 #. Show nice dialog box
-#: ../src/inkscape.cpp:679
+#: ../src/inkscape.cpp:697
 msgid "Inkscape encountered an internal error and will close now.\n"
 msgstr ""
 "Inkscape ist auf einen internen Fehler gestoßen und wird nun geschlossen.\n"
 
-#: ../src/inkscape.cpp:680
+#: ../src/inkscape.cpp:698
 msgid ""
 "Automatic backups of unsaved documents were done to the following "
 "locations:\n"
@@ -9004,14 +9026,14 @@ msgstr ""
 "Unter folgenden Speicherorten wurden automatische Sicherungskopien nicht "
 "gespeicherter Dokumente angelegt:\n"
 
-#: ../src/inkscape.cpp:681
+#: ../src/inkscape.cpp:699
 msgid "Automatic backup of the following documents failed:\n"
 msgstr ""
 "Anlegen von automatischen Sicherungskopien folgender Dokumente "
 "fehlgeschlagen:\n"
 
-#. wether to launch in fullscreen mode
-#. wether to search folders for SVG files recursively
+#. whether to launch in fullscreen mode
+#. whether to search folders for SVG files recursively
 #. time (in seconds) after which the next image of the slideshow is automatically loaded
 #. scale factor for images
 #. (currently only applied to the first image - others are resized to window dimensions)
@@ -9086,28 +9108,28 @@ msgstr ""
 msgid "Node or handle drag canceled."
 msgstr "Verschieben von Knoten oder Knotenanfassern abgebrochen."
 
-#: ../src/knotholder.cpp:180
+#: ../src/knotholder.cpp:187
 msgid "Change handle"
 msgstr "Anfasser ändern"
 
-#: ../src/knotholder.cpp:317
+#: ../src/knotholder.cpp:324
 msgid "Move handle"
 msgstr "Anfasser verschieben"
 
 #. TRANSLATORS: This refers to the pattern that's inside the object
-#: ../src/knotholder.cpp:336 ../src/knotholder.cpp:358
+#: ../src/knotholder.cpp:343 ../src/knotholder.cpp:365
 msgid "<b>Move</b> the pattern fill inside the object"
 msgstr "<b>Bewegen des Füllmusters</b> innerhalb des Objektes"
 
-#: ../src/knotholder.cpp:340 ../src/knotholder.cpp:362
+#: ../src/knotholder.cpp:347 ../src/knotholder.cpp:369
 msgid "<b>Scale</b> the pattern fill; uniformly if with <b>Ctrl</b>"
 msgstr "<b>Skalieren</b> des Füllmusters; gleichmäßig durch <b>Strg</b>"
 
-#: ../src/knotholder.cpp:344 ../src/knotholder.cpp:366
+#: ../src/knotholder.cpp:351 ../src/knotholder.cpp:373
 msgid "<b>Rotate</b> the pattern fill; with <b>Ctrl</b> to snap angle"
 msgstr "<b>Drehen</b> des Füllmusters; <b>Strg</b> rastet Winkel ein"
 
-#: ../src/libnrtype/FontFactory.cpp:652
+#: ../src/libnrtype/FontFactory.cpp:797
 msgid "Ignoring font without family that will crash Pango"
 msgstr ""
 "Schrift ohne zugehörige Schriftfamilie wird ignoriert, damit Pango nicht "
@@ -9115,218 +9137,228 @@ msgstr ""
 
 #. {constant defined in effect-enum.h, N_("name of your effect"), "name of your effect in SVG"}
 #. 0.46
-#: ../src/live_effects/effect.cpp:90
+#: ../src/live_effects/effect.cpp:93
 msgid "Bend"
 msgstr "Biegen"
 
-#: ../src/live_effects/effect.cpp:91
+#: ../src/live_effects/effect.cpp:94
 msgid "Gears"
 msgstr "Zahnräder"
 
-#: ../src/live_effects/effect.cpp:92
+#: ../src/live_effects/effect.cpp:95
 msgid "Pattern Along Path"
 msgstr "Muster entlang Pfad"
 
 #. for historic reasons, this effect is called skeletal(strokes) in Inkscape:SVG
-#: ../src/live_effects/effect.cpp:93
+#: ../src/live_effects/effect.cpp:96
 msgid "Stitch Sub-Paths"
 msgstr "Unterpfade vernähen"
 
 #. 0.47
-#: ../src/live_effects/effect.cpp:95
+#: ../src/live_effects/effect.cpp:98
 msgid "VonKoch"
 msgstr "VonKoch"
 
-#: ../src/live_effects/effect.cpp:96
+#: ../src/live_effects/effect.cpp:99
 msgid "Knot"
 msgstr "Knoten"
 
-#: ../src/live_effects/effect.cpp:97
+#: ../src/live_effects/effect.cpp:100
 msgid "Construct grid"
 msgstr "Gitter erzeugen"
 
-#: ../src/live_effects/effect.cpp:98
+#: ../src/live_effects/effect.cpp:101
 msgid "Spiro spline"
 msgstr "Spiro Spline"
 
-#: ../src/live_effects/effect.cpp:99
+#: ../src/live_effects/effect.cpp:102
 msgid "Envelope Deformation"
 msgstr "Hüllenverformung"
 
-#: ../src/live_effects/effect.cpp:100
+#: ../src/live_effects/effect.cpp:103
 msgid "Interpolate Sub-Paths"
 msgstr "Unterpfade interpolieren"
 
-#: ../src/live_effects/effect.cpp:101
+#: ../src/live_effects/effect.cpp:104
 msgid "Hatches (rough)"
 msgstr "Schraffur (grob)"
 
-#: ../src/live_effects/effect.cpp:102
+#: ../src/live_effects/effect.cpp:105
 msgid "Sketch"
 msgstr "Skizze"
 
-#: ../src/live_effects/effect.cpp:103
+#: ../src/live_effects/effect.cpp:106
 msgid "Ruler"
 msgstr "Lineal"
 
 #. 0.91
-#: ../src/live_effects/effect.cpp:105
+#: ../src/live_effects/effect.cpp:108
 msgid "Power stroke"
 msgstr "Power Stroke (variable Konturbreite)"
 
-#: ../src/live_effects/effect.cpp:106
+#: ../src/live_effects/effect.cpp:109 ../src/selection-chemistry.cpp:2933
 msgid "Clone original"
 msgstr "Original klonen"
 
-#: ../src/live_effects/effect.cpp:109
+#: ../src/live_effects/effect.cpp:112
 msgid "Lattice Deformation 2"
 msgstr "Gitterverformung 2"
 
-#: ../src/live_effects/effect.cpp:110
+#: ../src/live_effects/effect.cpp:113
 msgid "Perspective/Envelope"
 msgstr "Perspektive/Umhüllung"
 
 #. TODO:Wrong name with "-"
-#: ../src/live_effects/effect.cpp:111
+#: ../src/live_effects/effect.cpp:114
 msgid "Interpolate points"
 msgstr "Punkte interpolieren"
 
-#: ../src/live_effects/effect.cpp:112
+#: ../src/live_effects/effect.cpp:115
 msgid "Transform by 2 points"
 msgstr "Transformation an 2 Punkten"
 
-#: ../src/live_effects/effect.cpp:113
-#: ../src/live_effects/lpe-show_handles.cpp:27
-#: ../src/widgets/mesh-toolbar.cpp:505
+#: ../src/live_effects/effect.cpp:116
+#: ../src/live_effects/lpe-show_handles.cpp:28
+#: ../src/widgets/mesh-toolbar.cpp:514
 msgid "Show handles"
 msgstr "Anfasser zeigen"
 
-#: ../src/live_effects/effect.cpp:115 ../src/widgets/pencil-toolbar.cpp:115
+#: ../src/live_effects/effect.cpp:118 ../src/widgets/pencil-toolbar.cpp:137
 msgid "BSpline"
 msgstr "B-Spline"
 
-#: ../src/live_effects/effect.cpp:116
+#: ../src/live_effects/effect.cpp:119
 msgid "Join type"
 msgstr "Verbindungsart"
 
-#: ../src/live_effects/effect.cpp:117
+#: ../src/live_effects/effect.cpp:120
 msgid "Taper stroke"
 msgstr "Pfad verjüngen"
 
-#: ../src/live_effects/effect.cpp:118
+#: ../src/live_effects/effect.cpp:121
 msgid "Mirror symmetry"
 msgstr "Spiegelsymmetrie"
 
-#: ../src/live_effects/effect.cpp:119
+#: ../src/live_effects/effect.cpp:122
 msgid "Rotate copies"
 msgstr "Gedrehte Kopien"
 
 #. Ponyscape -> Inkscape 0.92
-#: ../src/live_effects/effect.cpp:121
+#: ../src/live_effects/effect.cpp:124
 msgid "Attach path"
 msgstr "Pfad anheften"
 
-#: ../src/live_effects/effect.cpp:122
+#: ../src/live_effects/effect.cpp:125
 msgid "Fill between strokes"
 msgstr "Zwischen Pfaden Füllen"
 
-#: ../src/live_effects/effect.cpp:123 ../src/selection-chemistry.cpp:2963
+#: ../src/live_effects/effect.cpp:126 ../src/selection-chemistry.cpp:2931
 msgid "Fill between many"
 msgstr "Zwischen Vielen Füllen"
 
-#: ../src/live_effects/effect.cpp:124
+#: ../src/live_effects/effect.cpp:127
 msgid "Ellipse by 5 points"
 msgstr "Ellipse durch 5 Punkte"
 
-#: ../src/live_effects/effect.cpp:125
+#: ../src/live_effects/effect.cpp:128
 msgid "Bounding Box"
 msgstr "Objektrahmen"
 
 #. 9.93
-#: ../src/live_effects/effect.cpp:127
+#: ../src/live_effects/effect.cpp:130
 #, fuzzy
-msgid "Measure Line"
-msgstr "Maßstab"
+msgid "Measure Segments"
+msgstr "Messwerkzeug"
 
-#: ../src/live_effects/effect.cpp:128
+#: ../src/live_effects/effect.cpp:131
 msgid "Fillet/Chamfer"
 msgstr "Abrunden/Fasen"
 
-#: ../src/live_effects/effect.cpp:129
+#: ../src/live_effects/effect.cpp:132
 #, fuzzy
 msgid "Boolean operation"
 msgstr "Goldener Schnitt"
 
-#: ../src/live_effects/effect.cpp:130
-msgid "Embrodery stitch"
+#: ../src/live_effects/effect.cpp:133
+msgid "Embroidery stitch"
 msgstr ""
 
-#: ../src/live_effects/effect.cpp:132
+#: ../src/live_effects/effect.cpp:134
+#, fuzzy
+msgid "Power clip"
+msgstr "Knoten in Linien"
+
+#: ../src/live_effects/effect.cpp:135
+#, fuzzy
+msgid "Power mask"
+msgstr "Power Stroke (variable Konturbreite)"
+
+#: ../src/live_effects/effect.cpp:137
 msgid "doEffect stack test"
 msgstr "AusführenEffekt-Reihentest"
 
-#: ../src/live_effects/effect.cpp:133
+#: ../src/live_effects/effect.cpp:138
 msgid "Angle bisector"
 msgstr "Winkelhalbierende"
 
-#: ../src/live_effects/effect.cpp:134
+#: ../src/live_effects/effect.cpp:139
 msgid "Circle (by center and radius)"
 msgstr "Kreis (Mittelpunkt+Radius)"
 
-#: ../src/live_effects/effect.cpp:135
+#: ../src/live_effects/effect.cpp:140
 msgid "Circle by 3 points"
 msgstr "Kreis durch 3 Punkte"
 
-#: ../src/live_effects/effect.cpp:136
+#: ../src/live_effects/effect.cpp:141
 msgid "Dynamic stroke"
 msgstr "Dynamischer Strich"
 
-#: ../src/live_effects/effect.cpp:137 ../share/extensions/extrude.inx.h:1
+#: ../src/live_effects/effect.cpp:142 ../share/extensions/extrude.inx.h:1
 msgid "Extrude"
 msgstr "Extrudieren"
 
-#: ../src/live_effects/effect.cpp:138
+#: ../src/live_effects/effect.cpp:143
 msgid "Lattice Deformation"
 msgstr "Gitterverformung"
 
-#: ../src/live_effects/effect.cpp:139
+#: ../src/live_effects/effect.cpp:144
 msgid "Line Segment"
 msgstr "Liniensegment"
 
-#: ../src/live_effects/effect.cpp:141
-#: ../src/live_effects/lpe-measure-line.cpp:46
+#: ../src/live_effects/effect.cpp:146
+#: ../src/live_effects/lpe-measure-segments.cpp:51
 msgid "Parallel"
 msgstr "Parallel"
 
-#: ../src/live_effects/effect.cpp:142
+#: ../src/live_effects/effect.cpp:147
 msgid "Path length"
 msgstr "Pfadlänge"
 
-#: ../src/live_effects/effect.cpp:143
+#: ../src/live_effects/effect.cpp:148
 msgid "Perpendicular bisector"
 msgstr "Senkrechte Winkelhalbierende"
 
-#: ../src/live_effects/effect.cpp:144
+#: ../src/live_effects/effect.cpp:149
 msgid "Perspective path"
 msgstr "Perspektivischer Pfad"
 
-#: ../src/live_effects/effect.cpp:145
+#: ../src/live_effects/effect.cpp:150
 msgid "Recursive skeleton"
 msgstr "Rekursives Gitter"
 
-#: ../src/live_effects/effect.cpp:146
+#: ../src/live_effects/effect.cpp:151
 msgid "Tangent to curve"
 msgstr "Tangente an Kurve"
 
-#: ../src/live_effects/effect.cpp:147
+#: ../src/live_effects/effect.cpp:152
 msgid "Text label"
 msgstr "Text-Bezeichner"
 
-#: ../src/live_effects/effect.cpp:366
+#: ../src/live_effects/effect.cpp:377
 msgid "Is visible?"
 msgstr "Sichtbar?"
 
-#: ../src/live_effects/effect.cpp:366
+#: ../src/live_effects/effect.cpp:377
 msgid ""
 "If unchecked, the effect remains applied to the object but is temporarily "
 "disabled on canvas"
@@ -9334,48 +9366,65 @@ msgstr ""
 "Wenn die Option deaktiviert ist, wird der Effekt auf das Objekt angewendet, "
 "aber temporär auf der Arbeitsfläche ausgeblendet."
 
-#: ../src/live_effects/effect.cpp:395
+#: ../src/live_effects/effect.cpp:406
 msgid "No effect"
 msgstr "Kein Effekt"
 
-#: ../src/live_effects/effect.cpp:583
+#: ../src/live_effects/effect.cpp:594
 #, c-format
 msgid "Please specify a parameter path for the LPE '%s' with %d mouse clicks"
 msgstr ""
 "Bitte erstellen Sie einen Parameterpfad für den Pfadeffekt \"%s\" mit %d "
 "Mausklicks."
 
-#: ../src/live_effects/effect.cpp:819
+#: ../src/live_effects/effect.cpp:837 ../src/live_effects/effect.cpp:908
 #, fuzzy
-msgid ". Change custom values for this parameter"
-msgstr "Aufzählungsparameter ändern"
+msgid "<b>Default value:</b> "
+msgstr " <b>_Erzeugen</b> "
 
-#: ../src/live_effects/effect.cpp:828 ../src/live_effects/effect.cpp:870
+#: ../src/live_effects/effect.cpp:838 ../src/live_effects/effect.cpp:895
+msgid "<b>Default value overridden:</b> "
+msgstr ""
+
+#: ../src/live_effects/effect.cpp:840 ../src/live_effects/effect.cpp:891
 #, fuzzy
 msgid "Update"
 msgstr "Akt_ualisieren"
 
-#: ../src/live_effects/effect.cpp:830 ../src/live_effects/effect.cpp:880
+#: ../src/live_effects/effect.cpp:841 ../src/live_effects/effect.cpp:894
+msgid "<b>Default value:</b> <s>"
+msgstr ""
+
+#: ../src/live_effects/effect.cpp:843 ../src/live_effects/effect.cpp:905
 #: ../src/ui/dialog/xml-tree.cpp:76
 msgid "Set"
 msgstr "Setzen"
 
+#: ../src/live_effects/effect.cpp:844 ../src/live_effects/effect.cpp:909
+msgid "<b>Default value overridden:</b> None\n"
+msgstr ""
+
+#: ../src/live_effects/effect.cpp:846 ../src/live_effects/effect.cpp:896
+#: ../src/live_effects/effect.cpp:910
+msgid "<b>Current parameter value:</b> "
+msgstr ""
+
 #. image-rendering
-#: ../src/live_effects/effect.cpp:839
+#: ../src/live_effects/effect.cpp:856
 #: ../share/extensions/image_attributes.inx.h:19
 msgid "Unset"
 msgstr "Nicht gesetzt"
 
-#: ../src/live_effects/effect.cpp:852
+#: ../src/live_effects/effect.cpp:870
 msgid "</b>: Set default parameters"
 msgstr ""
 
-#: ../src/live_effects/effect.cpp:952
+#: ../src/live_effects/effect.cpp:981
 #, c-format
 msgid "Editing parameter <b>%s</b>."
 msgstr "Bearbeite Parameter <b>%s</b>."
 
-#: ../src/live_effects/effect.cpp:957
+#: ../src/live_effects/effect.cpp:986
 msgid "None of the applied path effect's parameters can be edited on-canvas."
 msgstr ""
 "Keine Parameter der auf den Pfad angewandten Effekte können auf der "
@@ -9442,44 +9491,50 @@ msgstr "Anfang der Endpfadkurve:"
 msgid "End path curve end:"
 msgstr "Ende der Endpfadkurve:"
 
-#: ../src/live_effects/lpe-bendpath.cpp:54
+#: ../src/live_effects/lpe-bendpath.cpp:59
 msgid "Bend path:"
 msgstr "Verbiegepfad:"
 
-#: ../src/live_effects/lpe-bendpath.cpp:54
+#: ../src/live_effects/lpe-bendpath.cpp:59
 msgid "Path along which to bend the original path"
 msgstr "Pfad, entlang welchem der Originalpfad gebogen werden soll"
 
-#: ../src/live_effects/lpe-bendpath.cpp:56
-#: ../src/live_effects/lpe-patternalongpath.cpp:68
-#: ../src/ui/dialog/export.cpp:257 ../src/ui/dialog/transformation.cpp:67
+#: ../src/live_effects/lpe-bendpath.cpp:61
+#: ../src/live_effects/lpe-patternalongpath.cpp:72
+#: ../src/ui/dialog/export.cpp:253 ../src/ui/dialog/transformation.cpp:67
 #: ../src/ui/widget/page-sizer.cpp:220
 msgid "_Width:"
 msgstr "_Breite:"
 
-#: ../src/live_effects/lpe-bendpath.cpp:56
+#: ../src/live_effects/lpe-bendpath.cpp:61
 msgid "Width of the path"
 msgstr "Breite des Pfades"
 
-#: ../src/live_effects/lpe-bendpath.cpp:57
+#: ../src/live_effects/lpe-bendpath.cpp:62
 msgid "W_idth in units of length"
 msgstr "Breite in Einheiten der Länge"
 
-#: ../src/live_effects/lpe-bendpath.cpp:57
+#: ../src/live_effects/lpe-bendpath.cpp:62
 msgid "Scale the width of the path in units of its length"
 msgstr "Breite des Pfades in Vielfachen seiner Länge"
 
-#: ../src/live_effects/lpe-bendpath.cpp:58
+#: ../src/live_effects/lpe-bendpath.cpp:63
 msgid "_Original path is vertical"
 msgstr "Originalpfad ist vertikal"
 
-#: ../src/live_effects/lpe-bendpath.cpp:58
+#: ../src/live_effects/lpe-bendpath.cpp:63
 msgid "Rotates the original 90 degrees, before bending it along the bend path"
 msgstr ""
 "Rotiert das Original um 90 Grad, bevor es entlang des Pfades gebogen wird"
 
-#: ../src/live_effects/lpe-bendpath.cpp:163
-#: ../src/live_effects/lpe-patternalongpath.cpp:283
+#: ../src/live_effects/lpe-bendpath.cpp:64
+#: ../src/live_effects/lpe-patternalongpath.cpp:89
+#, fuzzy
+msgid "Hide width knot"
+msgstr "Knoten ausblenden"
+
+#: ../src/live_effects/lpe-bendpath.cpp:190
+#: ../src/live_effects/lpe-patternalongpath.cpp:298
 msgid "Change the width"
 msgstr "Breite ändern"
 
@@ -9602,7 +9657,7 @@ msgid "Fill type (winding mode) for operand path"
 msgstr ""
 
 #: ../src/live_effects/lpe-bounding-box.cpp:20
-#: ../src/live_effects/lpe-fill-between-many.cpp:22
+#: ../src/live_effects/lpe-fill-between-many.cpp:33
 #: ../src/live_effects/lpe-fill-between-strokes.cpp:20
 msgid "Linked path:"
 msgstr "Verknüpfter Pfad:"
@@ -9678,85 +9733,50 @@ msgid "Change to 0 weight"
 msgstr "Gewichtung auf 0 setzen"
 
 #: ../src/live_effects/lpe-bspline.cpp:160
-#: ../src/live_effects/parameter/parameter.cpp:187
+#: ../src/live_effects/parameter/parameter.cpp:194
 msgid "Change scalar parameter"
 msgstr "Skalarparameter ändern"
 
-#: ../src/live_effects/lpe-clone-original.cpp:23
-msgid "Linked Item:"
-msgstr "Verknüpftes Objekt:"
-
-#: ../src/live_effects/lpe-clone-original.cpp:23
-msgid "Item from which to take the original data"
-msgstr "Objekt, von dem die Orginaldaten übernommen werden sollen"
-
-#: ../src/live_effects/lpe-clone-original.cpp:24
-#: ../src/widgets/measure-toolbar.cpp:315
-msgid "Scale %"
-msgstr "Skalierung"
-
-#: ../src/live_effects/lpe-clone-original.cpp:24
-#, fuzzy
-msgid "Scale item %"
-msgstr "Skalierung"
-
-#: ../src/live_effects/lpe-clone-original.cpp:25
-msgid "Preserve position"
-msgstr "Position beibehalten"
-
 #: ../src/live_effects/lpe-clone-original.cpp:26
 #, fuzzy
-msgid "Inverse clone"
-msgstr "Invertierte Abrundung"
-
-#: ../src/live_effects/lpe-clone-original.cpp:26
-msgid "Use LPE item as origin"
-msgstr ""
+msgid "No shape"
+msgstr "Kein Tausch"
 
 #: ../src/live_effects/lpe-clone-original.cpp:27
-msgid "Clone shape -d-"
+#: ../src/live_effects/lpe-fill-between-many.cpp:25
+msgid "Without LPE's"
 msgstr ""
 
 #: ../src/live_effects/lpe-clone-original.cpp:28
+#: ../src/live_effects/lpe-fill-between-many.cpp:26
 #, fuzzy
-msgid "Clone transforms"
-msgstr "Transformationen zurücksetzen"
+msgid "With Spiro or BSpline"
+msgstr "Spiro Spline"
 
 #: ../src/live_effects/lpe-clone-original.cpp:29
-#, fuzzy
-msgid "Clone fill"
-msgstr "Datei schließen"
+#: ../src/live_effects/lpe-fill-between-many.cpp:27
+msgid "With LPE's"
+msgstr ""
 
-#: ../src/live_effects/lpe-clone-original.cpp:30
-#, fuzzy
-msgid "Clone stroke"
-msgstr "Keine Kontur"
+#: ../src/live_effects/lpe-clone-original.cpp:35
+msgid "Linked Item:"
+msgstr "Verknüpftes Objekt:"
 
-#: ../src/live_effects/lpe-clone-original.cpp:31
-#, fuzzy
-msgid "Clone paint order"
-msgstr "Farbmalmodus"
+#: ../src/live_effects/lpe-clone-original.cpp:35
+msgid "Item from which to take the original data"
+msgstr "Objekt, von dem die Orginaldaten übernommen werden sollen"
 
-#: ../src/live_effects/lpe-clone-original.cpp:32
+#: ../src/live_effects/lpe-clone-original.cpp:36
 #, fuzzy
-msgid "Clone opacity"
-msgstr "Deckkraft ändern"
+msgid "Shape linked"
+msgstr "ihre Verbindung zum Original verlieren"
 
-#: ../src/live_effects/lpe-clone-original.cpp:33
+#: ../src/live_effects/lpe-clone-original.cpp:39
+#: ../src/live_effects/lpe-fill-between-many.cpp:36
+#: ../src/live_effects/lpe-fill-between-strokes.cpp:24
 #, fuzzy
-msgid "Clone filter"
-msgstr "Datei schließen"
-
-#: ../src/live_effects/lpe-clone-original.cpp:322
-#: ../src/live_effects/lpe-clone-original.cpp:337
-#, fuzzy
-msgid "Show attributes override"
-msgstr "Attributwert suchen"
-
-#: ../src/live_effects/lpe-clone-original.cpp:335
-#, fuzzy
-msgid "Hide attributes override"
-msgstr "Attribute kürzen"
+msgid "Allow transforms"
+msgstr "Transformationen zurücksetzen"
 
 #: ../src/live_effects/lpe-constructgrid.cpp:24
 msgid "Size _X:"
@@ -10000,7 +10020,7 @@ msgid "traveling salesman 4-opt (seconds)"
 msgstr ""
 
 #: ../src/live_effects/lpe-embrodery-stitch.cpp:37
-msgid "traveling salesman 5-opt (miutes)"
+msgid "traveling salesman 5-opt (minutes)"
 msgstr ""
 
 #: ../src/live_effects/lpe-embrodery-stitch.cpp:44
@@ -10128,7 +10148,8 @@ msgid "Left path along which to bend the original path"
 msgstr "Linker Pfad, entlang welchem der Originalpfad gebogen wird"
 
 #: ../src/live_effects/lpe-envelope.cpp:23
-msgid "_Enable left & right paths"
+#, fuzzy
+msgid "_Enable left &amp; right paths"
 msgstr "Aktiviere linke und rechte Pfade"
 
 #: ../src/live_effects/lpe-envelope.cpp:23
@@ -10136,7 +10157,8 @@ msgid "Enable the left and right deformation paths"
 msgstr "Aktiviere linken und rechten Verformungs-Pfad"
 
 #: ../src/live_effects/lpe-envelope.cpp:24
-msgid "_Enable top & bottom paths"
+#, fuzzy
+msgid "_Enable top &amp; bottom paths"
 msgstr "Aktiviere obere und untere Pfade"
 
 #: ../src/live_effects/lpe-envelope.cpp:24
@@ -10151,35 +10173,37 @@ msgstr "Richtung"
 msgid "Defines the direction and magnitude of the extrusion"
 msgstr "Definiert Richtung und Ausmaß der Extrusion"
 
-#: ../src/live_effects/lpe-fill-between-many.cpp:22
+#: ../src/live_effects/lpe-fill-between-many.cpp:33
 msgid "Paths from which to take the original path data"
 msgstr "Pfade, von denen die Orginal-Pfaddaten genommen werden"
 
-#: ../src/live_effects/lpe-fill-between-many.cpp:23
+#: ../src/live_effects/lpe-fill-between-many.cpp:34
+msgid "LPE's on linked:"
+msgstr ""
+
+#: ../src/live_effects/lpe-fill-between-many.cpp:34
+msgid "LPE's on linked"
+msgstr ""
+
+#: ../src/live_effects/lpe-fill-between-many.cpp:35
 #: ../src/live_effects/lpe-fill-between-strokes.cpp:23
 #, fuzzy
 msgid "Fuse coincident points"
 msgstr "Neuer Connector-Punkt"
 
-#: ../src/live_effects/lpe-fill-between-many.cpp:24
-#: ../src/live_effects/lpe-fill-between-strokes.cpp:24
-#, fuzzy
-msgid "Allow transforms"
-msgstr "Transformationen zurücksetzen"
-
-#: ../src/live_effects/lpe-fill-between-many.cpp:25
+#: ../src/live_effects/lpe-fill-between-many.cpp:37
 #: ../src/live_effects/lpe-fill-between-strokes.cpp:25
 #, fuzzy
 msgid "Join subpaths"
 msgstr "Pfade verbinden"
 
-#: ../src/live_effects/lpe-fill-between-many.cpp:26
+#: ../src/live_effects/lpe-fill-between-many.cpp:38
 #: ../src/live_effects/lpe-fill-between-strokes.cpp:26
-#: ../src/ui/dialog/ocaldialogs.cpp:1090
+#: ../src/ui/dialog/ocaldialogs.cpp:1091
 msgid "Close"
 msgstr "Schließen"
 
-#: ../src/live_effects/lpe-fill-between-many.cpp:26
+#: ../src/live_effects/lpe-fill-between-many.cpp:38
 #: ../src/live_effects/lpe-fill-between-strokes.cpp:26
 #, fuzzy
 msgid "Close path"
@@ -10202,7 +10226,7 @@ msgid "Reverses the second path order"
 msgstr "Kehrt die Richtung des zweiten Pfads um"
 
 #: ../src/live_effects/lpe-fillet-chamfer.cpp:27
-#: ../src/widgets/text-toolbar.cpp:1905
+#: ../src/widgets/text-toolbar.cpp:2207
 #: ../share/extensions/render_barcode_qrcode.inx.h:5
 msgid "Auto"
 msgstr "Auto"
@@ -10216,8 +10240,8 @@ msgid "Force bezier"
 msgstr "Bézierkurven erzwingen"
 
 #: ../src/live_effects/lpe-fillet-chamfer.cpp:35
-#: ../src/live_effects/lpe-measure-line.cpp:52
-#: ../src/live_effects/lpe-ruler.cpp:39 ../src/widgets/gimp/ruler.cpp:194
+#: ../src/live_effects/lpe-measure-segments.cpp:57
+#: ../src/live_effects/lpe-ruler.cpp:39 ../src/widgets/gimp/ruler.cpp:197
 msgid "Unit"
 msgstr "Einheit"
 
@@ -10284,22 +10308,22 @@ msgstr "Länge der Hilfslinien mit Richtung:"
 msgid "Helper path size with direction to node"
 msgstr "Länge der Hilfslinien mit Richtung"
 
-#: ../src/live_effects/lpe-fillet-chamfer.cpp:228
+#: ../src/live_effects/lpe-fillet-chamfer.cpp:226
 #: ../src/ui/dialog/lpe-fillet-chamfer-properties.cpp:63
 msgid "Fillet"
 msgstr "Abrunden"
 
-#: ../src/live_effects/lpe-fillet-chamfer.cpp:233
+#: ../src/live_effects/lpe-fillet-chamfer.cpp:231
 #: ../src/ui/dialog/lpe-fillet-chamfer-properties.cpp:65
 msgid "Inverse fillet"
 msgstr "Invertierte Abrundung"
 
-#: ../src/live_effects/lpe-fillet-chamfer.cpp:239
+#: ../src/live_effects/lpe-fillet-chamfer.cpp:237
 #: ../src/ui/dialog/lpe-fillet-chamfer-properties.cpp:67
 msgid "Chamfer"
 msgstr "Fasen"
 
-#: ../src/live_effects/lpe-fillet-chamfer.cpp:244
+#: ../src/live_effects/lpe-fillet-chamfer.cpp:242
 #: ../src/ui/dialog/lpe-fillet-chamfer-properties.cpp:69
 msgid "Inverse chamfer"
 msgstr "Invertierte Fasung"
@@ -10362,32 +10386,32 @@ msgstr ""
 "der Knoten des Trajektorienpfades ab."
 
 #: ../src/live_effects/lpe-interpolate_points.cpp:25
-#: ../src/live_effects/lpe-powerstroke.cpp:123
+#: ../src/live_effects/lpe-powerstroke.cpp:126
 msgid "CubicBezierFit"
 msgstr "CubicBezierFit"
 
 #: ../src/live_effects/lpe-interpolate_points.cpp:26
-#: ../src/live_effects/lpe-powerstroke.cpp:124
+#: ../src/live_effects/lpe-powerstroke.cpp:127
 msgid "CubicBezierJohan"
 msgstr "CubicBezierJohan"
 
 #: ../src/live_effects/lpe-interpolate_points.cpp:27
-#: ../src/live_effects/lpe-powerstroke.cpp:125
+#: ../src/live_effects/lpe-powerstroke.cpp:128
 msgid "SpiroInterpolator"
 msgstr "Spiro-Interpolieren"
 
 #: ../src/live_effects/lpe-interpolate_points.cpp:28
-#: ../src/live_effects/lpe-powerstroke.cpp:126
+#: ../src/live_effects/lpe-powerstroke.cpp:129
 msgid "Centripetal Catmull-Rom"
 msgstr "Centripetal Catmull-Rom"
 
 #: ../src/live_effects/lpe-interpolate_points.cpp:36
-#: ../src/live_effects/lpe-powerstroke.cpp:168
+#: ../src/live_effects/lpe-powerstroke.cpp:171
 msgid "Interpolator type:"
 msgstr "Interpolatortyp:"
 
 #: ../src/live_effects/lpe-interpolate_points.cpp:37
-#: ../src/live_effects/lpe-powerstroke.cpp:168
+#: ../src/live_effects/lpe-powerstroke.cpp:171
 msgid ""
 "Determines which kind of interpolator will be used to interpolate between "
 "stroke width along the path"
@@ -10396,21 +10420,21 @@ msgstr ""
 "Strichstärken entlang des Pfades verwendet wird"
 
 #: ../src/live_effects/lpe-jointype.cpp:29
-#: ../src/live_effects/lpe-powerstroke.cpp:155
+#: ../src/live_effects/lpe-powerstroke.cpp:158
 #: ../src/live_effects/lpe-taperstroke.cpp:57
 msgid "Beveled"
 msgstr "Abgeschrägt"
 
 #: ../src/live_effects/lpe-jointype.cpp:30
 #: ../src/live_effects/lpe-jointype.cpp:41
-#: ../src/live_effects/lpe-powerstroke.cpp:156
+#: ../src/live_effects/lpe-powerstroke.cpp:159
 #: ../src/live_effects/lpe-taperstroke.cpp:58
-#: ../src/widgets/star-toolbar.cpp:532
+#: ../src/widgets/star-toolbar.cpp:544
 msgid "Rounded"
 msgstr "Abgerundet"
 
 #: ../src/live_effects/lpe-jointype.cpp:31
-#: ../src/live_effects/lpe-powerstroke.cpp:159
+#: ../src/live_effects/lpe-powerstroke.cpp:162
 #: ../src/live_effects/lpe-taperstroke.cpp:59
 msgid "Miter"
 msgstr "Gehrung"
@@ -10421,7 +10445,7 @@ msgstr "Gestutzte Gehrung"
 
 #. {LINEJOIN_EXTRP_MITER,  N_("Extrapolated"),      "extrapolated"}, // disabled because doesn't work well
 #: ../src/live_effects/lpe-jointype.cpp:33
-#: ../src/live_effects/lpe-powerstroke.cpp:158
+#: ../src/live_effects/lpe-powerstroke.cpp:161
 msgid "Extrapolated arc"
 msgstr "Abgeleitete Kurve"
 
@@ -10438,17 +10462,17 @@ msgid "Extrapolated arc Alt3"
 msgstr "Abgeleitete Kurve Variante 3"
 
 #: ../src/live_effects/lpe-jointype.cpp:40
-#: ../src/live_effects/lpe-powerstroke.cpp:138
+#: ../src/live_effects/lpe-powerstroke.cpp:141
 msgid "Butt"
 msgstr "Stoß"
 
 #: ../src/live_effects/lpe-jointype.cpp:42
-#: ../src/live_effects/lpe-powerstroke.cpp:139
+#: ../src/live_effects/lpe-powerstroke.cpp:142
 msgid "Square"
 msgstr "Quadrat"
 
 #: ../src/live_effects/lpe-jointype.cpp:43
-#: ../src/live_effects/lpe-powerstroke.cpp:141
+#: ../src/live_effects/lpe-powerstroke.cpp:144
 msgid "Peak"
 msgstr "Spitze"
 
@@ -10468,20 +10492,20 @@ msgstr "Form des Konturendes"
 #. TRANSLATORS: The line join style specifies the shape to be used at the
 #. corners of paths. It can be "miter", "round" or "bevel".
 #: ../src/live_effects/lpe-jointype.cpp:54
-#: ../src/live_effects/lpe-powerstroke.cpp:171
+#: ../src/live_effects/lpe-powerstroke.cpp:175
 #: ../src/widgets/stroke-style.cpp:262
 msgid "Join:"
 msgstr "Verbindung:"
 
 #: ../src/live_effects/lpe-jointype.cpp:54
-#: ../src/live_effects/lpe-powerstroke.cpp:171
+#: ../src/live_effects/lpe-powerstroke.cpp:175
 msgid "Determines the shape of the path's corners"
 msgstr "Bestimmt die Form der Pfad-Ecken"
 
 #. start_lean(_("Start path lean"), _("Start path lean"), "start_lean", &wr, this, 0.),
 #. end_lean(_("End path lean"), _("End path lean"), "end_lean", &wr, this, 0.),
 #: ../src/live_effects/lpe-jointype.cpp:57
-#: ../src/live_effects/lpe-powerstroke.cpp:172
+#: ../src/live_effects/lpe-powerstroke.cpp:176
 #: ../src/live_effects/lpe-taperstroke.cpp:72
 msgid "Miter limit:"
 msgstr "Gehrungslimit:"
@@ -10548,14 +10572,14 @@ msgstr "Kreuzungsmarkierungen"
 msgid "Crossings signs"
 msgstr "Kreuzungsmarkierungen"
 
-#: ../src/live_effects/lpe-knot.cpp:622
+#: ../src/live_effects/lpe-knot.cpp:618
 msgid "Drag to select a crossing, click to flip it"
 msgstr ""
 "Ziehen Sie, um eine Überschneidung auszuwählen; klicken Sie, um sie "
 "umzudrehen"
 
 #. / @todo Is this the right verb?
-#: ../src/live_effects/lpe-knot.cpp:660
+#: ../src/live_effects/lpe-knot.cpp:656
 msgid "Change knot crossing"
 msgstr "Knotenkreuz ändern"
 
@@ -10570,263 +10594,268 @@ msgid "Mirror movements in vertical"
 msgstr "Bewegungen vertikal spiegeln"
 
 #: ../src/live_effects/lpe-lattice2.cpp:38
+#, fuzzy
+msgid "Use only perimeter"
+msgstr "Booleschen Parameter ändern"
+
+#: ../src/live_effects/lpe-lattice2.cpp:39
 msgid "Update while moving knots (maybe slow)"
 msgstr ""
 "Während des Verschiebens von Knoten aktualisieren (möglicherweise langsam)"
 
-#: ../src/live_effects/lpe-lattice2.cpp:39
+#: ../src/live_effects/lpe-lattice2.cpp:40
 msgid "Control 0:"
 msgstr "Anfasser 0:"
 
-#: ../src/live_effects/lpe-lattice2.cpp:39
+#: ../src/live_effects/lpe-lattice2.cpp:40
 msgid "Control 0 - <b>Ctrl+Alt+Click</b>: reset, <b>Ctrl</b>: move along axes"
 msgstr ""
 "Anfasser 0 - <b>Strg+Alt+Klick</b>: zurücksetzen, <b>Ctrl</b>: nur entlang "
 "Hauptachsen verschieben"
 
-#: ../src/live_effects/lpe-lattice2.cpp:40
+#: ../src/live_effects/lpe-lattice2.cpp:41
 msgid "Control 1:"
 msgstr "Anfasser 1:"
 
-#: ../src/live_effects/lpe-lattice2.cpp:40
+#: ../src/live_effects/lpe-lattice2.cpp:41
 msgid "Control 1 - <b>Ctrl+Alt+Click</b>: reset, <b>Ctrl</b>: move along axes"
 msgstr ""
 "Anfasser 1 - <b>Strg+Alt+Klick</b>: zurücksetzen, <b>Ctrl</b>: nur entlang "
 "Hauptachsen verschieben"
 
-#: ../src/live_effects/lpe-lattice2.cpp:41
+#: ../src/live_effects/lpe-lattice2.cpp:42
 msgid "Control 2:"
 msgstr "Anfasser 2:"
 
-#: ../src/live_effects/lpe-lattice2.cpp:41
+#: ../src/live_effects/lpe-lattice2.cpp:42
 msgid "Control 2 - <b>Ctrl+Alt+Click</b>: reset, <b>Ctrl</b>: move along axes"
 msgstr ""
 "Anfasser 2 - <b>Strg+Alt+Klick</b>: zurücksetzen, <b>Ctrl</b>: nur entlang "
 "Hauptachsen verschieben"
 
-#: ../src/live_effects/lpe-lattice2.cpp:42
+#: ../src/live_effects/lpe-lattice2.cpp:43
 msgid "Control 3:"
 msgstr "Anfasser 3:"
 
-#: ../src/live_effects/lpe-lattice2.cpp:42
+#: ../src/live_effects/lpe-lattice2.cpp:43
 msgid "Control 3 - <b>Ctrl+Alt+Click</b>: reset, <b>Ctrl</b>: move along axes"
 msgstr ""
 "Anfasser 3 - <b>Strg+Alt+Klick</b>: zurücksetzen, <b>Ctrl</b>: nur entlang "
 "Hauptachsen verschieben"
 
-#: ../src/live_effects/lpe-lattice2.cpp:43
+#: ../src/live_effects/lpe-lattice2.cpp:44
 msgid "Control 4:"
 msgstr "Anfasser 4:"
 
-#: ../src/live_effects/lpe-lattice2.cpp:43
+#: ../src/live_effects/lpe-lattice2.cpp:44
 msgid "Control 4 - <b>Ctrl+Alt+Click</b>: reset, <b>Ctrl</b>: move along axes"
 msgstr ""
 "Anfasser 4 - <b>Strg+Alt+Klick</b>: zurücksetzen, <b>Ctrl</b>: nur entlang "
 "Hauptachsen verschieben"
 
-#: ../src/live_effects/lpe-lattice2.cpp:44
+#: ../src/live_effects/lpe-lattice2.cpp:45
 msgid "Control 5:"
 msgstr "Anfasser 5:"
 
-#: ../src/live_effects/lpe-lattice2.cpp:44
+#: ../src/live_effects/lpe-lattice2.cpp:45
 msgid "Control 5 - <b>Ctrl+Alt+Click</b>: reset, <b>Ctrl</b>: move along axes"
 msgstr ""
 "Anfasser 5 - <b>Strg+Alt+Klick</b>: zurücksetzen, <b>Ctrl</b>: nur entlang "
 "Hauptachsen verschieben"
 
-#: ../src/live_effects/lpe-lattice2.cpp:45
+#: ../src/live_effects/lpe-lattice2.cpp:46
 msgid "Control 6:"
 msgstr "Anfasser 6:"
 
-#: ../src/live_effects/lpe-lattice2.cpp:45
+#: ../src/live_effects/lpe-lattice2.cpp:46
 msgid "Control 6 - <b>Ctrl+Alt+Click</b>: reset, <b>Ctrl</b>: move along axes"
 msgstr ""
 "Anfasser 6 - <b>Strg+Alt+Klick</b>: zurücksetzen, <b>Ctrl</b>: nur entlang "
 "Hauptachsen verschieben"
 
-#: ../src/live_effects/lpe-lattice2.cpp:46
+#: ../src/live_effects/lpe-lattice2.cpp:47
 msgid "Control 7:"
 msgstr "Anfasser 7:"
 
-#: ../src/live_effects/lpe-lattice2.cpp:46
+#: ../src/live_effects/lpe-lattice2.cpp:47
 msgid "Control 7 - <b>Ctrl+Alt+Click</b>: reset, <b>Ctrl</b>: move along axes"
 msgstr ""
 "Anfasser 7 - <b>Strg+Alt+Klick</b>: zurücksetzen, <b>Ctrl</b>: nur entlang "
 "Hauptachsen verschieben"
 
-#: ../src/live_effects/lpe-lattice2.cpp:47
+#: ../src/live_effects/lpe-lattice2.cpp:48
 msgid "Control 8x9:"
 msgstr "Anfasser 8x9:"
 
-#: ../src/live_effects/lpe-lattice2.cpp:47
+#: ../src/live_effects/lpe-lattice2.cpp:48
 msgid ""
 "Control 8x9 - <b>Ctrl+Alt+Click</b>: reset, <b>Ctrl</b>: move along axes"
 msgstr ""
 "Anfasser 8x9 - <b>Strg+Alt+Klick</b>: zurücksetzen, <b>Ctrl</b>: nur entlang "
 "Hauptachsen verschieben"
 
-#: ../src/live_effects/lpe-lattice2.cpp:48
+#: ../src/live_effects/lpe-lattice2.cpp:49
 msgid "Control 10x11:"
 msgstr "Anfasser 10x11:"
 
-#: ../src/live_effects/lpe-lattice2.cpp:48
+#: ../src/live_effects/lpe-lattice2.cpp:49
 msgid ""
 "Control 10x11 - <b>Ctrl+Alt+Click</b>: reset, <b>Ctrl</b>: move along axes"
 msgstr ""
 "Anfasser 10x11 - <b>Strg+Alt+Klick</b>: zurücksetzen, <b>Ctrl</b>: nur "
 "entlang Hauptachsen verschieben"
 
-#: ../src/live_effects/lpe-lattice2.cpp:49
+#: ../src/live_effects/lpe-lattice2.cpp:50
 msgid "Control 12:"
 msgstr "Anfasser 12:"
 
-#: ../src/live_effects/lpe-lattice2.cpp:49
+#: ../src/live_effects/lpe-lattice2.cpp:50
 msgid "Control 12 - <b>Ctrl+Alt+Click</b>: reset, <b>Ctrl</b>: move along axes"
 msgstr ""
 "Anfasser 12 - <b>Strg+Alt+Klick</b>: zurücksetzen, <b>Ctrl</b>: nur entlang "
 "Hauptachsen verschieben"
 
-#: ../src/live_effects/lpe-lattice2.cpp:50
+#: ../src/live_effects/lpe-lattice2.cpp:51
 msgid "Control 13:"
 msgstr "Anfasser 13:"
 
-#: ../src/live_effects/lpe-lattice2.cpp:50
+#: ../src/live_effects/lpe-lattice2.cpp:51
 msgid "Control 13 - <b>Ctrl+Alt+Click</b>: reset, <b>Ctrl</b>: move along axes"
 msgstr ""
 "Anfasser 13 - <b>Strg+Alt+Klick</b>: zurücksetzen, <b>Ctrl</b>: nur entlang "
 "Hauptachsen verschieben"
 
-#: ../src/live_effects/lpe-lattice2.cpp:51
+#: ../src/live_effects/lpe-lattice2.cpp:52
 msgid "Control 14:"
 msgstr "Anfasser 14:"
 
-#: ../src/live_effects/lpe-lattice2.cpp:51
+#: ../src/live_effects/lpe-lattice2.cpp:52
 msgid "Control 14 - <b>Ctrl+Alt+Click</b>: reset, <b>Ctrl</b>: move along axes"
 msgstr ""
 "Anfasser 14 - <b>Strg+Alt+Klick</b>: zurücksetzen, <b>Ctrl</b>: nur entlang "
 "Hauptachsen verschieben"
 
-#: ../src/live_effects/lpe-lattice2.cpp:52
+#: ../src/live_effects/lpe-lattice2.cpp:53
 msgid "Control 15:"
 msgstr "Anfasser 15:"
 
-#: ../src/live_effects/lpe-lattice2.cpp:52
+#: ../src/live_effects/lpe-lattice2.cpp:53
 msgid "Control 15 - <b>Ctrl+Alt+Click</b>: reset, <b>Ctrl</b>: move along axes"
 msgstr ""
 "Anfasser 15 - <b>Strg+Alt+Klick</b>: zurücksetzen, <b>Ctrl</b>: nur entlang "
 "Hauptachsen verschieben"
 
-#: ../src/live_effects/lpe-lattice2.cpp:53
+#: ../src/live_effects/lpe-lattice2.cpp:54
 msgid "Control 16:"
 msgstr "Anfasser 16:"
 
-#: ../src/live_effects/lpe-lattice2.cpp:53
+#: ../src/live_effects/lpe-lattice2.cpp:54
 msgid "Control 16 - <b>Ctrl+Alt+Click</b>: reset, <b>Ctrl</b>: move along axes"
 msgstr ""
 "Anfasser 16 - <b>Strg+Alt+Klick</b>: zurücksetzen, <b>Ctrl</b>: nur entlang "
 "Hauptachsen verschieben"
 
-#: ../src/live_effects/lpe-lattice2.cpp:54
+#: ../src/live_effects/lpe-lattice2.cpp:55
 msgid "Control 17:"
 msgstr "Anfasser 17:"
 
-#: ../src/live_effects/lpe-lattice2.cpp:54
+#: ../src/live_effects/lpe-lattice2.cpp:55
 msgid "Control 17 - <b>Ctrl+Alt+Click</b>: reset, <b>Ctrl</b>: move along axes"
 msgstr ""
 "Anfasser 17 - <b>Strg+Alt+Klick</b>: zurücksetzen, <b>Ctrl</b>: nur entlang "
 "Hauptachsen verschieben"
 
-#: ../src/live_effects/lpe-lattice2.cpp:55
+#: ../src/live_effects/lpe-lattice2.cpp:56
 msgid "Control 18:"
 msgstr "Anfasser 18:"
 
-#: ../src/live_effects/lpe-lattice2.cpp:55
+#: ../src/live_effects/lpe-lattice2.cpp:56
 msgid "Control 18 - <b>Ctrl+Alt+Click</b>: reset, <b>Ctrl</b>: move along axes"
 msgstr ""
 "Anfasser 18 - <b>Strg+Alt+Klick</b>: zurücksetzen, <b>Ctrl</b>: nur entlang "
 "Hauptachsen verschieben"
 
-#: ../src/live_effects/lpe-lattice2.cpp:56
+#: ../src/live_effects/lpe-lattice2.cpp:57
 msgid "Control 19:"
 msgstr "Anfasser 19:"
 
-#: ../src/live_effects/lpe-lattice2.cpp:56
+#: ../src/live_effects/lpe-lattice2.cpp:57
 msgid "Control 19 - <b>Ctrl+Alt+Click</b>: reset, <b>Ctrl</b>: move along axes"
 msgstr ""
 "Anfasser 19 - <b>Strg+Alt+Klick</b>: zurücksetzen, <b>Ctrl</b>: nur entlang "
 "Hauptachsen verschieben"
 
-#: ../src/live_effects/lpe-lattice2.cpp:57
+#: ../src/live_effects/lpe-lattice2.cpp:58
 msgid "Control 20x21:"
 msgstr "Anfasser 20x21:"
 
-#: ../src/live_effects/lpe-lattice2.cpp:57
+#: ../src/live_effects/lpe-lattice2.cpp:58
 msgid ""
 "Control 20x21 - <b>Ctrl+Alt+Click</b>: reset, <b>Ctrl</b>: move along axes"
 msgstr ""
 "Anfasser 20x21 - <b>Strg+Alt+Klick</b>: zurücksetzen, <b>Ctrl</b>: nur "
 "entlang Hauptachsen verschieben"
 
-#: ../src/live_effects/lpe-lattice2.cpp:58
+#: ../src/live_effects/lpe-lattice2.cpp:59
 msgid "Control 22x23:"
 msgstr "Anfasser 22x23:"
 
-#: ../src/live_effects/lpe-lattice2.cpp:58
+#: ../src/live_effects/lpe-lattice2.cpp:59
 msgid ""
 "Control 22x23 - <b>Ctrl+Alt+Click</b>: reset, <b>Ctrl</b>: move along axes"
 msgstr ""
 "Anfasser 22x23 - <b>Strg+Alt+Klick</b>: zurücksetzen, <b>Ctrl</b>: nur "
 "entlang Hauptachsen verschieben"
 
-#: ../src/live_effects/lpe-lattice2.cpp:59
+#: ../src/live_effects/lpe-lattice2.cpp:60
 msgid "Control 24x26:"
 msgstr "Anfasser 24x26:"
 
-#: ../src/live_effects/lpe-lattice2.cpp:59
+#: ../src/live_effects/lpe-lattice2.cpp:60
 msgid ""
 "Control 24x26 - <b>Ctrl+Alt+Click</b>: reset, <b>Ctrl</b>: move along axes"
 msgstr ""
 "Anfasser 24x26 - <b>Strg+Alt+Klick</b>: zurücksetzen, <b>Ctrl</b>: nur "
 "entlang Hauptachsen verschieben"
 
-#: ../src/live_effects/lpe-lattice2.cpp:60
+#: ../src/live_effects/lpe-lattice2.cpp:61
 msgid "Control 25x27:"
 msgstr "Anfasser 25x27:"
 
-#: ../src/live_effects/lpe-lattice2.cpp:60
+#: ../src/live_effects/lpe-lattice2.cpp:61
 msgid ""
 "Control 25x27 - <b>Ctrl+Alt+Click</b>: reset, <b>Ctrl</b>: move along axes"
 msgstr ""
 "Anfasser 25x27 - <b>Strg+Alt+Klick</b>: zurücksetzen, <b>Ctrl</b>: nur "
 "entlang Hauptachsen verschieben"
 
-#: ../src/live_effects/lpe-lattice2.cpp:61
+#: ../src/live_effects/lpe-lattice2.cpp:62
 msgid "Control 28x30:"
 msgstr "Anfasser 28x30:"
 
-#: ../src/live_effects/lpe-lattice2.cpp:61
+#: ../src/live_effects/lpe-lattice2.cpp:62
 msgid ""
 "Control 28x30 - <b>Ctrl+Alt+Click</b>: reset, <b>Ctrl</b>: move along axes"
 msgstr ""
 "Anfasser 28x30 - <b>Strg+Alt+Klick</b>: zurücksetzen, <b>Ctrl</b>: nur "
 "entlang Hauptachsen verschieben"
 
-#: ../src/live_effects/lpe-lattice2.cpp:62
+#: ../src/live_effects/lpe-lattice2.cpp:63
 msgid "Control 29x31:"
 msgstr "Anfasser 29x31:"
 
-#: ../src/live_effects/lpe-lattice2.cpp:62
+#: ../src/live_effects/lpe-lattice2.cpp:63
 msgid ""
 "Control 29x31 - <b>Ctrl+Alt+Click</b>: reset, <b>Ctrl</b>: move along axes"
 msgstr ""
 "Anfasser 29x31 - <b>Strg+Alt+Klick</b>: zurücksetzen, <b>Ctrl</b>: nur "
 "entlang Hauptachsen verschieben"
 
-#: ../src/live_effects/lpe-lattice2.cpp:63
+#: ../src/live_effects/lpe-lattice2.cpp:64
 msgid "Control 32x33x34x35:"
 msgstr "Anfasser 32x33x34x35:"
 
-#: ../src/live_effects/lpe-lattice2.cpp:63
+#: ../src/live_effects/lpe-lattice2.cpp:64
 msgid ""
 "Control 32x33x34x35 - <b>Ctrl+Alt+Click</b>: reset, <b>Ctrl</b>: move along "
 "axes"
@@ -10834,202 +10863,195 @@ msgstr ""
 "Anfasser 32x33x34x35 - <b>Strg+Alt+Klick</b>: zurücksetzen, <b>Ctrl</b>: nur "
 "entlang Hauptachsen verschieben"
 
-#: ../src/live_effects/lpe-lattice2.cpp:228
+#: ../src/live_effects/lpe-lattice2.cpp:230
 msgid "Reset grid"
 msgstr "Gitter zurücksetzen"
 
-#: ../src/live_effects/lpe-lattice2.cpp:260
-#: ../src/live_effects/lpe-lattice2.cpp:275
+#: ../src/live_effects/lpe-lattice2.cpp:266
+#: ../src/live_effects/lpe-lattice2.cpp:281
 msgid "Show Points"
 msgstr "Punkte anzeigen"
 
-#: ../src/live_effects/lpe-lattice2.cpp:273
+#: ../src/live_effects/lpe-lattice2.cpp:279
 msgid "Hide Points"
 msgstr "Punkte ausblenden"
 
-#: ../src/live_effects/lpe-measure-line.cpp:44
-#: ../src/widgets/text-toolbar.cpp:1862
+#: ../src/live_effects/lpe-measure-segments.cpp:49
+#: ../src/widgets/text-toolbar.cpp:2164
 msgid "Horizontal"
 msgstr "Horizontal"
 
-#: ../src/live_effects/lpe-measure-line.cpp:45
+#: ../src/live_effects/lpe-measure-segments.cpp:50
 msgid "Vertical"
 msgstr "Vertikal"
 
-#: ../src/live_effects/lpe-measure-line.cpp:53
-#, fuzzy
-msgid "Font"
-msgstr "Schriftart*"
-
-#: ../src/live_effects/lpe-measure-line.cpp:53
-#, fuzzy
-msgid "Font Selector"
-msgstr "Auswahlwerkzeug"
-
-#: ../src/live_effects/lpe-measure-line.cpp:54
-#: ../src/widgets/gimp/ruler.cpp:184
+#: ../src/live_effects/lpe-measure-segments.cpp:58
+#: ../src/widgets/gimp/ruler.cpp:187
 #: ../share/extensions/gcodetools_graffiti.inx.h:9
 #: ../share/extensions/gcodetools_orientation_points.inx.h:2
 msgid "Orientation"
 msgstr "Ausrichtung"
 
-#: ../src/live_effects/lpe-measure-line.cpp:54
+#: ../src/live_effects/lpe-measure-segments.cpp:58
 #, fuzzy
 msgid "Orientation method"
 msgstr "Ausrichtung"
 
-#: ../src/live_effects/lpe-measure-line.cpp:55
+#: ../src/live_effects/lpe-measure-segments.cpp:59
 #, fuzzy
-msgid "Curve on origin"
-msgstr "Hilfslinienursprung"
+msgid "Color and opacity"
+msgstr "Deckkraft ändern"
 
-#: ../src/live_effects/lpe-measure-line.cpp:55
-msgid "Curve on origin, set 0 to start/end"
+#: ../src/live_effects/lpe-measure-segments.cpp:59
+#, fuzzy
+msgid "Set color and opacity of the measurements"
+msgstr "Die Einheiten, die für die Bemaßungen verwendet werden"
+
+#: ../src/live_effects/lpe-measure-segments.cpp:60
+#, fuzzy
+msgid "Font"
+msgstr "Schriftart*"
+
+#: ../src/live_effects/lpe-measure-segments.cpp:60
+#, fuzzy
+msgid "Font Selector"
+msgstr "Auswahlwerkzeug"
+
+#: ../src/live_effects/lpe-measure-segments.cpp:62
+#, fuzzy
+msgid "Fix overlaps °"
+msgstr "Max. Überlappung:"
+
+#: ../src/live_effects/lpe-measure-segments.cpp:62
+msgid "Min angle where overlaps are fixed, 180° no fix"
 msgstr ""
 
-#: ../src/live_effects/lpe-measure-line.cpp:57
-#: ../src/widgets/gimp/ruler.cpp:222
+#: ../src/live_effects/lpe-measure-segments.cpp:63
+#: ../src/widgets/gimp/ruler.cpp:225
 msgid "Position"
 msgstr "Position"
 
-#: ../src/live_effects/lpe-measure-line.cpp:58
+#: ../src/live_effects/lpe-measure-segments.cpp:64
 #, fuzzy
 msgid "Text top/bottom"
 msgstr "Von Oben nach unten"
 
-#: ../src/live_effects/lpe-measure-line.cpp:59
-#, fuzzy
-msgid "Text right/left"
-msgstr "Textausrichtung"
-
-#: ../src/live_effects/lpe-measure-line.cpp:60
+#: ../src/live_effects/lpe-measure-segments.cpp:65
 #, fuzzy
 msgid "Helpline distance"
 msgstr "Knotenabstand"
 
-#: ../src/live_effects/lpe-measure-line.cpp:61
+#: ../src/live_effects/lpe-measure-segments.cpp:66
 #, fuzzy
 msgid "Helpline overlap"
 msgstr "Überlappungen entfernen"
 
-#: ../src/live_effects/lpe-measure-line.cpp:62
-#: ../src/selection-chemistry.cpp:2262 ../src/seltrans.cpp:475
-#: ../src/ui/dialog/transformation.cpp:758 ../src/ui/widget/page-sizer.cpp:406
-#: ../share/extensions/interp_att_g.inx.h:14
+#: ../src/live_effects/lpe-measure-segments.cpp:67
+msgid "Line width. DIM line group standard are 0.25 or 0.35"
+msgstr ""
+
+#: ../src/live_effects/lpe-measure-segments.cpp:68
+#: ../src/selection-chemistry.cpp:2256 ../src/seltrans.cpp:475
+#: ../src/ui/dialog/transformation.cpp:758 ../src/ui/widget/page-sizer.cpp:420
+#: ../share/extensions/interp_att_g.inx.h:16
 msgid "Scale"
 msgstr "Skalieren"
 
-#: ../src/live_effects/lpe-measure-line.cpp:62
+#: ../src/live_effects/lpe-measure-segments.cpp:68
 msgid "Scaling factor"
 msgstr "Saklierungsfaktor"
 
-#: ../src/live_effects/lpe-measure-line.cpp:63
+#: ../src/live_effects/lpe-measure-segments.cpp:70
 #, fuzzy
 msgid "Format"
 msgstr "Format"
 
-#: ../src/live_effects/lpe-measure-line.cpp:63
+#: ../src/live_effects/lpe-measure-segments.cpp:70
 msgid "Format the number ex:{measure} {unit}, return to save"
 msgstr ""
 
-#: ../src/live_effects/lpe-measure-line.cpp:65
+#: ../src/live_effects/lpe-measure-segments.cpp:71
+#, fuzzy
+msgid "Blacklist"
+msgstr "Schwarz"
+
+#: ../src/live_effects/lpe-measure-segments.cpp:71
+msgid ""
+"Optional segment index that exclude measure, comma limited, you can add more "
+"LPE like this to fill the holes"
+msgstr ""
+
+#: ../src/live_effects/lpe-measure-segments.cpp:72
+#, fuzzy
+msgid "Inverse blacklist"
+msgstr "Invertierte Abrundung"
+
+#: ../src/live_effects/lpe-measure-segments.cpp:72
+#, fuzzy
+msgid "Blacklist as whitelist"
+msgstr "Schwarz-Weiß"
+
+#: ../src/live_effects/lpe-measure-segments.cpp:73
 #, fuzzy
 msgid "Arrows outside"
 msgstr "Kalte Außenseite"
 
-#: ../src/live_effects/lpe-measure-line.cpp:66
+#: ../src/live_effects/lpe-measure-segments.cpp:74
 #, fuzzy
 msgid "Flip side"
 msgstr "Knoten umkehren"
 
-#: ../src/live_effects/lpe-measure-line.cpp:67
+#: ../src/live_effects/lpe-measure-segments.cpp:75
 #, fuzzy
 msgid "Scale sensitive"
 msgstr "schreibungsabhängig"
 
-#: ../src/live_effects/lpe-measure-line.cpp:67
+#: ../src/live_effects/lpe-measure-segments.cpp:75
 msgid "Costrained scale sensitive to transformed containers"
 msgstr ""
 
-#: ../src/live_effects/lpe-measure-line.cpp:68
+#: ../src/live_effects/lpe-measure-segments.cpp:76
 #, fuzzy
 msgid "Local Number Format"
 msgstr "Zahlzeichen"
 
-#: ../src/live_effects/lpe-measure-line.cpp:68
+#: ../src/live_effects/lpe-measure-segments.cpp:76
 msgid "Local number format"
 msgstr ""
 
-#: ../src/live_effects/lpe-measure-line.cpp:69
-msgid "Line Group 0.5"
-msgstr ""
-
-#: ../src/live_effects/lpe-measure-line.cpp:69
-msgid "Line Group 0.5, from 0.7"
-msgstr ""
-
-#: ../src/live_effects/lpe-measure-line.cpp:70
+#: ../src/live_effects/lpe-measure-segments.cpp:77
 #, fuzzy
-msgid "Rotate Anotation"
+msgid "Rotate Annotation"
 msgstr "Buchstabendrehung"
 
-#: ../src/live_effects/lpe-measure-line.cpp:71
+#: ../src/live_effects/lpe-measure-segments.cpp:78
 #, fuzzy
 msgid "Hide if label over"
 msgstr "Ebene ausblenden"
 
-#: ../src/live_effects/lpe-measure-line.cpp:71
+#: ../src/live_effects/lpe-measure-segments.cpp:78
 msgid "Hide DIN line if label over"
 msgstr ""
 
-#: ../src/live_effects/lpe-measure-line.cpp:72
+#: ../src/live_effects/lpe-measure-segments.cpp:79
+msgid "Info Box"
+msgstr ""
+
+#: ../src/live_effects/lpe-measure-segments.cpp:79
 #, fuzzy
-msgid "CSS DIN line"
-msgstr "Neue Zeile"
+msgid "Important messages"
+msgstr "Importeinstellungen"
 
-#: ../src/live_effects/lpe-measure-line.cpp:72
-msgid "Override CSS to DIN line, return to save, empty to reset to DIM"
+#: ../src/live_effects/lpe-measure-segments.cpp:79
+msgid ""
+"Use <b>\"Style Dialog\"</b> to more styling. Each measure element has extra "
+"selectors. Use !important to override defaults..."
 msgstr ""
 
-#: ../src/live_effects/lpe-measure-line.cpp:73
-msgid "CSS helpers"
-msgstr ""
-
-#: ../src/live_effects/lpe-measure-line.cpp:73
-msgid "Override CSS to helper lines, return to save, empty to reset to DIM"
-msgstr ""
-
-#: ../src/live_effects/lpe-measure-line.cpp:74
-#, fuzzy
-msgid "CSS anotation"
-msgstr "Sättigung"
-
-#: ../src/live_effects/lpe-measure-line.cpp:74
-msgid "Override CSS to anotation text, return to save, empty to reset to DIM"
-msgstr ""
-
-#: ../src/live_effects/lpe-measure-line.cpp:75
-#, fuzzy
-msgid "CSS arrows"
-msgstr "Strg+Pfeile"
-
-#: ../src/live_effects/lpe-measure-line.cpp:75
-msgid "Override CSS to arrows, return to save, empty to reset DIM"
-msgstr ""
-
-#: ../src/live_effects/lpe-measure-line.cpp:332
+#: ../src/live_effects/lpe-measure-segments.cpp:324
 #, fuzzy
 msgid "Non Uniform Scale"
 msgstr "Gleichmäßiges Rauschen"
-
-#: ../src/live_effects/lpe-measure-line.cpp:726
-#: ../src/live_effects/lpe-measure-line.cpp:741
-msgid "Show DIM CSS style override"
-msgstr ""
-
-#: ../src/live_effects/lpe-measure-line.cpp:739
-msgid "Hide DIM CSS style override"
-msgstr ""
 
 #: ../src/live_effects/lpe-mirror_symmetry.cpp:42
 msgid "Vertical Page Center"
@@ -11051,8 +11073,10 @@ msgstr "Objektrahmenmitte X"
 msgid "Y from middle knot"
 msgstr "Objektrahmenmitte Y"
 
+#. Name
 #: ../src/live_effects/lpe-mirror_symmetry.cpp:53
-#: ../src/widgets/spray-toolbar.cpp:388 ../src/widgets/tweak-toolbar.cpp:253
+#: ../src/widgets/eraser-toolbar.cpp:170 ../src/widgets/spray-toolbar.cpp:389
+#: ../src/widgets/tweak-toolbar.cpp:253
 msgid "Mode"
 msgstr "Modus"
 
@@ -11114,59 +11138,59 @@ msgstr "Spiegelachse Punkt 1"
 msgid "Adjust center of mirroring"
 msgstr "Einstellen des Ursprungs"
 
-#: ../src/live_effects/lpe-patternalongpath.cpp:57
+#: ../src/live_effects/lpe-patternalongpath.cpp:61
 #: ../share/extensions/pathalongpath.inx.h:10
 msgid "Single"
 msgstr "Einzeln"
 
-#: ../src/live_effects/lpe-patternalongpath.cpp:58
+#: ../src/live_effects/lpe-patternalongpath.cpp:62
 #: ../share/extensions/pathalongpath.inx.h:11
 msgid "Single, stretched"
 msgstr "Einzeln, gestreckt"
 
-#: ../src/live_effects/lpe-patternalongpath.cpp:59
+#: ../src/live_effects/lpe-patternalongpath.cpp:63
 #: ../share/extensions/pathalongpath.inx.h:12
 msgid "Repeated"
 msgstr "Wiederholt"
 
-#: ../src/live_effects/lpe-patternalongpath.cpp:60
+#: ../src/live_effects/lpe-patternalongpath.cpp:64
 #: ../share/extensions/pathalongpath.inx.h:13
 msgid "Repeated, stretched"
 msgstr "Wiederholt, gestreckt"
 
-#: ../src/live_effects/lpe-patternalongpath.cpp:66
+#: ../src/live_effects/lpe-patternalongpath.cpp:70
 msgid "Pattern source:"
 msgstr "Quelle des Musters:"
 
-#: ../src/live_effects/lpe-patternalongpath.cpp:66
+#: ../src/live_effects/lpe-patternalongpath.cpp:70
 msgid "Path to put along the skeleton path"
 msgstr "Gerüstpfad entlang dieses Pfades setzen"
 
-#: ../src/live_effects/lpe-patternalongpath.cpp:68
+#: ../src/live_effects/lpe-patternalongpath.cpp:72
 msgid "Width of the pattern"
 msgstr "Breite des Musters"
 
-#: ../src/live_effects/lpe-patternalongpath.cpp:69
+#: ../src/live_effects/lpe-patternalongpath.cpp:73
 msgid "Pattern copies:"
 msgstr "Musterkopien:"
 
-#: ../src/live_effects/lpe-patternalongpath.cpp:69
+#: ../src/live_effects/lpe-patternalongpath.cpp:73
 msgid "How many pattern copies to place along the skeleton path"
 msgstr "Anzahl der Kopien entlang des Gerüstpfades"
 
-#: ../src/live_effects/lpe-patternalongpath.cpp:71
+#: ../src/live_effects/lpe-patternalongpath.cpp:75
 msgid "Wid_th in units of length"
 msgstr "Brei_te in Einheiten der Länge"
 
-#: ../src/live_effects/lpe-patternalongpath.cpp:72
+#: ../src/live_effects/lpe-patternalongpath.cpp:76
 msgid "Scale the width of the pattern in units of its length"
 msgstr "Breite des Musters in Einheiten seiner Länge skalieren"
 
-#: ../src/live_effects/lpe-patternalongpath.cpp:74
+#: ../src/live_effects/lpe-patternalongpath.cpp:78
 msgid "Spa_cing:"
 msgstr "Abs_tand:"
 
-#: ../src/live_effects/lpe-patternalongpath.cpp:76
+#: ../src/live_effects/lpe-patternalongpath.cpp:80
 #, no-c-format
 msgid ""
 "Space between copies of the pattern. Negative values allowed, but are "
@@ -11175,19 +11199,19 @@ msgstr ""
 "Abstand zwischen den Kopien. Negative Werte bis -90% der Musterbreite sind "
 "erlaubt."
 
-#: ../src/live_effects/lpe-patternalongpath.cpp:78
+#: ../src/live_effects/lpe-patternalongpath.cpp:82
 msgid "No_rmal offset:"
 msgstr "No_rmaler Versatz:"
 
-#: ../src/live_effects/lpe-patternalongpath.cpp:79
+#: ../src/live_effects/lpe-patternalongpath.cpp:83
 msgid "Tan_gential offset:"
 msgstr "Tan_gentialer Versatz:"
 
-#: ../src/live_effects/lpe-patternalongpath.cpp:80
+#: ../src/live_effects/lpe-patternalongpath.cpp:84
 msgid "Offsets in _unit of pattern size"
 msgstr "Versatz in der Einheit der M_ustergröße"
 
-#: ../src/live_effects/lpe-patternalongpath.cpp:81
+#: ../src/live_effects/lpe-patternalongpath.cpp:85
 msgid ""
 "Spacing, tangential and normal offset are expressed as a ratio of width/"
 "height"
@@ -11195,19 +11219,19 @@ msgstr ""
 "Abstände sowie tangentialer und radialer Versatz sind als Verhältnis Breite/"
 "Höhe angegeben"
 
-#: ../src/live_effects/lpe-patternalongpath.cpp:83
+#: ../src/live_effects/lpe-patternalongpath.cpp:87
 msgid "Pattern is _vertical"
 msgstr "Muster ist _vertikal"
 
-#: ../src/live_effects/lpe-patternalongpath.cpp:83
+#: ../src/live_effects/lpe-patternalongpath.cpp:87
 msgid "Rotate pattern 90 deg before applying"
 msgstr "Muster vor dem Anwenden um 90° drehen"
 
-#: ../src/live_effects/lpe-patternalongpath.cpp:85
+#: ../src/live_effects/lpe-patternalongpath.cpp:90
 msgid "_Fuse nearby ends:"
 msgstr "Beieinanderliegende Enden verschmelzen:"
 
-#: ../src/live_effects/lpe-patternalongpath.cpp:85
+#: ../src/live_effects/lpe-patternalongpath.cpp:90
 msgid "Fuse ends closer than this number. 0 means don't fuse."
 msgstr ""
 "Enden verschmelzen, die näher zusammen sind als diese Zahl. 0 bedeutet keine "
@@ -11287,42 +11311,42 @@ msgstr "Anfasser:"
 msgid "_Clear"
 msgstr "_Leeren"
 
-#: ../src/live_effects/lpe-powerstroke.cpp:121
+#: ../src/live_effects/lpe-powerstroke.cpp:124
 msgid "CubicBezierSmooth"
 msgstr "CubicBezierSmooth"
 
-#: ../src/live_effects/lpe-powerstroke.cpp:140
+#: ../src/live_effects/lpe-powerstroke.cpp:143
 #: ../share/extensions/gcodetools_prepare_path_for_plasma.inx.h:13
 msgid "Round"
 msgstr "Rundung"
 
-#: ../src/live_effects/lpe-powerstroke.cpp:142
+#: ../src/live_effects/lpe-powerstroke.cpp:145
 msgid "Zero width"
 msgstr "Nullbreite"
 
-#: ../src/live_effects/lpe-powerstroke.cpp:160
-#: ../src/widgets/pencil-toolbar.cpp:109
+#: ../src/live_effects/lpe-powerstroke.cpp:163
+#: ../src/widgets/pencil-toolbar.cpp:131
 msgid "Spiro"
 msgstr "Spiro"
 
-#: ../src/live_effects/lpe-powerstroke.cpp:166
+#: ../src/live_effects/lpe-powerstroke.cpp:169
 msgid "Offset points"
 msgstr "Versatzpunkte"
 
-#: ../src/live_effects/lpe-powerstroke.cpp:167
+#: ../src/live_effects/lpe-powerstroke.cpp:170
 msgid "Sort points"
 msgstr "Punkte sortieren"
 
-#: ../src/live_effects/lpe-powerstroke.cpp:167
+#: ../src/live_effects/lpe-powerstroke.cpp:170
 msgid "Sort offset points according to their time value along the curve"
 msgstr "Sortiert Versatzpunkte entsprechend ihres Zeitwertes entlang der Kurve"
 
-#: ../src/live_effects/lpe-powerstroke.cpp:169
+#: ../src/live_effects/lpe-powerstroke.cpp:172
 #: ../share/extensions/fractalize.inx.h:3
 msgid "Smoothness:"
 msgstr "Glättung:"
 
-#: ../src/live_effects/lpe-powerstroke.cpp:169
+#: ../src/live_effects/lpe-powerstroke.cpp:172
 msgid ""
 "Sets the smoothness for the CubicBezierJohan interpolator; 0 = linear "
 "interpolation, 1 = smooth"
@@ -11330,26 +11354,87 @@ msgstr ""
 "Setzt die Glättung für den CubicBezierJohan Interpolator; 0 = lineare "
 "Interpolation, 1 = abgerundet"
 
-#: ../src/live_effects/lpe-powerstroke.cpp:170
+#: ../src/live_effects/lpe-powerstroke.cpp:173
+#, fuzzy
+msgid "Width scale:"
+msgstr "Breite des Rechtecks"
+
+#: ../src/live_effects/lpe-powerstroke.cpp:173
+#, fuzzy
+msgid "Width scale all points"
+msgstr "Schriftarten auflisten"
+
+#: ../src/live_effects/lpe-powerstroke.cpp:174
 msgid "Start cap:"
 msgstr "Abschluss Pfadanfang:"
 
-#: ../src/live_effects/lpe-powerstroke.cpp:170
+#: ../src/live_effects/lpe-powerstroke.cpp:174
 msgid "Determines the shape of the path's start"
 msgstr "Bestimmt die Form des Pfadanfangs"
 
-#: ../src/live_effects/lpe-powerstroke.cpp:172
+#: ../src/live_effects/lpe-powerstroke.cpp:176
 #: ../src/widgets/stroke-style.cpp:302
 msgid "Maximum length of the miter (in units of stroke width)"
 msgstr "Maximale Länge der Gehrung (in Vielfachen der Konturlinienbreite)"
 
-#: ../src/live_effects/lpe-powerstroke.cpp:173
+#: ../src/live_effects/lpe-powerstroke.cpp:177
 msgid "End cap:"
 msgstr "Abschluss Pfadende:"
 
-#: ../src/live_effects/lpe-powerstroke.cpp:173
+#: ../src/live_effects/lpe-powerstroke.cpp:177
 msgid "Determines the shape of the path's end"
 msgstr "Bestimmt die Form des Pfadendes"
+
+# !!! mnemonics
+#: ../src/live_effects/lpe-powerclip.cpp:27
+#, fuzzy
+msgid "Hide clip"
+msgstr "Alle ausblenden"
+
+#: ../src/live_effects/lpe-powerclip.cpp:30
+#, fuzzy
+msgid "Inverse clip"
+msgstr "Invertierte Abrundung"
+
+#: ../src/live_effects/lpe-powerclip.cpp:31
+#, fuzzy
+msgid "Flatten clip"
+msgstr "Bézierkurven begradigen"
+
+#: ../src/live_effects/lpe-powerclip.cpp:31
+msgid "Flatten clip, see fill rule once convert to paths"
+msgstr ""
+
+#: ../src/live_effects/lpe-powerclip.cpp:278
+#, fuzzy
+msgid "Convert clips to paths, undoable"
+msgstr "Texte in Pfade umwandeln"
+
+#: ../src/live_effects/lpe-powermask.cpp:31
+#, fuzzy
+msgid "Invert mask"
+msgstr "Bild _invertieren"
+
+#. wrap(_("Wrap mask data"), _("Wrap mask data allowing previous filters"), "wrap", &wr, this, false),
+#: ../src/live_effects/lpe-powermask.cpp:33
+#, fuzzy
+msgid "Hide mask"
+msgstr "Bild ausblenden"
+
+#: ../src/live_effects/lpe-powermask.cpp:34
+#, fuzzy
+msgid "Add background to mask"
+msgstr "Hintergrundbild"
+
+#: ../src/live_effects/lpe-powermask.cpp:35
+#, fuzzy
+msgid "Background color and opacity"
+msgstr "Hintergrund-Deckkraft"
+
+#: ../src/live_effects/lpe-powermask.cpp:35
+#, fuzzy
+msgid "Set color and opacity of the background"
+msgstr "Fügt einfärbbaren deckenden Hintergrund hinzu"
 
 #: ../src/live_effects/lpe-rough-hatches.cpp:218
 msgid "Frequency randomness:"
@@ -11661,13 +11746,13 @@ msgstr "Keine"
 
 #: ../src/live_effects/lpe-ruler.cpp:30
 #: ../src/live_effects/lpe-transform_2pts.cpp:35
-#: ../src/ui/tools/measure-tool.cpp:749 ../src/widgets/arc-toolbar.cpp:334
+#: ../src/ui/tools/measure-tool.cpp:755 ../src/widgets/arc-toolbar.cpp:497
 msgid "Start"
 msgstr "Anfang"
 
 #: ../src/live_effects/lpe-ruler.cpp:31
 #: ../src/live_effects/lpe-transform_2pts.cpp:36
-#: ../src/ui/tools/measure-tool.cpp:750 ../src/widgets/arc-toolbar.cpp:347
+#: ../src/ui/tools/measure-tool.cpp:756 ../src/widgets/arc-toolbar.cpp:510
 msgid "End"
 msgstr "Ende"
 
@@ -11680,7 +11765,7 @@ msgid "Distance between successive ruler marks"
 msgstr "Abstand zwischen aufeinander folgenden Linealmarkierungen"
 
 #: ../src/live_effects/lpe-ruler.cpp:39 ../share/extensions/foldablebox.inx.h:7
-#: ../share/extensions/interp_att_g.inx.h:9
+#: ../share/extensions/interp_att_g.inx.h:11
 #: ../share/extensions/layout_nup.inx.h:3
 #: ../share/extensions/printing_marks.inx.h:11
 msgid "Unit:"
@@ -11742,24 +11827,29 @@ msgstr "Randmarkierungen:"
 msgid "Choose whether to draw marks at the beginning and end of the path"
 msgstr "Wählt Markierungen an Anfang und Ende des Pfades"
 
-#: ../src/live_effects/lpe-show_handles.cpp:26
+#: ../src/live_effects/lpe-show_handles.cpp:27
 msgid "Show nodes"
 msgstr "Knoten zeigen"
 
-#: ../src/live_effects/lpe-show_handles.cpp:28
+#: ../src/live_effects/lpe-show_handles.cpp:29
 msgid "Show path"
 msgstr "Pfad anzeigen"
 
-#: ../src/live_effects/lpe-show_handles.cpp:29
+#: ../src/live_effects/lpe-show_handles.cpp:30
 #, fuzzy
 msgid "Show center of node"
 msgstr "Objektmittelpunkte einrasten"
 
-#: ../src/live_effects/lpe-show_handles.cpp:30
+#: ../src/live_effects/lpe-show_handles.cpp:31
+#, fuzzy
+msgid "Show original"
+msgstr "Original klonen"
+
+#: ../src/live_effects/lpe-show_handles.cpp:32
 msgid "Scale nodes and handles"
 msgstr "Knoten und Anfasser skalieren"
 
-#: ../src/live_effects/lpe-show_handles.cpp:53
+#: ../src/live_effects/lpe-show_handles.cpp:56
 msgid ""
 "The \"show handles\" path effect will remove any custom style on the object "
 "you are applying it to. If this is not what you want, click Cancel."
@@ -11895,7 +11985,7 @@ msgid "How many construction lines (tangents) to draw"
 msgstr "Wie viele Konstruktionslinien (Tangenten) gezeichnet werden sollen"
 
 #: ../src/live_effects/lpe-sketch.cpp:51
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2784
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2801
 #: ../share/extensions/render_alphabetsoup.inx.h:3
 msgid "Scale:"
 msgstr "Skalierung:"
@@ -12073,11 +12163,11 @@ msgid "Change index of knot"
 msgstr "Knotenindex ändern"
 
 #: ../src/live_effects/lpe-transform_2pts.cpp:356
-#: ../src/ui/dialog/inkscape-preferences.cpp:1591
+#: ../src/ui/dialog/inkscape-preferences.cpp:1652
 #: ../src/ui/dialog/pixelartdialog.cpp:289
-#: ../src/ui/dialog/svg-fonts-dialog.cpp:793
+#: ../src/ui/dialog/svg-fonts-dialog.cpp:805
 #: ../src/ui/dialog/tracedialog.cpp:811
-#: ../src/ui/widget/preferences-widget.cpp:655
+#: ../src/ui/widget/preferences-widget.cpp:657
 msgid "Reset"
 msgstr "Zurücksetzen"
 
@@ -12138,114 +12228,172 @@ msgstr "_Maximale Komplexität:"
 msgid "Disable effect if the output is too complex"
 msgstr "Deaktivieren Sie den Effekt, wenn die Ausgabe zu komplex wird"
 
-#: ../src/live_effects/parameter/bool.cpp:79
+#: ../src/live_effects/parameter/bool.cpp:86
 msgid "Change bool parameter"
 msgstr "Booleschen Parameter ändern"
+
+#: ../src/live_effects/parameter/colorpicker.cpp:125
+#, fuzzy
+msgid "Change color button parameter"
+msgstr "Parameter für Schaltfläche ändern"
 
 #: ../src/live_effects/parameter/enum.h:49
 msgid "Change enumeration parameter"
 msgstr "Aufzählungsparameter ändern"
 
-#: ../src/live_effects/parameter/fontbutton.cpp:70
+#: ../src/live_effects/parameter/fontbutton.cpp:78
 #, fuzzy
 msgid "Change font button parameter"
 msgstr "Parameter für Schaltfläche ändern"
 
-#: ../src/live_effects/parameter/item.cpp:123
+#: ../src/live_effects/parameter/item.cpp:133
 #, fuzzy
 msgid "Link to item on clipboard"
 msgstr "Mit Pfad aus der Zwischenablage verknüpfen"
 
-#: ../src/live_effects/parameter/item.cpp:236
+#: ../src/live_effects/parameter/item.cpp:255
 #, fuzzy
 msgid "Link item parameter to path"
 msgstr "Pfadparameter mit Pfad verbinden"
 
+#: ../src/live_effects/parameter/originalitemarray.cpp:75
+#, fuzzy
+msgid "Active"
+msgstr "Alles inaktiv"
+
+#: ../src/live_effects/parameter/originalitemarray.cpp:82
+#: ../src/live_effects/parameter/originalpatharray.cpp:103
+#: ../src/ui/dialog/inkscape-preferences.cpp:1607
+#: ../src/ui/widget/page-sizer.cpp:269 ../src/widgets/gradient-selector.cpp:140
+#: ../src/widgets/sp-xmlview-attr-list.cpp:45
+msgid "Name"
+msgstr "Name"
+
+#: ../src/live_effects/parameter/originalitemarray.cpp:122
+#, fuzzy
+msgid "Link item parameter to item"
+msgstr "Pfadparameter mit Pfad verbinden"
+
+#: ../src/live_effects/parameter/originalitemarray.cpp:148
 #: ../src/live_effects/parameter/originalitem.cpp:66
 #, fuzzy
 msgid "Link to item"
 msgstr "Mit dem Pfad verknüpfen"
 
-#: ../src/live_effects/parameter/originalitem.cpp:79
-#: ../src/live_effects/parameter/originalpath.cpp:80
-msgid "Select original"
-msgstr "Original auswählen"
+#: ../src/live_effects/parameter/originalitemarray.cpp:161
+#, fuzzy
+msgid "Remove Item"
+msgstr "Element/Gruppe entfernen"
 
-#: ../src/live_effects/parameter/originalpath.cpp:67
-#: ../src/live_effects/parameter/originalpatharray.cpp:155
-msgid "Link to path"
-msgstr "Mit dem Pfad verknüpfen"
-
-#: ../src/live_effects/parameter/originalpatharray.cpp:81
-#: ../src/ui/dialog/inkscape-preferences.cpp:1546
-#: ../src/ui/widget/page-sizer.cpp:268 ../src/widgets/gradient-selector.cpp:140
-#: ../src/widgets/sp-xmlview-attr-list.cpp:45
-msgid "Name"
-msgstr "Name"
-
-#: ../src/live_effects/parameter/originalpatharray.cpp:89
-#: ../src/widgets/gradient-toolbar.cpp:1206
-msgid "Reverse"
-msgstr "Umkehren"
-
-#: ../src/live_effects/parameter/originalpatharray.cpp:129
-#: ../src/live_effects/parameter/originalpatharray.cpp:318
-#: ../src/live_effects/parameter/path.cpp:539
-msgid "Link path parameter to path"
-msgstr "Pfadparameter mit Pfad verbinden"
-
-#: ../src/live_effects/parameter/originalpatharray.cpp:168
-msgid "Remove Path"
-msgstr "Pfad entfernen"
-
-#: ../src/live_effects/parameter/originalpatharray.cpp:181
-#: ../src/ui/dialog/objects.cpp:1880
+#: ../src/live_effects/parameter/originalitemarray.cpp:174
+#: ../src/live_effects/parameter/originalpatharray.cpp:213
+#: ../src/ui/dialog/objects.cpp:1842
 msgid "Move Down"
 msgstr "Nach unten"
 
-#: ../src/live_effects/parameter/originalpatharray.cpp:194
-#: ../src/ui/dialog/objects.cpp:1888
+#: ../src/live_effects/parameter/originalitemarray.cpp:187
+#: ../src/live_effects/parameter/originalpatharray.cpp:226
+#: ../src/ui/dialog/objects.cpp:1850
 msgid "Move Up"
 msgstr "Nach oben"
 
-#: ../src/live_effects/parameter/originalpatharray.cpp:234
+#: ../src/live_effects/parameter/originalitemarray.cpp:227
+#, fuzzy
+msgid "Move item up"
+msgstr "Pfad nach oben verschieben"
+
+#: ../src/live_effects/parameter/originalitemarray.cpp:257
+#, fuzzy
+msgid "Move item down"
+msgstr "Pfad nach unten verschieben"
+
+#: ../src/live_effects/parameter/originalitemarray.cpp:275
+#, fuzzy
+msgid "Remove item"
+msgstr "Filter entfernen"
+
+#: ../src/live_effects/parameter/originalitemarray.cpp:315
+#, fuzzy
+msgid "Link itemarray parameter to item"
+msgstr "Pfadparameter mit Pfad verbinden"
+
+#: ../src/live_effects/parameter/originalitem.cpp:79
+#: ../src/live_effects/parameter/originalpath.cpp:81
+msgid "Select original"
+msgstr "Original auswählen"
+
+#: ../src/live_effects/parameter/originalpath.cpp:68
+#: ../src/live_effects/parameter/originalpatharray.cpp:187
+msgid "Link to path"
+msgstr "Mit dem Pfad verknüpfen"
+
+#: ../src/live_effects/parameter/originalpatharray.cpp:88
+#: ../src/widgets/gradient-toolbar.cpp:1095
+msgid "Reverse"
+msgstr "Umkehren"
+
+#: ../src/live_effects/parameter/originalpatharray.cpp:96
+#, fuzzy
+msgid "Visible"
+msgstr "Sichtbar"
+
+#: ../src/live_effects/parameter/originalpatharray.cpp:146
+#: ../src/live_effects/parameter/path.cpp:556
+msgid "Link path parameter to path"
+msgstr "Pfadparameter mit Pfad verbinden"
+
+#: ../src/live_effects/parameter/originalpatharray.cpp:161
+#, fuzzy
+msgid "Toggle path parameter to path"
+msgstr "Pfadparameter mit Pfad verbinden"
+
+#: ../src/live_effects/parameter/originalpatharray.cpp:200
+msgid "Remove Path"
+msgstr "Pfad entfernen"
+
+#: ../src/live_effects/parameter/originalpatharray.cpp:266
 msgid "Move path up"
 msgstr "Pfad nach oben verschieben"
 
-#: ../src/live_effects/parameter/originalpatharray.cpp:264
+#: ../src/live_effects/parameter/originalpatharray.cpp:296
 msgid "Move path down"
 msgstr "Pfad nach unten verschieben"
 
-#: ../src/live_effects/parameter/originalpatharray.cpp:282
+#: ../src/live_effects/parameter/originalpatharray.cpp:314
 msgid "Remove path"
 msgstr "Pfad entfernen"
 
-#: ../src/live_effects/parameter/path.cpp:201
+#: ../src/live_effects/parameter/originalpatharray.cpp:353
+#, fuzzy
+msgid "Link patharray parameter to path"
+msgstr "Pfadparameter mit Pfad verbinden"
+
+#: ../src/live_effects/parameter/path.cpp:211
 msgid "Edit on-canvas"
 msgstr "Auf der Arbeitsfläche bearbeiten"
 
-#: ../src/live_effects/parameter/path.cpp:214
+#: ../src/live_effects/parameter/path.cpp:224
 msgid "Copy path"
 msgstr "Pfad kopieren"
 
-#: ../src/live_effects/parameter/path.cpp:227
+#: ../src/live_effects/parameter/path.cpp:237
 msgid "Paste path"
 msgstr "Pfad einfügen"
 
-#: ../src/live_effects/parameter/path.cpp:239
+#: ../src/live_effects/parameter/path.cpp:249
 msgid "Link to path on clipboard"
 msgstr "Mit Pfad aus der Zwischenablage verknüpfen"
 
-#: ../src/live_effects/parameter/path.cpp:507
+#: ../src/live_effects/parameter/path.cpp:524
 msgid "Paste path parameter"
 msgstr "Pfadparameter einfügen"
 
-#: ../src/live_effects/parameter/point.cpp:139
+#: ../src/live_effects/parameter/point.cpp:165
 msgid "Change point parameter"
 msgstr "Punktparameter ändern"
 
-#: ../src/live_effects/parameter/powerstrokepointarray.cpp:239
-#: ../src/live_effects/parameter/powerstrokepointarray.cpp:256
+#: ../src/live_effects/parameter/powerstrokepointarray.cpp:267
+#: ../src/live_effects/parameter/powerstrokepointarray.cpp:284
 msgid ""
 "<b>Stroke width control point</b>: drag to alter the stroke width. <b>Ctrl"
 "+click</b> adds a control point, <b>Ctrl+Alt+click</b> deletes it, <b>Shift"
@@ -12256,7 +12404,7 @@ msgstr ""
 "<b>Umschalt+Klick</b> öffnet Dialog um Position/Strichstärke manuell "
 "festzulegen."
 
-#: ../src/live_effects/parameter/random.cpp:149
+#: ../src/live_effects/parameter/random.cpp:158
 msgid "Change random parameter"
 msgstr "Zufallsparameter ändern"
 
@@ -12332,20 +12480,20 @@ msgstr ""
 "<b>Abrunden</b>: <b>Strg+Klick</b> Typ ändern, <b>Umschalt+Klick</b> Dialog "
 "öffnen, <b>Strg+Alt+Klick</b> zurücksetzen"
 
-#: ../src/live_effects/parameter/text.cpp:126
+#: ../src/live_effects/parameter/text.cpp:143
 msgid "Change text parameter"
 msgstr "Textparameter ändern"
 
-#: ../src/live_effects/parameter/togglebutton.cpp:123
+#: ../src/live_effects/parameter/togglebutton.cpp:130
 msgid "Change togglebutton parameter"
 msgstr "Parameter für Schaltfläche ändern"
 
-#: ../src/live_effects/parameter/transformedpoint.cpp:117
-#: ../src/live_effects/parameter/vector.cpp:117
+#: ../src/live_effects/parameter/transformedpoint.cpp:126
+#: ../src/live_effects/parameter/vector.cpp:126
 msgid "Change vector parameter"
 msgstr "Vektorparameter ändern"
 
-#: ../src/live_effects/parameter/unit.cpp:87
+#: ../src/live_effects/parameter/unit.cpp:93
 msgid "Change unit parameter"
 msgstr "Einheitenparameter ändern"
 
@@ -12361,52 +12509,52 @@ msgstr ""
 msgid "Unable to find node ID: '%s'\n"
 msgstr "Kann Knoten-Kennung „%s“ nicht finden.\n"
 
-#: ../src/main.cpp:301
+#: ../src/main.cpp:303
 msgid "Print the Inkscape version number"
 msgstr "Versionsnummer von Inkscape ausgeben"
 
-#: ../src/main.cpp:306
+#: ../src/main.cpp:308
 msgid "Do not use X server (only process files from console)"
 msgstr "X-Server nicht verwenden (Dateien nur mittels Konsole verarbeiten)"
 
-#: ../src/main.cpp:311
+#: ../src/main.cpp:313
 msgid "Try to use X server (even if $DISPLAY is not set)"
 msgstr ""
 "Versuche, den X-Server zu verwenden (auch wenn die Umgebungsvariable "
 "„$DISPLAY“ nicht gesetzt wurde)"
 
-#: ../src/main.cpp:316
+#: ../src/main.cpp:318
 msgid "Open specified document(s) (option string may be excluded)"
 msgstr ""
 "Angegebene Dokumente öffnen (Optionszeichenkette muss nicht übergeben werden)"
 
-#: ../src/main.cpp:317 ../src/main.cpp:327 ../src/main.cpp:332
-#: ../src/main.cpp:404 ../src/main.cpp:408 ../src/main.cpp:413
-#: ../src/main.cpp:418 ../src/main.cpp:429 ../src/main.cpp:445
-#: ../src/main.cpp:450
+#: ../src/main.cpp:319 ../src/main.cpp:329 ../src/main.cpp:334
+#: ../src/main.cpp:406 ../src/main.cpp:410 ../src/main.cpp:415
+#: ../src/main.cpp:420 ../src/main.cpp:431 ../src/main.cpp:447
+#: ../src/main.cpp:452
 msgid "FILENAME"
 msgstr "DATEINAME"
 
-#: ../src/main.cpp:321
+#: ../src/main.cpp:323
 msgid "xverbs command"
 msgstr ""
 
-#: ../src/main.cpp:322
+#: ../src/main.cpp:324
 #, fuzzy
 msgid "XVERBS_FILENAME"
 msgstr "DATEINAME"
 
-#: ../src/main.cpp:326
+#: ../src/main.cpp:328
 msgid "Print document(s) to specified output file (use '| program' for pipe)"
 msgstr ""
 "Dokumente in angegebene Ausgabedatei drucken (verwenden Sie „| Programm“ zur "
 "Weiterleitung)"
 
-#: ../src/main.cpp:331
+#: ../src/main.cpp:333
 msgid "Export document to a PNG file"
 msgstr "Das Dokument in eine PNG-Datei exportieren"
 
-#: ../src/main.cpp:336
+#: ../src/main.cpp:338
 msgid ""
 "Resolution for exporting to bitmap and for rasterization of filters in PS/"
 "EPS/PDF (default 96)"
@@ -12414,11 +12562,11 @@ msgstr ""
 "Auflösung beim Exportieren von Bitmaps und für Rasterisierung von Filtern in "
 "PS/EPS/PDF (Standard ist 96)"
 
-#: ../src/main.cpp:337 ../src/ui/widget/rendering-options.cpp:37
+#: ../src/main.cpp:339 ../src/ui/widget/rendering-options.cpp:37
 msgid "DPI"
 msgstr "DPI"
 
-#: ../src/main.cpp:341
+#: ../src/main.cpp:343
 msgid ""
 "Exported area in SVG user units (default is the page; 0,0 is lower-left "
 "corner)"
@@ -12426,29 +12574,29 @@ msgstr ""
 "Exportierter Bereich in SVG-Benutzereinheiten (Standard: gesamte Seite, "
 "„0,0“ ist die untere linke Ecke)"
 
-#: ../src/main.cpp:342
+#: ../src/main.cpp:344
 msgid "x0:y0:x1:y1"
 msgstr "X0:Y0:X1:Y1"
 
-#: ../src/main.cpp:346
+#: ../src/main.cpp:348
 msgid "Exported area is the entire drawing (not page)"
 msgstr "Exportierter Bereich ist die gesamte Zeichnung (nicht die Seite)"
 
-#: ../src/main.cpp:351
+#: ../src/main.cpp:353
 msgid "Exported area is the entire page"
 msgstr "Exportierter Bereich ist die gesamte Seite"
 
-#: ../src/main.cpp:356
-msgid "Only for PS/EPS/PDF, sets margin in mm around exported area (default 0)"
+#: ../src/main.cpp:358
+msgid ""
+"Sets margin around exported area (default 0) in units of page size for SVG "
+"and mm for PS/EPS/PDF"
 msgstr ""
-"Nur für PS/EPS/PDF. Setzt einen Rand in mm um den exportierten Bereich "
-"(Standard 0)"
 
-#: ../src/main.cpp:357 ../src/main.cpp:399
+#: ../src/main.cpp:359 ../src/main.cpp:401
 msgid "VALUE"
 msgstr "WERT"
 
-#: ../src/main.cpp:361
+#: ../src/main.cpp:363
 msgid ""
 "Snap the bitmap export area outwards to the nearest integer values (in SVG "
 "user units)"
@@ -12456,85 +12604,85 @@ msgstr ""
 "Die Fläche für den Export einer Bitmap nach außen auf die nächsten "
 "Ganzzahlen aufrunden (in SVG-Benutzereinheiten)"
 
-#: ../src/main.cpp:366
+#: ../src/main.cpp:368
 msgid "The width of exported bitmap in pixels (overrides export-dpi)"
 msgstr "Breite der erzeugten Rastergrafik in Pixeln (überschreibt Export-dpi)"
 
-#: ../src/main.cpp:367
+#: ../src/main.cpp:369
 msgid "WIDTH"
 msgstr "BREITE"
 
-#: ../src/main.cpp:371
+#: ../src/main.cpp:373
 msgid "The height of exported bitmap in pixels (overrides export-dpi)"
 msgstr "Höhe der erzeugten Rastergrafik in Pixeln (überschreibt Export-dpi)"
 
-#: ../src/main.cpp:372
+#: ../src/main.cpp:374
 msgid "HEIGHT"
 msgstr "HÖHE"
 
 # Changed because this refers to object id in xml
-#: ../src/main.cpp:376
+#: ../src/main.cpp:378
 msgid "The ID of the object to export"
 msgstr "ID des zu exportierenden Objektes"
 
-#: ../src/main.cpp:377 ../src/main.cpp:494
-#: ../src/ui/dialog/inkscape-preferences.cpp:1549
+#: ../src/main.cpp:379 ../src/main.cpp:496
+#: ../src/ui/dialog/inkscape-preferences.cpp:1610
 msgid "ID"
 msgstr "ID"
 
 #. TRANSLATORS: this means: "Only export the object whose id is given in --export-id".
 #. See "man inkscape" for details.
-#: ../src/main.cpp:383
+#: ../src/main.cpp:385
 msgid ""
 "Export just the object with export-id, hide all others (only with export-id)"
 msgstr ""
 "Nur das Objekt mit der angegebenen Export-ID exportieren, alle anderen "
 "auslassen"
 
-#: ../src/main.cpp:388
+#: ../src/main.cpp:390
 msgid "Use stored filename and DPI hints when exporting (only with export-id)"
 msgstr ""
 "Verwende gespeicherten Dateinamen und DPI-Hinweise zum Exportieren (nur mit "
 "Export-ID)"
 
-#: ../src/main.cpp:393
+#: ../src/main.cpp:395
 msgid "Background color of exported bitmap (any SVG-supported color string)"
 msgstr ""
 "Hintergrundfarbe der exportierten Rastergrafik (jede von SVG unterstützte "
 "Farbzeichenkette)"
 
-#: ../src/main.cpp:394
+#: ../src/main.cpp:396
 msgid "COLOR"
 msgstr "FARBE"
 
-#: ../src/main.cpp:398
+#: ../src/main.cpp:400
 msgid "Background opacity of exported bitmap (either 0.0 to 1.0, or 1 to 255)"
 msgstr ""
 "Hintergrunddeckkraft der exportierten Rastergrafik (0,0 bis 1,0 oder 1 bis "
 "255)"
 
-#: ../src/main.cpp:403
+#: ../src/main.cpp:405
 #, fuzzy
 msgid "Export document to an inkscape SVG file (similar to save as.)"
 msgstr ""
 "Dokument als reine SVG-Datei exportieren (ohne Sodipodi- oder Inkscape-"
 "Namensräume)"
 
-#: ../src/main.cpp:407
+#: ../src/main.cpp:409
 msgid "Export document to plain SVG file (no sodipodi or inkscape namespaces)"
 msgstr ""
 "Dokument als reine SVG-Datei exportieren (ohne Sodipodi- oder Inkscape-"
 "Namensräume)"
 
-#: ../src/main.cpp:412
+#: ../src/main.cpp:414
 msgid "Export document to a PS file"
 msgstr "Das Dokument als PS-Datei exportieren"
 
-#: ../src/main.cpp:417
+#: ../src/main.cpp:419
 msgid "Export document to an EPS file"
 msgstr "Das Dokument als EPS-Datei exportieren"
 
-#: ../src/main.cpp:422
+#: ../src/main.cpp:424
 msgid ""
 "Choose the PostScript Level used to export. Possible choices are 2 and 3 "
 "(the default)"
@@ -12542,17 +12690,17 @@ msgstr ""
 "Wähle das PostScript-Level für den Export. Auswahlmöglichkeiten sind 2 und 3 "
 "(Standard)"
 
-#: ../src/main.cpp:424
+#: ../src/main.cpp:426
 msgid "PS Level"
 msgstr "PS-Level"
 
-#: ../src/main.cpp:428
+#: ../src/main.cpp:430
 msgid "Export document to a PDF file"
 msgstr "Das Dokument als PDF-Datei exportieren"
 
 # !!! would these quotes need to be kept as they are? Looks like it's explaining command line options.
 #. TRANSLATORS: "--export-pdf-version" is an Inkscape command line option; see "inkscape --help"
-#: ../src/main.cpp:434
+#: ../src/main.cpp:436
 #, fuzzy
 msgid ""
 "Export PDF to given version. (hint: make sure to input a version found in "
@@ -12562,11 +12710,11 @@ msgstr ""
 "dass die Version exakt wie im PDF-Export-Dialog angegeben wird, z. B. "
 "Beispiel \"PDF 1.4\", dieses ist PDF/A-konform)"
 
-#: ../src/main.cpp:435
+#: ../src/main.cpp:437
 msgid "PDF_VERSION"
 msgstr "PDF_VERSION"
 
-#: ../src/main.cpp:439
+#: ../src/main.cpp:441
 msgid ""
 "Export PDF/PS/EPS without text. Besides the PDF/PS/EPS, a LaTeX file is "
 "exported, putting the text on top of the PDF/PS/EPS file. Include the result "
@@ -12576,26 +12724,26 @@ msgstr ""
 "exportiert, die den Text über die PDF/PS/EPS-Datei legt. Einbinden des "
 "Ergebnisses in Latex mit: \\input{latexfile.tex}"
 
-#: ../src/main.cpp:444
+#: ../src/main.cpp:446
 msgid "Export document to an Enhanced Metafile (EMF) File"
 msgstr "Dokument als Erweiterte Metadatei (EMF) exportieren"
 
-#: ../src/main.cpp:449
+#: ../src/main.cpp:451
 msgid "Export document to a Windows Metafile (WMF) File"
 msgstr "Dokument als Windows-Metadatei (WMF) exportieren"
 
-#: ../src/main.cpp:454
+#: ../src/main.cpp:456
 msgid "Convert text object to paths on export (PS, EPS, PDF, SVG)"
 msgstr "Textelemente beim Export (PS, EPS, PDF, SVG) in Pfade umwandeln"
 
-#: ../src/main.cpp:459
+#: ../src/main.cpp:461
 msgid ""
 "Render filtered objects without filters, instead of rasterizing (PS, EPS, "
 "PDF)"
 msgstr "Objekte ohne Filter zeichnen, statt Rasterisierung (PS, EPS, PDF)"
 
 #. TRANSLATORS: "--query-id" is an Inkscape command line option; see "inkscape --help"
-#: ../src/main.cpp:465
+#: ../src/main.cpp:467
 msgid ""
 "Query the X coordinate of the drawing or, if specified, of the object with --"
 "query-id"
@@ -12604,7 +12752,7 @@ msgstr ""
 "Objektes"
 
 #. TRANSLATORS: "--query-id" is an Inkscape command line option; see "inkscape --help"
-#: ../src/main.cpp:471
+#: ../src/main.cpp:473
 msgid ""
 "Query the Y coordinate of the drawing or, if specified, of the object with --"
 "query-id"
@@ -12613,7 +12761,7 @@ msgstr ""
 "Objektes"
 
 #. TRANSLATORS: "--query-id" is an Inkscape command line option; see "inkscape --help"
-#: ../src/main.cpp:477
+#: ../src/main.cpp:479
 msgid ""
 "Query the width of the drawing or, if specified, of the object with --query-"
 "id"
@@ -12622,35 +12770,35 @@ msgstr ""
 "Objektes"
 
 #. TRANSLATORS: "--query-id" is an Inkscape command line option; see "inkscape --help"
-#: ../src/main.cpp:483
+#: ../src/main.cpp:485
 msgid ""
 "Query the height of the drawing or, if specified, of the object with --query-"
 "id"
 msgstr ""
 "Abfragen der Höhe der Zeichnung oder des mit --query-id angegebenen Objektes"
 
-#: ../src/main.cpp:488
+#: ../src/main.cpp:490
 msgid "List id,x,y,w,h for all objects"
 msgstr "id, x, y, w und h für alle Objekte auflisten"
 
-#: ../src/main.cpp:493
+#: ../src/main.cpp:495
 msgid "The ID of the object whose dimensions are queried"
 msgstr "ID des Objektes, dessen Abmessungen abgefragt werden"
 
 #. TRANSLATORS: this option makes Inkscape print the name (path) of the extension directory
-#: ../src/main.cpp:499
+#: ../src/main.cpp:501
 msgid "Print out the extension directory and exit"
 msgstr "Erweiterungsverzeichnis ausgeben und beenden"
 
-#: ../src/main.cpp:504
+#: ../src/main.cpp:506
 msgid "Remove unused definitions from the defs section(s) of the document"
 msgstr "Unbenutzte Elemente aus den <defs> des Dokuments entfernen"
 
-#: ../src/main.cpp:510
+#: ../src/main.cpp:512
 msgid "Enter a listening loop for D-Bus messages in console mode"
 msgstr "Warteschleife für D-Bus-Nachrichten im Konsolen-Modus eingeben"
 
-#: ../src/main.cpp:515
+#: ../src/main.cpp:517
 msgid ""
 "Specify the D-Bus bus name to listen for messages on (default is org."
 "inkscape)"
@@ -12658,43 +12806,45 @@ msgstr ""
 "D-Bus-Namen angeben, dessen Nachrichten angezeigt werden sollen (Standard "
 "ist org.inkscape)"
 
-#: ../src/main.cpp:516
+#: ../src/main.cpp:518
 msgid "BUS-NAME"
 msgstr "BUS-NAME"
 
-#: ../src/main.cpp:521
+#: ../src/main.cpp:523
 msgid "List the IDs of all the verbs in Inkscape"
 msgstr "Listet die ID aller Verben in Inkscape"
 
-#: ../src/main.cpp:526
+#: ../src/main.cpp:528
 msgid "Verb to call when Inkscape opens."
 msgstr "Aufzurufendes Verb wenn Inkscape startet"
 
-#: ../src/main.cpp:527
+#: ../src/main.cpp:529
 msgid "VERB-ID"
 msgstr "VERB-ID"
 
-#: ../src/main.cpp:531
+#: ../src/main.cpp:533
 msgid "Object ID to select when Inkscape opens."
 msgstr "ID des Objektes, das beim Start von Inkscape ausgewählt werden soll"
 
-#: ../src/main.cpp:532
+#: ../src/main.cpp:534
 msgid "OBJECT-ID"
 msgstr "OBJECT-ID"
 
-#: ../src/main.cpp:536
+#: ../src/main.cpp:538
 msgid "Start Inkscape in interactive shell mode."
 msgstr "Inkscape in interaktivem Konsolenmodus starten."
 
-#: ../src/main.cpp:541
+#: ../src/main.cpp:543
 msgid "Do not fix legacy (pre-0.92) files' text baseline spacing on opening."
 msgstr ""
 
-#: ../src/main.cpp:546
-msgid "Method used to convert pre-.92 document dpi, if needed."
+#: ../src/main.cpp:548
+msgid ""
+"Method used to convert pre-.92 document dpi, if needed. ([none|scale-viewbox|"
+"scale-document])"
 msgstr ""
 
-#: ../src/main.cpp:865 ../src/main.cpp:1259
+#: ../src/main.cpp:837 ../src/main.cpp:1185
 msgid ""
 "[OPTIONS...] [FILE...]\n"
 "\n"
@@ -12734,45 +12884,45 @@ msgstr "<b>Pfad</b>muss zum Zerlegen ausgewählt sein."
 msgid "Breaking apart paths..."
 msgstr "Zerlege Pfade..."
 
-#: ../src/path-chemistry.cpp:289
+#: ../src/path-chemistry.cpp:287
 msgid "Break apart"
 msgstr "Zerlegen"
 
-#: ../src/path-chemistry.cpp:293
+#: ../src/path-chemistry.cpp:291
 msgid "<b>No path(s)</b> to break apart in the selection."
 msgstr "<b>Kein Pfad</b> ausgewählt, der zerlegt werden könnte."
 
-#: ../src/path-chemistry.cpp:301
+#: ../src/path-chemistry.cpp:299
 msgid "Select <b>object(s)</b> to convert to path."
 msgstr "<b>Objekte</b> auswählen, die in einen Pfad umgewandelt werden sollen."
 
-#: ../src/path-chemistry.cpp:307
+#: ../src/path-chemistry.cpp:305
 msgid "Converting objects to paths..."
 msgstr "Wandle Objekte in Pfade um..."
 
-#: ../src/path-chemistry.cpp:327
+#: ../src/path-chemistry.cpp:328
 msgid "Object to path"
 msgstr "Objekt in Pfad umwandeln"
 
-#: ../src/path-chemistry.cpp:330
+#: ../src/path-chemistry.cpp:331
 msgid "<b>No objects</b> to convert to path in the selection."
 msgstr ""
 "<b>Keine Objekte</b> ausgewählt, die in einen Pfad umgewandelt werden "
 "könnten."
 
-#: ../src/path-chemistry.cpp:614
+#: ../src/path-chemistry.cpp:624
 msgid "Select <b>path(s)</b> to reverse."
 msgstr "Mindestens <b>einen Pfad</b> zum Umkehren auswählen."
 
-#: ../src/path-chemistry.cpp:622
+#: ../src/path-chemistry.cpp:632
 msgid "Reversing paths..."
 msgstr "Kehre Pfadrichtungen um..."
 
-#: ../src/path-chemistry.cpp:660
+#: ../src/path-chemistry.cpp:670
 msgid "Reverse path"
 msgstr "Pfadrichtung umkehren"
 
-#: ../src/path-chemistry.cpp:663
+#: ../src/path-chemistry.cpp:673
 msgid "<b>No paths</b> to reverse in the selection."
 msgstr "Die Auswahl enthält <b>keine Pfade</b> zum Umkehren."
 
@@ -12899,7 +13049,7 @@ msgstr "Open-Font-Lizenz"
 
 #. Create the Title label and edit control
 #. TRANSLATORS: for info, see http://www.w3.org/TR/2000/CR-SVG-20000802/linking.html#AElementXLinkTitleAttribute
-#: ../src/rdf.cpp:235 ../src/ui/dialog/filedialogimpl-win32.cpp:1881
+#: ../src/rdf.cpp:235 ../src/ui/dialog/filedialogimpl-win32.cpp:1882
 #: ../src/ui/dialog/object-attributes.cpp:54
 msgid "Title:"
 msgstr "Titel:"
@@ -12980,7 +13130,7 @@ msgstr "Beziehung:"
 msgid "A related resource"
 msgstr "Zugehöriges Dokument"
 
-#: ../src/rdf.cpp:267 ../src/ui/dialog/inkscape-preferences.cpp:1897
+#: ../src/rdf.cpp:267 ../src/ui/dialog/inkscape-preferences.cpp:1958
 msgid "Language:"
 msgstr "Sprache:"
 
@@ -13063,11 +13213,11 @@ msgstr "Text löschen"
 msgid "<b>Nothing</b> was deleted."
 msgstr "Es wurde <b>nichts</b> gelöscht."
 
-#: ../src/selection-chemistry.cpp:410 ../src/ui/dialog/swatches.cpp:270
-#: ../src/ui/tools/text-tool.cpp:959 ../src/widgets/eraser-toolbar.cpp:145
-#: ../src/widgets/gradient-toolbar.cpp:1182
-#: ../src/widgets/gradient-toolbar.cpp:1196
-#: ../src/widgets/gradient-toolbar.cpp:1210 ../src/widgets/node-toolbar.cpp:399
+#: ../src/selection-chemistry.cpp:410 ../src/ui/dialog/swatches.cpp:282
+#: ../src/ui/tools/text-tool.cpp:955 ../src/widgets/eraser-toolbar.cpp:151
+#: ../src/widgets/gradient-toolbar.cpp:1071
+#: ../src/widgets/gradient-toolbar.cpp:1085
+#: ../src/widgets/gradient-toolbar.cpp:1099 ../src/widgets/node-toolbar.cpp:399
 msgid "Delete"
 msgstr "Löschen"
 
@@ -13088,45 +13238,45 @@ msgstr "Alles löschen"
 msgid "Select <b>some objects</b> to group."
 msgstr "<b>Einige Objekte</b> zum Gruppieren auswählen."
 
-#: ../src/selection-chemistry.cpp:765
+#: ../src/selection-chemistry.cpp:769
 msgctxt "Verb"
 msgid "Group"
 msgstr "Gruppieren"
 
-#: ../src/selection-chemistry.cpp:787
+#: ../src/selection-chemistry.cpp:785
 msgid "<b>No objects selected</b> to pop out of group."
 msgstr ""
 "<b>Keine Objekte ausgewählt</b>, die aus der Gruppe herausgelöst werden "
 "könnten."
 
-#: ../src/selection-chemistry.cpp:796
+#: ../src/selection-chemistry.cpp:794
 msgid "Selection <b>not in a group</b>."
 msgstr "Auswahl ist <b>nicht in einer Gruppe</b>."
 
-#: ../src/selection-chemistry.cpp:811
+#: ../src/selection-chemistry.cpp:809
 msgid "Pop selection from group"
 msgstr "Auswahl aus Gruppe entfernen"
 
-#: ../src/selection-chemistry.cpp:875
+#: ../src/selection-chemistry.cpp:871
 msgid "Select a <b>group</b> to ungroup."
 msgstr ""
 "Eine <b>Gruppe</b> auswählen, deren Gruppierung aufgehoben werden soll."
 
-#: ../src/selection-chemistry.cpp:881
+#: ../src/selection-chemistry.cpp:877
 msgid "<b>No groups</b> to ungroup in the selection."
 msgstr "<b>Keine Gruppe</b> zum Aufheben in dieser Auswahl."
 
-#: ../src/selection-chemistry.cpp:888 ../src/sp-item-group.cpp:656
-#: ../src/ui/dialog/objects.cpp:1942
+#: ../src/selection-chemistry.cpp:884 ../src/sp-item-group.cpp:651
+#: ../src/ui/dialog/objects.cpp:1904
 msgid "Ungroup"
 msgstr "Gruppierung aufheben"
 
-#: ../src/selection-chemistry.cpp:975 ../src/selection-chemistry.cpp:1027
+#: ../src/selection-chemistry.cpp:971 ../src/selection-chemistry.cpp:1023
 msgid "Select <b>object(s)</b> to raise."
 msgstr "<b>Objekte</b> zum Anheben auswählen."
 
-#: ../src/selection-chemistry.cpp:982 ../src/selection-chemistry.cpp:1033
-#: ../src/selection-chemistry.cpp:1059 ../src/selection-chemistry.cpp:1116
+#: ../src/selection-chemistry.cpp:978 ../src/selection-chemistry.cpp:1029
+#: ../src/selection-chemistry.cpp:1055 ../src/selection-chemistry.cpp:1112
 msgid ""
 "You cannot raise/lower objects from <b>different groups</b> or <b>layers</b>."
 msgstr ""
@@ -13134,253 +13284,253 @@ msgstr ""
 "gleichzeitig angehoben/abgesenkt werden."
 
 #. TRANSLATORS: "Raise" means "to raise an object" in the undo history
-#: ../src/selection-chemistry.cpp:1021
+#: ../src/selection-chemistry.cpp:1017
 msgctxt "Undo action"
 msgid "Raise"
 msgstr "Anheben"
 
-#: ../src/selection-chemistry.cpp:1047
+#: ../src/selection-chemistry.cpp:1043
 msgid "Raise to top"
 msgstr "Nach ganz oben anheben"
 
-#: ../src/selection-chemistry.cpp:1053
+#: ../src/selection-chemistry.cpp:1049
 msgid "Select <b>object(s)</b> to lower."
 msgstr "<b>Objekt(e)</b> zum Absenken auswählen."
 
 #. TRANSLATORS: "Lower" means "to lower an object" in the undo history
-#: ../src/selection-chemistry.cpp:1102
+#: ../src/selection-chemistry.cpp:1098
 msgctxt "Undo action"
 msgid "Lower"
 msgstr "Absenken"
 
-#: ../src/selection-chemistry.cpp:1110
+#: ../src/selection-chemistry.cpp:1106
 msgid "Select <b>object(s)</b> to lower to bottom."
 msgstr ""
 "<b>Objekt(e)</b> auswählen, die nach ganz unten abgesenkt werden sollen."
 
-#: ../src/selection-chemistry.cpp:1140
+#: ../src/selection-chemistry.cpp:1136
 msgid "Lower to bottom"
 msgstr "Nach ganz unten absenken"
 
-#: ../src/selection-chemistry.cpp:1146
+#: ../src/selection-chemistry.cpp:1142
 #, fuzzy
 msgid "Select <b>object(s)</b> to stack up."
 msgstr "<b>Objekt(e)</b> auswählen, die nach oben angehoben werden sollen."
 
-#: ../src/selection-chemistry.cpp:1157
+#: ../src/selection-chemistry.cpp:1153
 #, fuzzy
 msgid "We hit top."
 msgstr "Nach ganz oben anheben"
 
 #. TRANSLATORS: undo history: "stack up" means to raise an object of its ordinal position by 1
-#: ../src/selection-chemistry.cpp:1165
+#: ../src/selection-chemistry.cpp:1161
 #, fuzzy
 msgctxt "Undo action"
 msgid "stack up"
 msgstr "Umschichten"
 
-#: ../src/selection-chemistry.cpp:1170
+#: ../src/selection-chemistry.cpp:1166
 #, fuzzy
 msgid "Select <b>object(s)</b> to stack down."
 msgstr "<b>Objekte</b> zum Kombinieren auswählen."
 
-#: ../src/selection-chemistry.cpp:1181
+#: ../src/selection-chemistry.cpp:1177
 #, fuzzy
 msgid "We hit bottom."
 msgstr "Nach ganz unten absenken"
 
 #. TRANSLATORS: undo history: "stack down" means to lower an object of its ordinal position by 1
-#: ../src/selection-chemistry.cpp:1189
+#: ../src/selection-chemistry.cpp:1185
 #, fuzzy
 msgctxt "Undo action"
 msgid "stack down"
 msgstr "Umschichten-Modus"
 
 # !!! just make the menu item insensitive
-#: ../src/selection-chemistry.cpp:1199
+#: ../src/selection-chemistry.cpp:1195
 msgid "Nothing to undo."
 msgstr "Es gibt nichts rückgängig zu machen."
 
 # # !!! just make the menu item insensitive
-#: ../src/selection-chemistry.cpp:1210
+#: ../src/selection-chemistry.cpp:1206
 msgid "Nothing to redo."
 msgstr "Es gibt nichts wiederherzustellen."
 
-#: ../src/selection-chemistry.cpp:1282
+#: ../src/selection-chemistry.cpp:1278
 msgid "Paste"
 msgstr "Einfügen"
 
-#: ../src/selection-chemistry.cpp:1290
+#: ../src/selection-chemistry.cpp:1286
 msgid "Paste style"
 msgstr "Stil übertragen"
 
-#: ../src/selection-chemistry.cpp:1299
+#: ../src/selection-chemistry.cpp:1295
 msgid "Paste live path effect"
 msgstr "Pfadeffekt einfügen"
 
-#: ../src/selection-chemistry.cpp:1319
+#: ../src/selection-chemistry.cpp:1315
 msgid "Select <b>object(s)</b> to remove live path effects from."
 msgstr "<b>Objekt(e)</b> auswählen, deren Pfadeffekte entfernt werden sollen."
 
-#: ../src/selection-chemistry.cpp:1332
+#: ../src/selection-chemistry.cpp:1328
 msgid "Remove live path effect"
 msgstr "Pfadeffekt entfernen"
 
-#: ../src/selection-chemistry.cpp:1341
+#: ../src/selection-chemistry.cpp:1337
 msgid "Select <b>object(s)</b> to remove filters from."
 msgstr "<b>Objekt(e)</b> auswählen, deren Filter entfernt werden sollen."
 
-#: ../src/selection-chemistry.cpp:1351
-#: ../src/ui/dialog/filter-effects-dialog.cpp:1674
+#: ../src/selection-chemistry.cpp:1347
+#: ../src/ui/dialog/filter-effects-dialog.cpp:1685
 msgid "Remove filter"
 msgstr "Filter entfernen"
 
-#: ../src/selection-chemistry.cpp:1360
+#: ../src/selection-chemistry.cpp:1356
 msgid "Paste size"
 msgstr "Größe einfügen"
 
-#: ../src/selection-chemistry.cpp:1369
+#: ../src/selection-chemistry.cpp:1365
 msgid "Paste size separately"
 msgstr "Größe getrennt einfügen"
 
-#: ../src/selection-chemistry.cpp:1399
+#: ../src/selection-chemistry.cpp:1395
 msgid "Select <b>object(s)</b> to move to the layer above."
 msgstr ""
 "<b>Objekt(e)</b> auswählen, welche in die Ebene darüber verschoben werden "
 "sollen."
 
-#: ../src/selection-chemistry.cpp:1425
+#: ../src/selection-chemistry.cpp:1421
 msgid "Raise to next layer"
 msgstr "In darüberliegende Ebene anheben"
 
-#: ../src/selection-chemistry.cpp:1432
+#: ../src/selection-chemistry.cpp:1428
 msgid "No more layers above."
 msgstr "Keine weiteren Ebenen über dieser."
 
-#: ../src/selection-chemistry.cpp:1445
+#: ../src/selection-chemistry.cpp:1441
 msgid "Select <b>object(s)</b> to move to the layer below."
 msgstr ""
 "<b>Objekt(e)</b> auswählen, welche in die Ebene darunter verschoben werden "
 "sollen."
 
-#: ../src/selection-chemistry.cpp:1471
+#: ../src/selection-chemistry.cpp:1467
 msgid "Lower to previous layer"
 msgstr "Zur darunterliegenden Ebene absenken"
 
-#: ../src/selection-chemistry.cpp:1478
+#: ../src/selection-chemistry.cpp:1474
 msgid "No more layers below."
 msgstr "Keine weiteren Ebenen unter dieser."
 
-#: ../src/selection-chemistry.cpp:1491
+#: ../src/selection-chemistry.cpp:1487
 msgid "Select <b>object(s)</b> to move."
 msgstr "<b>Objekt(e)</b> zum Verschieben auswählen."
 
-#: ../src/selection-chemistry.cpp:1509 ../src/verbs.cpp:2819
+#: ../src/selection-chemistry.cpp:1505 ../src/verbs.cpp:2849
 msgid "Move selection to layer"
 msgstr "Auswahl zur Ebene verschieben"
 
-#: ../src/selection-chemistry.cpp:1601 ../src/seltrans.cpp:385
+#: ../src/selection-chemistry.cpp:1597 ../src/seltrans.cpp:385
 msgid "Cannot transform an embedded SVG."
 msgstr "Kann ein eingebettetes SVG nicht transformieren."
 
-#: ../src/selection-chemistry.cpp:1767
+#: ../src/selection-chemistry.cpp:1763
 msgid "Remove transform"
 msgstr "Transformationen zurücksetzen"
 
-#: ../src/selection-chemistry.cpp:1866
+#: ../src/selection-chemistry.cpp:1862
 msgid "Rotate 90° CCW"
 msgstr "90° gegen den Uhrzeigersinn drehen"
 
-#: ../src/selection-chemistry.cpp:1866
+#: ../src/selection-chemistry.cpp:1862
 msgid "Rotate 90° CW"
 msgstr "90° im Uhrzeigersinn drehen"
 
-#: ../src/selection-chemistry.cpp:1885 ../src/seltrans.cpp:478
+#: ../src/selection-chemistry.cpp:1881 ../src/seltrans.cpp:478
 #: ../src/ui/dialog/transformation.cpp:784
 msgid "Rotate"
 msgstr "Drehen"
 
-#: ../src/selection-chemistry.cpp:2233
+#: ../src/selection-chemistry.cpp:2227
 msgid "Rotate by pixels"
 msgstr "Pixelweise drehen"
 
-#: ../src/selection-chemistry.cpp:2286
+#: ../src/selection-chemistry.cpp:2280
 msgid "Scale by whole factor"
 msgstr "Um einen ganzzahligen Faktor skalieren"
 
-#: ../src/selection-chemistry.cpp:2300
+#: ../src/selection-chemistry.cpp:2294
 msgid "Move vertically"
 msgstr "Vertikal verschieben"
 
-#: ../src/selection-chemistry.cpp:2303
+#: ../src/selection-chemistry.cpp:2297
 msgid "Move horizontally"
 msgstr "Horizontal verschieben"
 
-#: ../src/selection-chemistry.cpp:2306 ../src/selection-chemistry.cpp:2331
+#: ../src/selection-chemistry.cpp:2300 ../src/selection-chemistry.cpp:2325
 #: ../src/seltrans.cpp:472 ../src/ui/dialog/transformation.cpp:695
 msgid "Move"
 msgstr "Verschieben"
 
-#: ../src/selection-chemistry.cpp:2325
+#: ../src/selection-chemistry.cpp:2319
 msgid "Move vertically by pixels"
 msgstr "Vertikal um einzelne Pixel verschieben"
 
-#: ../src/selection-chemistry.cpp:2328
+#: ../src/selection-chemistry.cpp:2322
 msgid "Move horizontally by pixels"
 msgstr "Horizontal um einzelne Pixel verschieben"
 
-#: ../src/selection-chemistry.cpp:2532
+#: ../src/selection-chemistry.cpp:2530
 msgid "The selection has no applied path effect."
 msgstr "Die Auswahl enthält keine Objekte mit Pfadeffekt."
 
-#: ../src/selection-chemistry.cpp:2620 ../src/ui/dialog/clonetiler.cpp:2060
+#: ../src/selection-chemistry.cpp:2588 ../src/ui/dialog/clonetiler.cpp:2060
 msgid "Select an <b>object</b> to clone."
 msgstr "Zu klonendes <b>Objekt</b> auswählen."
 
-#: ../src/selection-chemistry.cpp:2655
+#: ../src/selection-chemistry.cpp:2623
 msgctxt "Action"
 msgid "Clone"
 msgstr "Klonen"
 
-#: ../src/selection-chemistry.cpp:2664
+#: ../src/selection-chemistry.cpp:2632
 msgid "Select <b>clones</b> to relink."
 msgstr "<b>Klone</b> auswählen, die neu verknüpft werden sollen"
 
-#: ../src/selection-chemistry.cpp:2672
+#: ../src/selection-chemistry.cpp:2640
 msgid "Copy an <b>object</b> to clipboard to relink clones to."
 msgstr ""
 "<b>Objekt</b>, mit dem die Klone neu verknüpft werden sollen, in die "
 "Zwischenablage kopieren."
 
-#: ../src/selection-chemistry.cpp:2694
+#: ../src/selection-chemistry.cpp:2662
 msgid "<b>No clones to relink</b> in the selection."
 msgstr ""
 "<b>Keine Klone</b> in der Auswahl, deren Verknüpfung erneut gesetzt werden "
 "kann."
 
-#: ../src/selection-chemistry.cpp:2697
+#: ../src/selection-chemistry.cpp:2665
 msgid "Relink clone"
 msgstr "Klon neu verknüpfen"
 
-#: ../src/selection-chemistry.cpp:2706 ../src/selection-chemistry.cpp:2792
+#: ../src/selection-chemistry.cpp:2674 ../src/selection-chemistry.cpp:2760
 msgid "Select <b>clones</b> to unlink."
 msgstr "<b>Klon</b> auswählen, dessen Verknüpfung aufgehoben werden soll."
 
-#: ../src/selection-chemistry.cpp:2779 ../src/selection-chemistry.cpp:2810
+#: ../src/selection-chemistry.cpp:2747 ../src/selection-chemistry.cpp:2778
 msgid "<b>No clones to unlink</b> in the selection."
 msgstr ""
 "<b>Keine Klone</b> in der Auswahl, deren Verknüpfung aufgehoben werden kann."
 
-#: ../src/selection-chemistry.cpp:2784
+#: ../src/selection-chemistry.cpp:2752
 msgid "Unlink clone"
 msgstr "Klonverbindung auftrennen"
 
-#: ../src/selection-chemistry.cpp:2814
+#: ../src/selection-chemistry.cpp:2782
 #, fuzzy
 msgid "Unlink clone recursively"
 msgstr "Klonverbindung auftrennen"
 
-#: ../src/selection-chemistry.cpp:2824
+#: ../src/selection-chemistry.cpp:2792
 msgid ""
 "Select a <b>clone</b> to go to its original. Select a <b>linked offset</b> "
 "to go to its source. Select a <b>text on path</b> to go to the path. Select "
@@ -13391,7 +13541,7 @@ msgstr ""
 "den Ausgangspfad zu finden. <b>Fließtextpfad</b> auswählen, um seinen Rahmen "
 "zu finden."
 
-#: ../src/selection-chemistry.cpp:2877
+#: ../src/selection-chemistry.cpp:2833
 msgid ""
 "<b>Cannot find</b> the object to select (orphaned clone, offset, textpath, "
 "flowed text?)"
@@ -13399,7 +13549,7 @@ msgstr ""
 "Gesuchtes Objekt <b>nicht gefunden</b> - vielleicht ist der Klon, der "
 "verbundene Versatz, der Textpfad oder der Fließtext verwaist?"
 
-#: ../src/selection-chemistry.cpp:2884
+#: ../src/selection-chemistry.cpp:2840
 msgid ""
 "The object you're trying to select is <b>not visible</b> (it is in &lt;"
 "defs&gt;)"
@@ -13407,232 +13557,232 @@ msgstr ""
 "Dieses Objekt kann nicht ausgewählt werden - es ist <b>unsichtbar</b> und "
 "befindet sich in &lt;defs&gt;."
 
-#: ../src/selection-chemistry.cpp:2970
+#: ../src/selection-chemistry.cpp:2938
 msgid "Select path(s) to fill."
 msgstr "Pfad(e) zum Füllen auswählen."
 
-#: ../src/selection-chemistry.cpp:2987
+#: ../src/selection-chemistry.cpp:2955
 msgid "Select <b>object(s)</b> to convert to marker."
 msgstr ""
 "<b>Objekt(e)</b> auswählen, die in eine Knotenmarkierung umgewandelt werden "
 "sollen."
 
-#: ../src/selection-chemistry.cpp:3059
+#: ../src/selection-chemistry.cpp:3027
 msgid "Objects to marker"
 msgstr "Objekte zu Knotenmarkierung"
 
-#: ../src/selection-chemistry.cpp:3082
+#: ../src/selection-chemistry.cpp:3050
 msgid "Select <b>object(s)</b> to convert to guides."
 msgstr ""
 "<b>Objekt(e)</b> auswählen, die in Hilfslinien umgewandelt werden sollen."
 
-#: ../src/selection-chemistry.cpp:3103
+#: ../src/selection-chemistry.cpp:3071
 msgid "Objects to guides"
 msgstr "Objekte zu Hilfslinien"
 
-#: ../src/selection-chemistry.cpp:3135
+#: ../src/selection-chemistry.cpp:3102
 msgid "Select <b>objects</b> to convert to symbol."
 msgstr "Wählen Sie <b>Objekte</b> zum Konvertieren in ein Symbol aus."
 
-#: ../src/selection-chemistry.cpp:3239
+#: ../src/selection-chemistry.cpp:3245
 msgid "Group to symbol"
 msgstr "Gruppe zu Symbol"
 
-#: ../src/selection-chemistry.cpp:3253
+#: ../src/selection-chemistry.cpp:3258
 msgid "Select a <b>symbol</b> to extract objects from."
 msgstr "Wählen Sie ein <b>Symbol</b>, um Objekte daraus zu entnehmen."
 
-#: ../src/selection-chemistry.cpp:3263
+#: ../src/selection-chemistry.cpp:3268
 msgid "Select only one <b>symbol</b> in Symbol dialog to convert to group."
 msgstr ""
 "Wählen Sie nur ein<b>Symbol</b> aus, um es in eine Gruppe zu konvertieren."
 
-#: ../src/selection-chemistry.cpp:3319
+#: ../src/selection-chemistry.cpp:3329
 msgid "Group from symbol"
 msgstr "Symbol zu Gruppe"
 
-#: ../src/selection-chemistry.cpp:3334
+#: ../src/selection-chemistry.cpp:3344
 msgid "Select <b>object(s)</b> to convert to pattern."
 msgstr ""
 "<b>Objekt(e)</b> auswählen, die in ein Füllmuster umgewandelt werden sollen."
 
-#: ../src/selection-chemistry.cpp:3430
+#: ../src/selection-chemistry.cpp:3440
 msgid "Objects to pattern"
 msgstr "Objekte in Füllmuster umwandeln"
 
-#: ../src/selection-chemistry.cpp:3442
+#: ../src/selection-chemistry.cpp:3452
 msgid "Select an <b>object with pattern fill</b> to extract objects from."
 msgstr ""
 "Ein <b>Objekt mit Musterfüllung</b> auswählen, um die Füllung zu extrahieren."
 
-#: ../src/selection-chemistry.cpp:3502
+#: ../src/selection-chemistry.cpp:3512
 msgid "<b>No pattern fills</b> in the selection."
 msgstr "Die Auswahl enthält <b>keine Musterfüllung</b>."
 
-#: ../src/selection-chemistry.cpp:3505
+#: ../src/selection-chemistry.cpp:3515
 msgid "Pattern to objects"
 msgstr "Füllmuster in Objekte umwandeln"
 
-#: ../src/selection-chemistry.cpp:3587
+#: ../src/selection-chemistry.cpp:3597
 msgid "Select <b>object(s)</b> to make a bitmap copy."
 msgstr "<b>Objekt(e) auswählen</b>, um eine Bitmap-Kopie zu erstellen."
 
-#: ../src/selection-chemistry.cpp:3591
+#: ../src/selection-chemistry.cpp:3601
 msgid "Rendering bitmap..."
 msgstr "Bitmap wird gerendert..."
 
-#: ../src/selection-chemistry.cpp:3778
+#: ../src/selection-chemistry.cpp:3788
 msgid "Create bitmap"
 msgstr "Bitmap erstellen"
 
-#: ../src/selection-chemistry.cpp:3800 ../src/selection-chemistry.cpp:3910
+#: ../src/selection-chemistry.cpp:3810 ../src/selection-chemistry.cpp:3919
 msgid "Select <b>object(s)</b> to create clippath or mask from."
 msgstr ""
 "<b>Objekt(e)</b> auswählen, um Ausschneidepfad oder Maske daraus zu erzeugen."
 
-#: ../src/selection-chemistry.cpp:3886 ../src/ui/dialog/objects.cpp:1948
+#: ../src/selection-chemistry.cpp:3895 ../src/ui/dialog/objects.cpp:1910
 msgid "Create Clip Group"
 msgstr "Ausschneidemaske erzeugen"
 
-#: ../src/selection-chemistry.cpp:3914
+#: ../src/selection-chemistry.cpp:3923
 msgid "Select mask object and <b>object(s)</b> to apply clippath or mask to."
 msgstr ""
 "Maskenobjekt und <b>Objekt(e)</b> zur Anwendung von Ausschneidepfad oder "
 "Maske auswählen."
 
-#: ../src/selection-chemistry.cpp:4058
+#: ../src/selection-chemistry.cpp:4073
 msgid "Set clipping path"
 msgstr "Ausschneidepfad setzen"
 
-#: ../src/selection-chemistry.cpp:4060
+#: ../src/selection-chemistry.cpp:4075
 msgid "Set mask"
 msgstr "Maske setzen"
 
-#: ../src/selection-chemistry.cpp:4072
+#: ../src/selection-chemistry.cpp:4087
 msgid "Select <b>object(s)</b> to remove clippath or mask from."
 msgstr ""
 "<b>Objekt(e)</b> auswählen, deren Ausschneidepfad oder Maske entfernt werden "
 "soll."
 
-#: ../src/selection-chemistry.cpp:4189
+#: ../src/selection-chemistry.cpp:4200
 msgid "Release clipping path"
 msgstr "Ausschneidepfad freigeben"
 
-#: ../src/selection-chemistry.cpp:4191
+#: ../src/selection-chemistry.cpp:4202
 msgid "Release mask"
 msgstr "Maske freigeben"
 
 # While it's canvas in English, the page size is what is intended (according to cpp file).
-#: ../src/selection-chemistry.cpp:4207
+#: ../src/selection-chemistry.cpp:4218
 msgid "Select <b>object(s)</b> to fit canvas to."
 msgstr ""
 "<b>Objekt(e)</b> auswählen, an die die Seitengröße angepasst werden soll."
 
 #. Fit Page
-#: ../src/selection-chemistry.cpp:4215 ../src/verbs.cpp:3186
+#: ../src/selection-chemistry.cpp:4226 ../src/verbs.cpp:3220
 msgid "Fit Page to Selection"
 msgstr "Seite in Auswahl einpassen"
 
-#: ../src/selection-chemistry.cpp:4289 ../src/verbs.cpp:2689
+#: ../src/selection-chemistry.cpp:4300 ../src/verbs.cpp:2719
 #, fuzzy
 msgid "Swap fill and stroke of an object"
 msgstr "Füllung und Linie vertauschen"
 
-#: ../src/selection-chemistry.cpp:4317 ../src/verbs.cpp:3188
+#: ../src/selection-chemistry.cpp:4328 ../src/verbs.cpp:3222
 msgid "Fit Page to Drawing"
 msgstr "Seite in Zeichnungsgröße einpassen"
 
-#: ../src/selection-chemistry.cpp:4338
+#: ../src/selection-chemistry.cpp:4349
 msgid "Fit Page to Selection or Drawing"
 msgstr "Seite in Auswahl oder ganze Zeichnung einpassen"
 
-#: ../src/selection-describer.cpp:129
+#: ../src/selection-describer.cpp:118
 msgid "root"
 msgstr "Wurzel"
 
 # CHECK
-#: ../src/selection-describer.cpp:131 ../src/widgets/ege-paint-def.cpp:64
+#: ../src/selection-describer.cpp:120 ../src/widgets/ege-paint-def.cpp:64
 #: ../src/widgets/ege-paint-def.cpp:88
 msgid "none"
 msgstr "keine"
 
-#: ../src/selection-describer.cpp:143
+#: ../src/selection-describer.cpp:132
 #, c-format
 msgid "layer <b>%s</b>"
 msgstr "Ebene <b>%s</b>"
 
-#: ../src/selection-describer.cpp:145
+#: ../src/selection-describer.cpp:134
 #, c-format
 msgid "layer <b><i>%s</i></b>"
 msgstr "Ebene <b><i>%s</i></b>"
 
 # !!!
-#: ../src/selection-describer.cpp:156
+#: ../src/selection-describer.cpp:145
 #, c-format
 msgid "<i>%s</i>"
 msgstr "<i>%s</i>"
 
-#: ../src/selection-describer.cpp:166
+#: ../src/selection-describer.cpp:155
 #, c-format
 msgid " in %s"
 msgstr " in %s"
 
-#: ../src/selection-describer.cpp:168
+#: ../src/selection-describer.cpp:157
 msgid " hidden in definitions"
 msgstr " versteckt in Definitionen"
 
-#: ../src/selection-describer.cpp:170
+#: ../src/selection-describer.cpp:159
 #, c-format
 msgid " in group %s (%s)"
 msgstr " in Gruppe %s (%s)"
 
-#: ../src/selection-describer.cpp:172
+#: ../src/selection-describer.cpp:161
 #, c-format
 msgid " in unnamed group (%s)"
 msgstr " in unbenannter Gruppe (%s)"
 
-#: ../src/selection-describer.cpp:174
+#: ../src/selection-describer.cpp:163
 #, c-format
 msgid " in <b>%i</b> parent (%s)"
 msgid_plural " in <b>%i</b> parents (%s)"
 msgstr[0] " in <b>%i</b> Elternelement (%s)"
 msgstr[1] " in <b>%i</b> Elternelementen (%s)"
 
-#: ../src/selection-describer.cpp:177
+#: ../src/selection-describer.cpp:166
 #, c-format
 msgid " in <b>%i</b> layer"
 msgid_plural " in <b>%i</b> layers"
 msgstr[0] " in <b>%i</b> Ebene"
 msgstr[1] " in <b>%i</b> Ebenen"
 
-#: ../src/selection-describer.cpp:189
+#: ../src/selection-describer.cpp:178
 msgid "Convert symbol to group to edit"
 msgstr "Symbol zum Bearbeiten in eine Gruppe konvertieren"
 
-#: ../src/selection-describer.cpp:193
+#: ../src/selection-describer.cpp:182
 msgid "Remove from symbols tray to edit symbol"
 msgstr "Aus der Symbolablage entfernen, um das Symbol zu bearbeiten"
 
-#: ../src/selection-describer.cpp:199
+#: ../src/selection-describer.cpp:188
 msgid "Use <b>Shift+D</b> to look up original"
 msgstr "<b>Umschalt+D</b> zum Finden des Originals verwenden"
 
-#: ../src/selection-describer.cpp:205
+#: ../src/selection-describer.cpp:194
 msgid "Use <b>Shift+D</b> to look up path"
 msgstr "<b>Umschalt+D</b> zum Finden des Pfades verwenden"
 
-#: ../src/selection-describer.cpp:211
+#: ../src/selection-describer.cpp:200
 msgid "Use <b>Shift+D</b> to look up frame"
 msgstr "<b>Umschalt+D</b> zum Finden des Rahmens verwenden"
 
-#: ../src/selection-describer.cpp:227
+#: ../src/selection-describer.cpp:216
 #, c-format
 msgid "<b>%1$i</b> objects selected of type %2$s"
 msgid_plural "<b>%1$i</b> objects selected of types %2$s"
 msgstr[0] "<b>%1$i</b> Objekte des Typs %2$s ausgewählt"
 msgstr[1] "<b>%1$i</b> Objekte der Typen %2$s ausgewählt"
 
-#: ../src/selection-describer.cpp:237
+#: ../src/selection-describer.cpp:226
 #, c-format
 msgid "; <i>%d filtered object</i> "
 msgid_plural "; <i>%d filtered objects</i> "
@@ -13695,7 +13845,7 @@ msgstr "Stempeln"
 msgid "Reset center"
 msgstr "Mittelpunkt zurücksetzen"
 
-#: ../src/seltrans.cpp:958 ../src/seltrans.cpp:1062
+#: ../src/seltrans.cpp:960 ../src/seltrans.cpp:1064
 #, c-format
 msgid "<b>Scale</b>: %0.2f%% x %0.2f%%; with <b>Ctrl</b> to lock ratio"
 msgstr ""
@@ -13704,24 +13854,24 @@ msgstr ""
 
 #. TRANSLATORS: don't modify the first ";"
 #. (it will NOT be displayed as ";" - only the second one will be)
-#: ../src/seltrans.cpp:1199
+#: ../src/seltrans.cpp:1201
 #, c-format
 msgid "<b>Skew</b>: %0.2f&#176;; with <b>Ctrl</b> to snap angle"
 msgstr "<b>Scheren</b>: %0.2f &#176;; Winkel mit <b>Strg</b> einrasten"
 
 #. TRANSLATORS: don't modify the first ";"
 #. (it will NOT be displayed as ";" - only the second one will be)
-#: ../src/seltrans.cpp:1275
+#: ../src/seltrans.cpp:1277
 #, c-format
 msgid "<b>Rotate</b>: %0.2f&#176;; with <b>Ctrl</b> to snap angle"
 msgstr "<b>Drehen</b>: %0.2f&#176;; Winkel mit <b>Strg</b> einrasten"
 
-#: ../src/seltrans.cpp:1312
+#: ../src/seltrans.cpp:1314
 #, c-format
 msgid "Move <b>center</b> to %s, %s"
 msgstr "<b>Mittelpunkt</b> verschieben nach %s, %s"
 
-#: ../src/seltrans.cpp:1458
+#: ../src/seltrans.cpp:1459
 #, c-format
 msgid ""
 "<b>Move</b> by %s, %s; with <b>Ctrl</b> to restrict to horizontal/vertical; "
@@ -13730,8 +13880,8 @@ msgstr ""
 "<b>Verschieben</b> um %s, %s; mit <b>Strg</b> auf horizontale/vertikale "
 "Verschiebung beschränken; <b>Umschalt</b> deaktiviert das Einrasten"
 
-#: ../src/shortcuts.cpp:397 ../src/ui/dialog/export.cpp:1296
-#: ../src/ui/dialog/export.cpp:1330
+#: ../src/shortcuts.cpp:397 ../src/ui/dialog/export.cpp:1293
+#: ../src/ui/dialog/export.cpp:1323
 msgid "Select a filename for exporting"
 msgstr "Wählen Sie einen Namen für die zu exportierende Datei"
 
@@ -13754,32 +13904,32 @@ msgid "without URI"
 msgstr "ohne URI"
 
 # Any idea on how to translate the very specific term "slicer" to German?
-#: ../src/sp-ellipse.cpp:385 ../src/widgets/arc-toolbar.cpp:364
+#: ../src/sp-ellipse.cpp:387 ../src/widgets/arc-toolbar.cpp:529
 #, fuzzy
 msgid "Slice"
 msgstr "Slicer"
 
-#: ../src/sp-ellipse.cpp:388 ../src/widgets/arc-toolbar.cpp:378
+#: ../src/sp-ellipse.cpp:390 ../src/widgets/arc-toolbar.cpp:541
 msgid "Chord"
 msgstr ""
 
-#: ../src/sp-ellipse.cpp:391
+#: ../src/sp-ellipse.cpp:393
 msgid "Arc"
 msgstr "Bogen"
 
 #. Ellipse
-#: ../src/sp-ellipse.cpp:395 ../src/sp-ellipse.cpp:402
-#: ../src/ui/dialog/inkscape-preferences.cpp:407
-#: ../src/widgets/pencil-toolbar.cpp:176
+#: ../src/sp-ellipse.cpp:397 ../src/sp-ellipse.cpp:404
+#: ../src/ui/dialog/inkscape-preferences.cpp:447
+#: ../src/widgets/pencil-toolbar.cpp:221
 msgid "Ellipse"
 msgstr "Ellipse"
 
-#: ../src/sp-ellipse.cpp:399
+#: ../src/sp-ellipse.cpp:401
 msgid "Circle"
 msgstr "Kreis"
 
 #. TRANSLATORS: "Flow region" is an area where text is allowed to flow
-#: ../src/sp-flowregion.cpp:178
+#: ../src/sp-flowregion.cpp:169
 msgid "Flow Region"
 msgstr "Fließtextbereich"
 
@@ -13787,35 +13937,35 @@ msgstr "Fließtextbereich"
 #. * flow excluded region.  flowRegionExclude in SVG 1.2: see
 #. * http://www.w3.org/TR/2004/WD-SVG12-20041027/flow.html#flowRegion-elem and
 #. * http://www.w3.org/TR/2004/WD-SVG12-20041027/flow.html#flowRegionExclude-elem.
-#: ../src/sp-flowregion.cpp:331
+#: ../src/sp-flowregion.cpp:313
 msgid "Flow Excluded Region"
 msgstr "Ausgeschlossenen Bereich umfließen"
 
-#: ../src/sp-flowtext.cpp:279
+#: ../src/sp-flowtext.cpp:273
 msgid "Flowed Text"
 msgstr "Fließtext"
 
-#: ../src/sp-flowtext.cpp:281
+#: ../src/sp-flowtext.cpp:275
 msgid "Linked Flowed Text"
 msgstr "Verknüpfter Fließtext"
 
-#: ../src/sp-flowtext.cpp:287 ../src/sp-text.cpp:368
-#: ../src/ui/tools/text-tool.cpp:1602
+#: ../src/sp-flowtext.cpp:281 ../src/sp-text.cpp:339
+#: ../src/ui/tools/text-tool.cpp:1598
 msgid " [truncated]"
 msgstr "[abgeschnitten]"
 
-#: ../src/sp-flowtext.cpp:289
+#: ../src/sp-flowtext.cpp:283
 #, c-format
 msgid "(%d character%s)"
 msgid_plural "(%d characters%s)"
 msgstr[0] "(%d Zeichen%s)"
 msgstr[1] "(%d Zeichen%s)"
 
-#: ../src/sp-guide.cpp:258
+#: ../src/sp-guide.cpp:257
 msgid "Create Guides Around the Page"
 msgstr "Hilfslinien an Seitenrändern erstellen"
 
-#: ../src/sp-guide.cpp:271 ../src/verbs.cpp:2681
+#: ../src/sp-guide.cpp:270 ../src/verbs.cpp:2711
 msgid "Delete All Guides"
 msgstr "Hilfslinien löschen"
 
@@ -13847,36 +13997,36 @@ msgstr "Horizontale Hilfslinie bei %s"
 msgid "at %d degrees, through (%s,%s)"
 msgstr "bei %d Grad, durch (%s, %s)"
 
-#: ../src/sp-image.cpp:514
+#: ../src/sp-image.cpp:499
 msgid "embedded"
 msgstr "eingebettet"
 
-#: ../src/sp-image.cpp:522
+#: ../src/sp-image.cpp:507
 #, c-format
 msgid "[bad reference]: %s"
 msgstr "[falsche Referenz]: %s"
 
-#: ../src/sp-image.cpp:523
+#: ../src/sp-image.cpp:508
 #, c-format
 msgid "%d &#215; %d: %s"
 msgstr "%d &#215; %d: %s"
 
-#: ../src/sp-item-group.cpp:312 ../src/ui/dialog/objects.cpp:1941
+#: ../src/sp-item-group.cpp:309 ../src/ui/dialog/objects.cpp:1903
 msgid "Group"
 msgstr "Gruppe"
 
 # Or 'von'? 'Eine Gruppe von Objekten' sounds more natural.
-#: ../src/sp-item-group.cpp:318 ../src/sp-switch.cpp:69
+#: ../src/sp-item-group.cpp:315 ../src/sp-switch.cpp:69
 #, c-format
 msgid "of <b>%d</b> object"
 msgstr "aus <b>%d</b> Objekt"
 
-#: ../src/sp-item-group.cpp:318 ../src/sp-switch.cpp:69
+#: ../src/sp-item-group.cpp:315 ../src/sp-switch.cpp:69
 #, c-format
 msgid "of <b>%d</b> objects"
 msgstr "aus <b>%d</b> Objekten"
 
-#: ../src/sp-item.cpp:1032 ../src/verbs.cpp:208
+#: ../src/sp-item.cpp:1032 ../src/verbs.cpp:211
 msgid "Object"
 msgstr "Objekt"
 
@@ -13904,7 +14054,7 @@ msgstr "%s; <i>gefiltert</i>"
 msgid "Line"
 msgstr "Linie"
 
-#: ../src/sp-lpe-item.cpp:296 ../src/sp-lpe-item.cpp:765
+#: ../src/sp-lpe-item.cpp:296 ../src/sp-lpe-item.cpp:802
 msgid "An exception occurred during execution of the Path Effect."
 msgstr "Beim Anwenden des Pfadeffektes ist ein Fehler aufgetreten."
 
@@ -13960,12 +14110,12 @@ msgid "<b>Polyline</b>"
 msgstr "<b>Linienzug</b>"
 
 #. Rectangle
-#: ../src/sp-rect.cpp:194 ../src/ui/dialog/inkscape-preferences.cpp:397
+#: ../src/sp-rect.cpp:194 ../src/ui/dialog/inkscape-preferences.cpp:437
 msgid "Rectangle"
 msgstr "Rechteck"
 
 #. Spiral
-#: ../src/sp-spiral.cpp:218 ../src/ui/dialog/inkscape-preferences.cpp:415
+#: ../src/sp-spiral.cpp:218 ../src/ui/dialog/inkscape-preferences.cpp:455
 #: ../share/extensions/gcodetools_area.inx.h:16
 msgid "Spiral"
 msgstr "Spirale"
@@ -13978,24 +14128,24 @@ msgid "with %3f turns"
 msgstr "mit %3f Windungen"
 
 #. Star
-#: ../src/sp-star.cpp:245 ../src/ui/dialog/inkscape-preferences.cpp:411
-#: ../src/widgets/star-toolbar.cpp:467
+#: ../src/sp-star.cpp:246 ../src/ui/dialog/inkscape-preferences.cpp:451
+#: ../src/widgets/star-toolbar.cpp:479
 msgid "Star"
 msgstr "Stern"
 
-#: ../src/sp-star.cpp:246 ../src/widgets/star-toolbar.cpp:460
+#: ../src/sp-star.cpp:247 ../src/widgets/star-toolbar.cpp:472
 msgid "Polygon"
 msgstr "Polygon"
 
 #. while there will never be less than 3 vertices, we still need to
 #. make calls to ngettext because the pluralization may be different
 #. for various numbers >=3.  The singular form is used as the index.
-#: ../src/sp-star.cpp:253
+#: ../src/sp-star.cpp:254
 #, c-format
 msgid "with %d vertex"
 msgstr "mit %d Eckpunkt"
 
-#: ../src/sp-star.cpp:253
+#: ../src/sp-star.cpp:254
 #, c-format
 msgid "with %d vertices"
 msgstr "mit %d Eckpunkten"
@@ -14004,7 +14154,7 @@ msgstr "mit %d Eckpunkten"
 msgid "Conditional Group"
 msgstr "Bedingte Gruppe"
 
-#: ../src/sp-text.cpp:349 ../src/verbs.cpp:342
+#: ../src/sp-text.cpp:320 ../src/verbs.cpp:345
 #: ../share/extensions/lorem_ipsum.inx.h:8
 #: ../share/extensions/replace_font.inx.h:11 ../share/extensions/split.inx.h:10
 #: ../share/extensions/text_braille.inx.h:2
@@ -14019,12 +14169,12 @@ msgstr "Bedingte Gruppe"
 msgid "Text"
 msgstr "Text"
 
-#: ../src/sp-text.cpp:372
+#: ../src/sp-text.cpp:343
 #, c-format
 msgid "on path%s (%s, %s)"
 msgstr "an Pfad%s (%s, %s)"
 
-#: ../src/sp-text.cpp:373
+#: ../src/sp-text.cpp:344
 #, c-format
 msgid "%s (%s, %s)"
 msgstr "%s (%s, %s)"
@@ -14037,38 +14187,38 @@ msgstr "Geklonte Zeichendaten"
 msgid " from "
 msgstr " von "
 
-#: ../src/sp-tref.cpp:237 ../src/sp-use.cpp:272
+#: ../src/sp-tref.cpp:237 ../src/sp-use.cpp:269
 msgid "[orphaned]"
 msgstr "[verwaist]"
 
-#: ../src/sp-tspan.cpp:215
+#: ../src/sp-tspan.cpp:214
 msgid "Text Span"
 msgstr "Textspanne"
 
-#: ../src/sp-use.cpp:235
+#: ../src/sp-use.cpp:232
 msgid "Symbol"
 msgstr "Symbol"
 
-#: ../src/sp-use.cpp:237
+#: ../src/sp-use.cpp:234
 msgid "Clone"
 msgstr "Klon"
 
-#: ../src/sp-use.cpp:245 ../src/sp-use.cpp:247 ../src/sp-use.cpp:249
+#: ../src/sp-use.cpp:242 ../src/sp-use.cpp:244 ../src/sp-use.cpp:246
 #, c-format
 msgid "called %s"
 msgstr "%s aufgerufen"
 
-#: ../src/sp-use.cpp:249
+#: ../src/sp-use.cpp:246
 msgid "Unnamed Symbol"
 msgstr "Unbenanntes Symbol"
 
 #. TRANSLATORS: Used for statusbar description for long <use> chains:
 #. * "Clone of: Clone of: ... in Layer 1".
-#: ../src/sp-use.cpp:258
+#: ../src/sp-use.cpp:255
 msgid "..."
 msgstr "..."
 
-#: ../src/sp-use.cpp:267
+#: ../src/sp-use.cpp:264
 #, c-format
 msgid "of: %s"
 msgstr "von: %s"
@@ -14117,74 +14267,74 @@ msgstr ""
 "Differenz-, XOR-, Divisions- oder Pfad-Zerschneiden-Operation ermittelt "
 "werden."
 
-#: ../src/splivarot.cpp:1663
+#: ../src/splivarot.cpp:1667
 msgid "Select <b>stroked path(s)</b> to convert stroke to path."
 msgstr ""
 "<b>Pfade mit Kontur</b> auswählen, um die Konturlinie in einen Pfad "
 "umzuwandeln."
 
-#: ../src/splivarot.cpp:1679
+#: ../src/splivarot.cpp:1683
 msgid "Convert stroke to path"
 msgstr "Kontur in Pfad umwandeln"
 
 #. TRANSLATORS: "to outline" means "to convert stroke to path"
-#: ../src/splivarot.cpp:1682
+#: ../src/splivarot.cpp:1686
 msgid "<b>No stroked paths</b> in the selection."
 msgstr "<b>Keine Pfade mit Konturlinien</b> in der Auswahl."
 
-#: ../src/splivarot.cpp:1753
+#: ../src/splivarot.cpp:1757
 msgid "Selected object is <b>not a path</b>, cannot inset/outset."
 msgstr ""
 "Ausgewähltes Objekt ist <b>kein Pfad</b> - kann es nicht schrumpfen/"
 "erweitern."
 
-#: ../src/splivarot.cpp:1844 ../src/splivarot.cpp:1911
+#: ../src/splivarot.cpp:1848 ../src/splivarot.cpp:1915
 msgid "Create linked offset"
 msgstr "Verbundenen Versatz erzeugen"
 
-#: ../src/splivarot.cpp:1845 ../src/splivarot.cpp:1912
+#: ../src/splivarot.cpp:1849 ../src/splivarot.cpp:1916
 msgid "Create dynamic offset"
 msgstr "Dynamischen Versatz erzeugen"
 
-#: ../src/splivarot.cpp:1937
+#: ../src/splivarot.cpp:1941
 msgid "Select <b>path(s)</b> to inset/outset."
 msgstr "<b>Pfad</b> zum Schrumpfen/Erweitern auswählen."
 
-#: ../src/splivarot.cpp:2122
+#: ../src/splivarot.cpp:2126
 msgid "Outset path"
 msgstr "Pfad erweitern"
 
-#: ../src/splivarot.cpp:2122
+#: ../src/splivarot.cpp:2126
 msgid "Inset path"
 msgstr "Pfad schrumpfen"
 
-#: ../src/splivarot.cpp:2124
+#: ../src/splivarot.cpp:2128
 msgid "<b>No paths</b> to inset/outset in the selection."
 msgstr "Die Auswahl enthält <b>keine Pfade</b> zum Schrumpfen/Erweitern."
 
-#: ../src/splivarot.cpp:2286
+#: ../src/splivarot.cpp:2290
 msgid "Simplifying paths (separately):"
 msgstr "Vereinfache Pfade (getrennt):"
 
-#: ../src/splivarot.cpp:2288
+#: ../src/splivarot.cpp:2292
 msgid "Simplifying paths:"
 msgstr "Vereinfache Pfade:"
 
-#: ../src/splivarot.cpp:2325
+#: ../src/splivarot.cpp:2329
 #, c-format
 msgid "%s <b>%d</b> of <b>%d</b> paths simplified..."
 msgstr "%s <b>%d</b> von <b>%d</b> Pfaden vereinfacht..."
 
-#: ../src/splivarot.cpp:2338
+#: ../src/splivarot.cpp:2342
 #, c-format
 msgid "<b>%d</b> paths simplified."
 msgstr "<b>%d</b> Pfade vereinfacht."
 
-#: ../src/splivarot.cpp:2352
+#: ../src/splivarot.cpp:2356
 msgid "Select <b>path(s)</b> to simplify."
 msgstr "<b>Pfad</b> zum Vereinfachen auswählen."
 
-#: ../src/splivarot.cpp:2368
+#: ../src/splivarot.cpp:2372
 msgid "<b>No paths</b> to simplify in the selection."
 msgstr "Die Auswahl enthält <b>keine Pfade</b> zum Vereinfachen."
 
@@ -14215,31 +14365,31 @@ msgid "The flowed text(s) must be <b>visible</b> in order to be put on a path."
 msgstr ""
 "Der Fließtext muss <b>sichtbar</b> sein, um einem Pfad zugewiesen zu werden."
 
-#: ../src/text-chemistry.cpp:181 ../src/verbs.cpp:2716
+#: ../src/text-chemistry.cpp:181 ../src/verbs.cpp:2746
 msgid "Put text on path"
 msgstr "Text an Pfad ausrichten"
 
-#: ../src/text-chemistry.cpp:193
+#: ../src/text-chemistry.cpp:192
 msgid "Select <b>a text on path</b> to remove it from path."
 msgstr "Einen <b>Text</b> zum Trennen von einem Pfad auswählen."
 
-#: ../src/text-chemistry.cpp:212
+#: ../src/text-chemistry.cpp:211
 msgid "<b>No texts-on-paths</b> in the selection."
 msgstr "<b>Kein Text an Pfad</b> in der Auswahl vorhanden."
 
-#: ../src/text-chemistry.cpp:215 ../src/verbs.cpp:2718
+#: ../src/text-chemistry.cpp:214 ../src/verbs.cpp:2748
 msgid "Remove text from path"
 msgstr "Text von Pfad trennen"
 
-#: ../src/text-chemistry.cpp:257 ../src/text-chemistry.cpp:277
+#: ../src/text-chemistry.cpp:256 ../src/text-chemistry.cpp:276
 msgid "Select <b>text(s)</b> to remove kerns from."
 msgstr "<b>Text</b> auswählen, um Kerning zu entfernen."
 
-#: ../src/text-chemistry.cpp:280
+#: ../src/text-chemistry.cpp:279
 msgid "Remove manual kerns"
 msgstr "Manuelle Unterschneidungen entfernen"
 
-#: ../src/text-chemistry.cpp:300
+#: ../src/text-chemistry.cpp:299
 msgid ""
 "Select <b>a text</b> and one or more <b>paths or shapes</b> to flow text "
 "into frame."
@@ -14247,32 +14397,32 @@ msgstr ""
 "Einen <b>Text</b> und <b>Pfad(e)</b> oder <b>Form(en)</b> zum Erzeugen eines "
 "Fließtextes auswählen."
 
-#: ../src/text-chemistry.cpp:369
+#: ../src/text-chemistry.cpp:368
 msgid "Flow text into shape"
 msgstr "Text in Form fließen lassen"
 
-#: ../src/text-chemistry.cpp:391
+#: ../src/text-chemistry.cpp:390
 msgid "Select <b>a flowed text</b> to unflow it."
 msgstr "<b>Fließtext</b> zum Aufheben auswählen."
 
-#: ../src/text-chemistry.cpp:464
+#: ../src/text-chemistry.cpp:461
 msgid "Unflow flowed text"
 msgstr "Fließtext aufheben"
 
-#: ../src/text-chemistry.cpp:476
+#: ../src/text-chemistry.cpp:473
 msgid "Select <b>flowed text(s)</b> to convert."
 msgstr "<b>Fließtext</b> zum Umwandeln auswählen."
 
-#: ../src/text-chemistry.cpp:494
+#: ../src/text-chemistry.cpp:491
 msgid "The flowed text(s) must be <b>visible</b> in order to be converted."
 msgstr ""
 "Der Fließtext muss <b>sichtbar</b> sein, um umgewandelt werden zu können."
 
-#: ../src/text-chemistry.cpp:521
+#: ../src/text-chemistry.cpp:518
 msgid "Convert flowed text to text"
 msgstr "Fließtext in Text umwandeln"
 
-#: ../src/text-chemistry.cpp:526
+#: ../src/text-chemistry.cpp:523
 msgid "<b>No flowed text(s)</b> to convert in the selection."
 msgstr "<b>Kein Fließtext</b> zum Umwandeln in der Auswahl."
 
@@ -14331,42 +14481,47 @@ msgid "Trace: Done. %ld nodes created"
 msgstr "Nachzeichnen: Abgeschlossen. %ld Knoten erstellt"
 
 #. check whether something is selected
-#: ../src/ui/clipboard.cpp:258
+#: ../src/ui/clipboard.cpp:259
 msgid "Nothing was copied."
 msgstr "Es wurde nichts kopiert."
 
-#: ../src/ui/clipboard.cpp:389 ../src/ui/clipboard.cpp:604
-#: ../src/ui/clipboard.cpp:633
+#: ../src/ui/clipboard.cpp:390 ../src/ui/clipboard.cpp:605
+#: ../src/ui/clipboard.cpp:634 ../src/ui/clipboard.cpp:666
 msgid "Nothing on the clipboard."
 msgstr "Es ist nichts in der Zwischenablage."
 
-#: ../src/ui/clipboard.cpp:446
+#: ../src/ui/clipboard.cpp:447
 msgid "Select <b>object(s)</b> to paste style to."
 msgstr "Objekt(e) auswählen, um Stil darauf anzuwenden."
 
-#: ../src/ui/clipboard.cpp:457 ../src/ui/clipboard.cpp:474
+#: ../src/ui/clipboard.cpp:458 ../src/ui/clipboard.cpp:475
 msgid "No style on the clipboard."
 msgstr "Kein Stil in der Zwischenablage."
 
-#: ../src/ui/clipboard.cpp:500
+#: ../src/ui/clipboard.cpp:501
 msgid "Select <b>object(s)</b> to paste size to."
 msgstr "<b>Objekt(e)</b> auswählen, um Größe einzufügen."
 
-#: ../src/ui/clipboard.cpp:508
+#: ../src/ui/clipboard.cpp:509
 msgid "No size on the clipboard."
 msgstr "Keine Größe in der Zwischenablage."
 
-#: ../src/ui/clipboard.cpp:565
+#: ../src/ui/clipboard.cpp:566
 msgid "Select <b>object(s)</b> to paste live path effect to."
 msgstr "<b>Objekt(e)</b> auswählen, um den Pfadeffekt einzufügen."
 
 #. no_effect:
-#: ../src/ui/clipboard.cpp:591
+#: ../src/ui/clipboard.cpp:592
 msgid "No effect on the clipboard."
 msgstr "Kein Effekt in der Zwischenablage."
 
-#: ../src/ui/clipboard.cpp:610 ../src/ui/clipboard.cpp:647
+#: ../src/ui/clipboard.cpp:611 ../src/ui/clipboard.cpp:648
 msgid "Clipboard does not contain a path."
+msgstr "Die Zwischenablage enthält keinen Pfad."
+
+#: ../src/ui/clipboard.cpp:697
+#, fuzzy
+msgid "Clipboard does not contain any."
 msgstr "Die Zwischenablage enthält keinen Pfad."
 
 #: ../src/ui/contextmenu.cpp:58
@@ -14407,7 +14562,7 @@ msgid "_Pop selection out of group"
 msgstr "Auswahl aus Gruppe herauslösen"
 
 #. Item dialog
-#: ../src/ui/contextmenu.cpp:323 ../src/verbs.cpp:3118
+#: ../src/ui/contextmenu.cpp:323 ../src/verbs.cpp:3152
 msgid "_Object Properties..."
 msgstr "_Objekteigenschaften..."
 
@@ -14455,7 +14610,7 @@ msgid "Create _Link"
 msgstr "_Verknüpfung erstellen"
 
 #. Set mask
-#: ../src/ui/contextmenu.cpp:421 ../src/ui/dialog/objects.cpp:1956
+#: ../src/ui/contextmenu.cpp:421 ../src/ui/dialog/objects.cpp:1918
 msgid "Set Mask"
 msgstr "Maske setzen"
 
@@ -14480,7 +14635,7 @@ msgid "Release C_lip"
 msgstr "Ausschneidemaske _freigeben"
 
 #. Group
-#: ../src/ui/contextmenu.cpp:472 ../src/verbs.cpp:2708
+#: ../src/ui/contextmenu.cpp:472 ../src/verbs.cpp:2738
 msgid "_Group"
 msgstr "_Gruppieren"
 
@@ -14489,7 +14644,7 @@ msgid "Create link"
 msgstr "Verknüpfung erstellen"
 
 #. Ungroup
-#: ../src/ui/contextmenu.cpp:578 ../src/verbs.cpp:2710
+#: ../src/ui/contextmenu.cpp:578 ../src/verbs.cpp:2740
 msgid "_Ungroup"
 msgstr "Grupp_ierung aufheben"
 
@@ -14524,7 +14679,7 @@ msgstr "Extern bearbeiten..."
 
 #. Trace Bitmap
 #. TRANSLATORS: "to trace" means "to convert a bitmap to vector graphics" (to vectorize)
-#: ../src/ui/contextmenu.cpp:676 ../src/verbs.cpp:2789
+#: ../src/ui/contextmenu.cpp:676 ../src/verbs.cpp:2819
 msgid "_Trace Bitmap..."
 msgstr "Bitmap _nachzeichnen..."
 
@@ -14546,43 +14701,35 @@ msgstr "Bild extrahieren..."
 #. Item dialog
 #. Fill and Stroke dialog
 #: ../src/ui/contextmenu.cpp:850 ../src/ui/contextmenu.cpp:870
-#: ../src/verbs.cpp:3081
+#: ../src/verbs.cpp:3115
 msgid "_Fill and Stroke..."
 msgstr "_Füllung und Kontur..."
 
 #. Edit Text dialog
-#: ../src/ui/contextmenu.cpp:876 ../src/verbs.cpp:3100
+#: ../src/ui/contextmenu.cpp:876 ../src/verbs.cpp:3134
 msgid "_Text and Font..."
 msgstr "_Text und Schriftart..."
 
 #. Spellcheck dialog
-#: ../src/ui/contextmenu.cpp:882 ../src/verbs.cpp:3108
+#: ../src/ui/contextmenu.cpp:882 ../src/verbs.cpp:3142
 msgid "Check Spellin_g..."
 msgstr "Rechtschreibprüfun_g..."
 
-#. *
-#. * Constructor
-#.
-#: ../src/ui/dialog/aboutbox.cpp:77
-msgid "About Inkscape"
-msgstr "Informationen über Inkscape"
+#: ../src/ui/dialog/aboutbox.cpp:87
+#, fuzzy
+msgid "Inkscape website"
+msgstr "Inkscape: _Grundlagen"
 
-# !!!
-#: ../src/ui/dialog/aboutbox.cpp:88
-msgid "_Splash"
-msgstr "_Begrüßung"
+#: ../src/ui/dialog/aboutbox.cpp:89
+msgid "© 2017 Inkscape Developers"
+msgstr ""
 
-#: ../src/ui/dialog/aboutbox.cpp:92
-msgid "_Authors"
-msgstr "_Autoren"
-
-#: ../src/ui/dialog/aboutbox.cpp:94
-msgid "_Translators"
-msgstr "Ü_bersetzer"
-
-#: ../src/ui/dialog/aboutbox.cpp:96
-msgid "_License"
-msgstr "_Lizenz"
+#: ../src/ui/dialog/aboutbox.cpp:90
+#, fuzzy
+msgid ""
+"Open Source Scalable Vector Graphics Editor\n"
+"Draw Freely."
+msgstr "Skalierbare Vektorgrafiken erstellen und bearbeiten"
 
 # Hier muss die deutsche Grafik, die bei der Inkscape-Info angezeigt werden soll, benannt werden!
 #. TRANSLATORS: This is the filename of the `About Inkscape' picture in
@@ -14590,16 +14737,20 @@ msgstr "_Lizenz"
 #. the filename of its translated version, e.g. about.zh.svg for Chinese.
 #.
 #. Please don't translate the filename unless the translated picture exists.
+#. Try to get the translated version of the 'About Inkscape' file first.  If the
+#. translation fails, or if the file does not exist, then fall-back to the
+#. default untranslated "about.svg" file
+#.
 #. FIXME? INKSCAPE_SCREENSDIR and "about.svg" are in UTF-8, not the
 #. native filename encoding... and the filename passed to sp_document_new
 #. should be in UTF-*8..
-#: ../src/ui/dialog/aboutbox.cpp:188
+#: ../src/ui/dialog/aboutbox.cpp:111
 msgid "about.svg"
 msgstr "about.svg"
 
 #. TRANSLATORS: Put here your name (and other national contributors')
 #. one per line in the form of: name surname (email). Use \n for newline.
-#: ../src/ui/dialog/aboutbox.cpp:458
+#: ../src/ui/dialog/aboutbox.cpp:179
 msgid "translator-credits"
 msgstr ""
 "Adib Taraben (theadib@gmail.com)\n"
@@ -14649,7 +14800,7 @@ msgstr "V:"
 
 #: ../src/ui/dialog/align-and-distribute.cpp:488
 #: ../src/ui/dialog/align-and-distribute.cpp:918
-#: ../src/widgets/connector-toolbar.cpp:404
+#: ../src/widgets/connector-toolbar.cpp:407
 msgid "Remove overlaps"
 msgstr "Überlappungen entfernen"
 
@@ -14683,7 +14834,7 @@ msgid "Rearrange"
 msgstr "Anordnen"
 
 #: ../src/ui/dialog/align-and-distribute.cpp:919
-#: ../src/widgets/toolbox.cpp:1291
+#: ../src/widgets/toolbox.cpp:1294
 msgid "Nodes"
 msgstr "Knoten"
 
@@ -14697,53 +14848,53 @@ msgid "_Treat selection as group: "
 msgstr "Auswahl als Gruppe behandeln:"
 
 #. Align
-#: ../src/ui/dialog/align-and-distribute.cpp:933 ../src/verbs.cpp:3218
-#: ../src/verbs.cpp:3219
+#: ../src/ui/dialog/align-and-distribute.cpp:933 ../src/verbs.cpp:3252
+#: ../src/verbs.cpp:3253
 msgid "Align right edges of objects to the left edge of the anchor"
 msgstr "Rechte Objektkanten an linker Seite der Verankerung ausrichten"
 
-#: ../src/ui/dialog/align-and-distribute.cpp:936 ../src/verbs.cpp:3220
-#: ../src/verbs.cpp:3221
+#: ../src/ui/dialog/align-and-distribute.cpp:936 ../src/verbs.cpp:3254
+#: ../src/verbs.cpp:3255
 msgid "Align left edges"
 msgstr "Linke Kanten ausrichten"
 
-#: ../src/ui/dialog/align-and-distribute.cpp:939 ../src/verbs.cpp:3222
-#: ../src/verbs.cpp:3223
+#: ../src/ui/dialog/align-and-distribute.cpp:939 ../src/verbs.cpp:3256
+#: ../src/verbs.cpp:3257
 msgid "Center on vertical axis"
 msgstr "Vertikal zentrieren"
 
-#: ../src/ui/dialog/align-and-distribute.cpp:942 ../src/verbs.cpp:3224
-#: ../src/verbs.cpp:3225
+#: ../src/ui/dialog/align-and-distribute.cpp:942 ../src/verbs.cpp:3258
+#: ../src/verbs.cpp:3259
 msgid "Align right sides"
 msgstr "Rechte Kanten ausrichten"
 
-#: ../src/ui/dialog/align-and-distribute.cpp:945 ../src/verbs.cpp:3226
-#: ../src/verbs.cpp:3227
+#: ../src/ui/dialog/align-and-distribute.cpp:945 ../src/verbs.cpp:3260
+#: ../src/verbs.cpp:3261
 msgid "Align left edges of objects to the right edge of the anchor"
 msgstr "Linke Objektkanten an rechter Seite der Verankerung ausrichten"
 
-#: ../src/ui/dialog/align-and-distribute.cpp:948 ../src/verbs.cpp:3228
-#: ../src/verbs.cpp:3229
+#: ../src/ui/dialog/align-and-distribute.cpp:948 ../src/verbs.cpp:3262
+#: ../src/verbs.cpp:3263
 msgid "Align bottom edges of objects to the top edge of the anchor"
 msgstr "Objektunterkanten an Oberkante der Verankerung ausrichten"
 
-#: ../src/ui/dialog/align-and-distribute.cpp:951 ../src/verbs.cpp:3230
-#: ../src/verbs.cpp:3231
+#: ../src/ui/dialog/align-and-distribute.cpp:951 ../src/verbs.cpp:3264
+#: ../src/verbs.cpp:3265
 msgid "Align top edges"
 msgstr "Oberkanten ausrichten"
 
-#: ../src/ui/dialog/align-and-distribute.cpp:954 ../src/verbs.cpp:3232
-#: ../src/verbs.cpp:3233
+#: ../src/ui/dialog/align-and-distribute.cpp:954 ../src/verbs.cpp:3266
+#: ../src/verbs.cpp:3267
 msgid "Center on horizontal axis"
 msgstr "Horizontal zentrieren"
 
-#: ../src/ui/dialog/align-and-distribute.cpp:957 ../src/verbs.cpp:3234
-#: ../src/verbs.cpp:3235
+#: ../src/ui/dialog/align-and-distribute.cpp:957 ../src/verbs.cpp:3268
+#: ../src/verbs.cpp:3269
 msgid "Align bottom edges"
 msgstr "Unterkanten ausrichten"
 
-#: ../src/ui/dialog/align-and-distribute.cpp:960 ../src/verbs.cpp:3236
-#: ../src/verbs.cpp:3237
+#: ../src/ui/dialog/align-and-distribute.cpp:960 ../src/verbs.cpp:3270
+#: ../src/verbs.cpp:3271
 msgid "Align top edges of objects to the bottom edge of the anchor"
 msgstr "Objektoberkanten an Unterkante der Verankerung ausrichten"
 
@@ -14796,7 +14947,7 @@ msgid "Distribute baselines of texts vertically"
 msgstr "Grundlinien der Textelemente vertikal gleichmäßig verteilen"
 
 #: ../src/ui/dialog/align-and-distribute.cpp:1011
-#: ../src/widgets/connector-toolbar.cpp:366
+#: ../src/widgets/connector-toolbar.cpp:369
 msgid "Nicely arrange selected connector network"
 msgstr "Das gewählte Netzwerk von Objektverbindern gefällig anordnen"
 
@@ -14867,8 +15018,8 @@ msgstr "Kleinstes Objekt"
 
 #: ../src/ui/dialog/align-and-distribute.cpp:1059
 #: ../src/ui/dialog/document-properties.cpp:145
-#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:1486
-#: ../src/widgets/desktop-widget.cpp:1984
+#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:1489
+#: ../src/widgets/desktop-widget.cpp:1997
 #: ../share/extensions/empty_page.inx.h:1
 #: ../share/extensions/voronoi2svg.inx.h:10
 msgid "Page"
@@ -14900,16 +15051,16 @@ msgid "Profile name:"
 msgstr "Profilname:"
 
 #: ../src/ui/dialog/calligraphic-profile-rename.cpp:54
-#: ../src/ui/dialog/guides.cpp:160 ../src/verbs.cpp:2627
+#: ../src/ui/dialog/guides.cpp:160 ../src/verbs.cpp:2657
 msgid "_Delete"
 msgstr "_Löschen"
 
 #: ../src/ui/dialog/calligraphic-profile-rename.cpp:59
-#: ../src/ui/dialog/export.cpp:1300
-#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:1053
-#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:1600
-#: ../src/ui/dialog/input.cpp:914 ../src/verbs.cpp:2565
-#: ../src/widgets/desktop-widget.cpp:1090
+#: ../src/ui/dialog/export.cpp:1297
+#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:1043
+#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:1603
+#: ../src/ui/dialog/input.cpp:915 ../src/verbs.cpp:2595
+#: ../src/widgets/desktop-widget.cpp:1103
 msgid "_Save"
 msgstr "_Speichern"
 
@@ -15603,16 +15754,16 @@ msgstr "<small>Das Objekt hat <b>%d</b> gekachelte Klone.</small>"
 msgid "<small>Object has no tiled clones.</small>"
 msgstr "<small>Das Objekt hat keine gekachelten Klone.</small>"
 
-#: ../src/ui/dialog/clonetiler.cpp:1939
+#: ../src/ui/dialog/clonetiler.cpp:1941
 msgid "Select <b>one object</b> whose tiled clones to unclump."
 msgstr ""
 "<b>Ein Objekt</b> auswählen, dessen gekachelte Klone entklumpt werden sollen."
 
-#: ../src/ui/dialog/clonetiler.cpp:1959
+#: ../src/ui/dialog/clonetiler.cpp:1961
 msgid "Unclump tiled clones"
 msgstr "Gekachelte Klone entklumpen"
 
-#: ../src/ui/dialog/clonetiler.cpp:1988
+#: ../src/ui/dialog/clonetiler.cpp:1990
 msgid "Select <b>one object</b> whose tiled clones to remove."
 msgstr ""
 "<b>Ein Objekt</b> auswählen, dessen gekachelte Klone entfernt werden sollen."
@@ -15638,15 +15789,15 @@ msgstr "<small>Gekachelte Klone erstellen...</small>"
 msgid "Create tiled clones"
 msgstr "Gekachelte Klone erzeugen"
 
-#: ../src/ui/dialog/clonetiler.cpp:2683
+#: ../src/ui/dialog/clonetiler.cpp:2682
 msgid "<small>Per row:</small>"
 msgstr "<small>Pro Reihe:</small>"
 
-#: ../src/ui/dialog/clonetiler.cpp:2697
+#: ../src/ui/dialog/clonetiler.cpp:2696
 msgid "<small>Per column:</small>"
 msgstr "<small>Pro Spalte:</small>"
 
-#: ../src/ui/dialog/clonetiler.cpp:2705
+#: ../src/ui/dialog/clonetiler.cpp:2704
 msgid "<small>Randomize:</small>"
 msgstr "<small>Zufallsfaktor:</small>"
 
@@ -15710,12 +15861,12 @@ msgstr "Nutzungsbedingungen - Lizenz"
 
 # !!!
 #: ../src/ui/dialog/document-metadata.cpp:115
-#: ../src/ui/dialog/document-properties.cpp:958
+#: ../src/ui/dialog/document-properties.cpp:970
 msgid "<b>Dublin Core Entities</b>"
 msgstr "<b>Dublin-Core-Entities</b>"
 
 #: ../src/ui/dialog/document-metadata.cpp:147
-#: ../src/ui/dialog/document-properties.cpp:1004
+#: ../src/ui/dialog/document-properties.cpp:1016
 msgid "<b>License</b>"
 msgstr "<b>Lizenz</b>"
 
@@ -15974,11 +16125,11 @@ msgstr "_Entfernen"
 msgid "Remove selected grid."
 msgstr "Ausgewähltes Gitter entfernen."
 
-#: ../src/ui/dialog/document-properties.cpp:146 ../src/widgets/toolbox.cpp:1398
+#: ../src/ui/dialog/document-properties.cpp:146 ../src/widgets/toolbox.cpp:1401
 msgid "Guides"
 msgstr "Hilfslinien"
 
-#: ../src/ui/dialog/document-properties.cpp:148 ../src/verbs.cpp:3030
+#: ../src/ui/dialog/document-properties.cpp:148 ../src/verbs.cpp:3064
 msgid "Snap"
 msgstr "Einrasten"
 
@@ -16030,183 +16181,184 @@ msgstr "<b>Verschiedenes</b>"
 #. Inkscape::GC::release(defsRepr);
 #. inform the document, so we can undo
 #. Color Management
-#: ../src/ui/dialog/document-properties.cpp:520 ../src/verbs.cpp:3202
+#: ../src/ui/dialog/document-properties.cpp:520 ../src/verbs.cpp:3236
 msgid "Link Color Profile"
 msgstr "Farbprofil verknüpfen"
 
-#: ../src/ui/dialog/document-properties.cpp:587
-#: ../src/ui/dialog/document-properties.cpp:597
-#: ../src/ui/dialog/document-properties.cpp:606
-#: ../src/ui/dialog/filter-effects-dialog.cpp:1308
-#: ../src/ui/dialog/svg-fonts-dialog.cpp:299
-#: ../src/ui/dialog/svg-fonts-dialog.cpp:308
-#: ../src/ui/dialog/svg-fonts-dialog.cpp:317
+#: ../src/ui/dialog/document-properties.cpp:599
+#: ../src/ui/dialog/document-properties.cpp:609
+#: ../src/ui/dialog/document-properties.cpp:618
+#: ../src/ui/dialog/filter-effects-dialog.cpp:1314
+#: ../src/ui/dialog/svg-fonts-dialog.cpp:311
+#: ../src/ui/dialog/svg-fonts-dialog.cpp:320
+#: ../src/ui/dialog/svg-fonts-dialog.cpp:329
 #, fuzzy
 msgid "_Remove"
 msgstr "_Entfernen"
 
-#: ../src/ui/dialog/document-properties.cpp:639
+#: ../src/ui/dialog/document-properties.cpp:651
 msgid "Remove linked color profile"
 msgstr "Verknüpftes Farbprofil entfernen"
 
-#: ../src/ui/dialog/document-properties.cpp:658
+#: ../src/ui/dialog/document-properties.cpp:670
 msgid "<b>Linked Color Profiles:</b>"
 msgstr "<b>Verknüpfte Farbprofile:</b>"
 
-#: ../src/ui/dialog/document-properties.cpp:660
+#: ../src/ui/dialog/document-properties.cpp:672
 msgid "<b>Available Color Profiles:</b>"
 msgstr "<b>Verfügbare Farbprofile:</b>"
 
-#: ../src/ui/dialog/document-properties.cpp:662
+#: ../src/ui/dialog/document-properties.cpp:674
 msgid "Link Profile"
 msgstr "Profil verknüpfen"
 
-#: ../src/ui/dialog/document-properties.cpp:665
+#: ../src/ui/dialog/document-properties.cpp:677
 msgid "Unlink Profile"
 msgstr "Profil entknüpfen"
 
-#: ../src/ui/dialog/document-properties.cpp:730
+#: ../src/ui/dialog/document-properties.cpp:742
 msgid "Profile Name"
 msgstr "Profilname"
 
-#: ../src/ui/dialog/document-properties.cpp:766
+#: ../src/ui/dialog/document-properties.cpp:778
 msgid "External scripts"
 msgstr "Externe Skripte"
 
-#: ../src/ui/dialog/document-properties.cpp:767
+#: ../src/ui/dialog/document-properties.cpp:779
 msgid "Embedded scripts"
 msgstr "Eingebettete Skripte"
 
-#: ../src/ui/dialog/document-properties.cpp:772
+#: ../src/ui/dialog/document-properties.cpp:784
 msgid "<b>External script files:</b>"
 msgstr "<b>Externe Skriptdateien:</b>"
 
-#: ../src/ui/dialog/document-properties.cpp:774
+#: ../src/ui/dialog/document-properties.cpp:786
 msgid "Add the current file name or browse for a file"
 msgstr ""
 "Fügen Sie den aktuellen Dateinamen hinzu oder suchen Sie nach einer Datei"
 
-#: ../src/ui/dialog/document-properties.cpp:777
-#: ../src/ui/dialog/document-properties.cpp:842
-#: ../src/ui/widget/selected-style.cpp:361
+#: ../src/ui/dialog/document-properties.cpp:789
+#: ../src/ui/dialog/document-properties.cpp:854
+#: ../src/ui/widget/selected-style.cpp:359
 msgid "Remove"
 msgstr "Entfernen"
 
-#: ../src/ui/dialog/document-properties.cpp:829
+#: ../src/ui/dialog/document-properties.cpp:841
 msgid "Filename"
 msgstr "Dateiname"
 
-#: ../src/ui/dialog/document-properties.cpp:837
+#: ../src/ui/dialog/document-properties.cpp:849
 msgid "<b>Embedded script files:</b>"
 msgstr "<b>Eingebettete Skriptdateien:</b>"
 
-#: ../src/ui/dialog/document-properties.cpp:839
-#: ../src/ui/dialog/objects.cpp:1920
+#. Name
+#: ../src/ui/dialog/document-properties.cpp:851
+#: ../src/ui/dialog/objects.cpp:1882 ../src/widgets/gradient-toolbar.cpp:875
 msgid "New"
 msgstr "Neu"
 
-#: ../src/ui/dialog/document-properties.cpp:882
+#: ../src/ui/dialog/document-properties.cpp:894
 msgid "Script id"
 msgstr "Skript-ID"
 
-#: ../src/ui/dialog/document-properties.cpp:888
+#: ../src/ui/dialog/document-properties.cpp:900
 msgid "<b>Content:</b>"
 msgstr "<b>Inhalt:</b>"
 
-#: ../src/ui/dialog/document-properties.cpp:984
+#: ../src/ui/dialog/document-properties.cpp:996
 msgid "_Save as default"
 msgstr "Als Standardeinstellung _speichern"
 
-#: ../src/ui/dialog/document-properties.cpp:985
+#: ../src/ui/dialog/document-properties.cpp:997
 msgid "Save this metadata as the default metadata"
 msgstr "Aktuelle Metadaten als Standard abspeichern"
 
-#: ../src/ui/dialog/document-properties.cpp:986
+#: ../src/ui/dialog/document-properties.cpp:998
 msgid "Use _default"
 msgstr "Standardeinstellungen _benutzen"
 
-#: ../src/ui/dialog/document-properties.cpp:987
+#: ../src/ui/dialog/document-properties.cpp:999
 msgid "Use the previously saved default metadata here"
 msgstr "Die zuvor gespeicherten Standardmetadaten verwenden"
 
 #. inform the document, so we can undo
-#: ../src/ui/dialog/document-properties.cpp:1046
+#: ../src/ui/dialog/document-properties.cpp:1058
 msgid "Add external script..."
 msgstr "Füge externes Skript hinzu..."
 
-#: ../src/ui/dialog/document-properties.cpp:1085
+#: ../src/ui/dialog/document-properties.cpp:1097
 msgid "Select a script to load"
 msgstr "Skript zum Laden auswählen"
 
 #. inform the document, so we can undo
-#: ../src/ui/dialog/document-properties.cpp:1113
+#: ../src/ui/dialog/document-properties.cpp:1125
 msgid "Add embedded script..."
 msgstr "Füge eingebettetes Skript hinzu..."
 
 #. inform the document, so we can undo
-#: ../src/ui/dialog/document-properties.cpp:1144
+#: ../src/ui/dialog/document-properties.cpp:1156
 msgid "Remove external script"
 msgstr "Lösche externes Skript"
 
 #. inform the document, so we can undo
-#: ../src/ui/dialog/document-properties.cpp:1173
+#: ../src/ui/dialog/document-properties.cpp:1185
 msgid "Remove embedded script"
 msgstr "Eingebettetes Skript entfernen"
 
 #. TODO repr->set_content(_EmbeddedContent.get_buffer()->get_text());
 #. inform the document, so we can undo
-#: ../src/ui/dialog/document-properties.cpp:1267
+#: ../src/ui/dialog/document-properties.cpp:1279
 msgid "Edit embedded script"
 msgstr "Eingebettetes Skript bearbeiten"
 
-#: ../src/ui/dialog/document-properties.cpp:1351
+#: ../src/ui/dialog/document-properties.cpp:1363
 msgid "<b>Creation</b>"
 msgstr "<b>Erzeugen</b>"
 
-#: ../src/ui/dialog/document-properties.cpp:1352
+#: ../src/ui/dialog/document-properties.cpp:1364
 msgid "<b>Defined grids</b>"
 msgstr "<b>Definierte Gitter</b>"
 
-#: ../src/ui/dialog/document-properties.cpp:1598
+#: ../src/ui/dialog/document-properties.cpp:1610
 msgid "Remove grid"
 msgstr "Gitter entfernen"
 
-#: ../src/ui/dialog/document-properties.cpp:1690
+#: ../src/ui/dialog/document-properties.cpp:1702
 msgid "Changed default display unit"
 msgstr "Änderung der Anzeigeeinheit"
 
-#: ../src/ui/dialog/export.cpp:124 ../src/verbs.cpp:3005
+#: ../src/ui/dialog/export.cpp:120 ../src/verbs.cpp:3039
 msgid "_Page"
 msgstr "_Seite"
 
-#: ../src/ui/dialog/export.cpp:124 ../src/verbs.cpp:3009
+#: ../src/ui/dialog/export.cpp:120 ../src/verbs.cpp:3043
 msgid "_Drawing"
 msgstr "_Zeichnung"
 
-#: ../src/ui/dialog/export.cpp:124 ../src/verbs.cpp:3011
+#: ../src/ui/dialog/export.cpp:120 ../src/verbs.cpp:3045
 msgid "_Selection"
 msgstr "_Auswahl"
 
-#: ../src/ui/dialog/export.cpp:124
+#: ../src/ui/dialog/export.cpp:120
 msgid "_Custom"
 msgstr "_Benutzerdefiniert"
 
-#: ../src/ui/dialog/export.cpp:142 ../src/widgets/measure-toolbar.cpp:286
-#: ../src/widgets/measure-toolbar.cpp:294
+#: ../src/ui/dialog/export.cpp:138 ../src/widgets/measure-toolbar.cpp:304
+#: ../src/widgets/measure-toolbar.cpp:312
 #: ../share/extensions/render_gears.inx.h:6
 msgid "Units:"
 msgstr "Einheiten:"
 
-#: ../src/ui/dialog/export.cpp:144
+#: ../src/ui/dialog/export.cpp:140
 msgid "_Export As..."
 msgstr "_Exportieren als..."
 
-#: ../src/ui/dialog/export.cpp:147
+#: ../src/ui/dialog/export.cpp:143
 msgid "B_atch export all selected objects"
 msgstr "Alle gewählten Objekte auf einmal exportieren"
 
 # !!! "export hints" are not clear to the user I guess
-#: ../src/ui/dialog/export.cpp:147
+#: ../src/ui/dialog/export.cpp:143
 msgid ""
 "Export each selected object into its own PNG file, using export hints if any "
 "(caution, overwrites without asking!)"
@@ -16215,200 +16367,200 @@ msgstr ""
 "Berücksichtigung von Exporthinweisen, wenn vorhanden (Vorsicht, überschreibt "
 "ohne Warnung!)"
 
-#: ../src/ui/dialog/export.cpp:148
+#: ../src/ui/dialog/export.cpp:144
 #, fuzzy
 msgid "Use interlacing"
 msgstr "Kantenglättung verwenden"
 
-#: ../src/ui/dialog/export.cpp:148
+#: ../src/ui/dialog/export.cpp:144
 msgid ""
 "Enables ADAM7 interlacing for PNG output. This results in slightly heavier "
 "images, but big images will look better sooner when loading the file"
 msgstr ""
 
-#: ../src/ui/dialog/export.cpp:149
+#: ../src/ui/dialog/export.cpp:145
 #, fuzzy
 msgid "Bit depth"
 msgstr "Z-Tiefe:"
 
-#: ../src/ui/dialog/export.cpp:151
+#: ../src/ui/dialog/export.cpp:147
 #, fuzzy
 msgid "Compression"
 msgstr "Textrichtung"
 
-#: ../src/ui/dialog/export.cpp:153
+#: ../src/ui/dialog/export.cpp:149
 msgid "pHYs dpi"
 msgstr ""
 
-#: ../src/ui/dialog/export.cpp:158
+#: ../src/ui/dialog/export.cpp:154
 #, fuzzy
 msgid "Hide all except selected"
 msgstr "Alle außer Ausgewählte verstecken"
 
-#: ../src/ui/dialog/export.cpp:158
+#: ../src/ui/dialog/export.cpp:154
 msgid "In the exported image, hide all objects except those that are selected"
 msgstr "Verstecke alle Objekte außer den gerade gewählten im exportierten Bild"
 
-#: ../src/ui/dialog/export.cpp:159
+#: ../src/ui/dialog/export.cpp:155
 msgid "Close when complete"
 msgstr "Schließen wenn fertig"
 
-#: ../src/ui/dialog/export.cpp:159
+#: ../src/ui/dialog/export.cpp:155
 msgid "Once the export completes, close this dialog"
 msgstr "Wenn der Export fertig ist, schließe den Dialog."
 
-#: ../src/ui/dialog/export.cpp:177
+#: ../src/ui/dialog/export.cpp:173
 msgid "<b>Export area</b>"
 msgstr "<b>Exportbereich</b>"
 
-#: ../src/ui/dialog/export.cpp:210
+#: ../src/ui/dialog/export.cpp:206
 msgid "_x0:"
 msgstr "_x0:"
 
-#: ../src/ui/dialog/export.cpp:214
+#: ../src/ui/dialog/export.cpp:210
 msgid "x_1:"
 msgstr "x_1:"
 
-#: ../src/ui/dialog/export.cpp:218
+#: ../src/ui/dialog/export.cpp:214
 msgid "Wid_th:"
 msgstr "Brei_te:"
 
-#: ../src/ui/dialog/export.cpp:222
+#: ../src/ui/dialog/export.cpp:218
 msgid "_y0:"
 msgstr "_y0:"
 
-#: ../src/ui/dialog/export.cpp:226
+#: ../src/ui/dialog/export.cpp:222
 msgid "y_1:"
 msgstr "y_1:"
 
-#: ../src/ui/dialog/export.cpp:230
+#: ../src/ui/dialog/export.cpp:226
 msgid "Hei_ght:"
 msgstr "Höhe:"
 
-#: ../src/ui/dialog/export.cpp:245
+#: ../src/ui/dialog/export.cpp:241
 msgid "<b>Image size</b>"
 msgstr "<b>Bildgröße</b>"
 
-#: ../src/ui/dialog/export.cpp:257 ../src/ui/dialog/export.cpp:268
+#: ../src/ui/dialog/export.cpp:253 ../src/ui/dialog/export.cpp:264
 msgid "pixels at"
 msgstr "Pixel bei"
 
-#: ../src/ui/dialog/export.cpp:263
+#: ../src/ui/dialog/export.cpp:259
 msgid "dp_i"
 msgstr "dp_i"
 
-#: ../src/ui/dialog/export.cpp:268 ../src/ui/dialog/transformation.cpp:69
+#: ../src/ui/dialog/export.cpp:264 ../src/ui/dialog/transformation.cpp:69
 #: ../src/ui/widget/page-sizer.cpp:221
 msgid "_Height:"
 msgstr "_Höhe:"
 
-#: ../src/ui/dialog/export.cpp:276
-#: ../src/ui/dialog/inkscape-preferences.cpp:1478
-#: ../src/ui/dialog/inkscape-preferences.cpp:1482
-#: ../src/ui/dialog/inkscape-preferences.cpp:1506
+#: ../src/ui/dialog/export.cpp:272
+#: ../src/ui/dialog/inkscape-preferences.cpp:1539
+#: ../src/ui/dialog/inkscape-preferences.cpp:1543
+#: ../src/ui/dialog/inkscape-preferences.cpp:1567
 msgid "dpi"
 msgstr "dpi"
 
-#: ../src/ui/dialog/export.cpp:284
+#: ../src/ui/dialog/export.cpp:280
 msgid "<b>_Filename</b>"
 msgstr "<b>_Dateiname</b>"
 
-#: ../src/ui/dialog/export.cpp:322
+#: ../src/ui/dialog/export.cpp:318
 msgid "_Export"
 msgstr "_Exportieren"
 
-#: ../src/ui/dialog/export.cpp:324
+#: ../src/ui/dialog/export.cpp:320
 msgid "Export the bitmap file with these settings"
 msgstr "Rastergrafik mit diesen Einstellungen exportieren"
 
 #. Advanced
-#: ../src/ui/dialog/export.cpp:330
+#: ../src/ui/dialog/export.cpp:326
 msgid "Advanced"
 msgstr ""
 
-#: ../src/ui/dialog/export.cpp:344
+#: ../src/ui/dialog/export.cpp:340
 msgid ""
 "Will force-set the physical dpi for the png file. Set this to 72 if you're "
 "planning to work on your png with Photoshop"
 msgstr ""
 
 # Example file name
-#: ../src/ui/dialog/export.cpp:484
+#: ../src/ui/dialog/export.cpp:480
 msgid "bitmap"
 msgstr "Rastergrafik"
 
-#: ../src/ui/dialog/export.cpp:591
+#: ../src/ui/dialog/export.cpp:587
 #, c-format
 msgid "B_atch export %d selected object"
 msgid_plural "B_atch export %d selected objects"
 msgstr[0] "B_atch-Export von %d gewähltem Objekt"
 msgstr[1] "B_atch-Export von %d gewählten Objekten"
 
-#: ../src/ui/dialog/export.cpp:907
+#: ../src/ui/dialog/export.cpp:903
 msgid "Export in progress"
 msgstr "Exportieren läuft"
 
-#: ../src/ui/dialog/export.cpp:1008
+#: ../src/ui/dialog/export.cpp:1005
 msgid "No items selected."
 msgstr "Kein Element gewählt."
 
-#: ../src/ui/dialog/export.cpp:1012 ../src/ui/dialog/export.cpp:1014
+#: ../src/ui/dialog/export.cpp:1009 ../src/ui/dialog/export.cpp:1011
 msgid "Exporting %1 files"
 msgstr "Exportiere %1 Dateien"
 
-#: ../src/ui/dialog/export.cpp:1056 ../src/ui/dialog/export.cpp:1058
+#: ../src/ui/dialog/export.cpp:1053 ../src/ui/dialog/export.cpp:1055
 #, c-format
 msgid "Exporting file <b>%s</b>..."
 msgstr "Exportiere Datei <b>%s</b>..."
 
-#: ../src/ui/dialog/export.cpp:1069 ../src/ui/dialog/export.cpp:1164
+#: ../src/ui/dialog/export.cpp:1066 ../src/ui/dialog/export.cpp:1161
 #, c-format
 msgid "Could not export to filename %s.\n"
 msgstr "Konnte nicht als Datei %s exportieren.\n"
 
-#: ../src/ui/dialog/export.cpp:1072
+#: ../src/ui/dialog/export.cpp:1069
 #, c-format
 msgid "Could not export to filename <b>%s</b>."
 msgstr "Konnte nicht als Datei <b>%s</b> exportieren."
 
-#: ../src/ui/dialog/export.cpp:1087
+#: ../src/ui/dialog/export.cpp:1084
 #, c-format
 msgid "Successfully exported <b>%d</b> files from <b>%d</b> selected items."
 msgstr ""
 "Erfolgreich <b>%d</b> Dateien aus <b>%d</b> ausgewählten Objekten exportiert."
 
-#: ../src/ui/dialog/export.cpp:1098
+#: ../src/ui/dialog/export.cpp:1095
 msgid "You have to enter a filename."
 msgstr "Sie müssen einen Dateinamen angeben"
 
-#: ../src/ui/dialog/export.cpp:1099
+#: ../src/ui/dialog/export.cpp:1096
 msgid "You have to enter a filename"
 msgstr "Sie müssen einen Dateinamen angeben"
 
-#: ../src/ui/dialog/export.cpp:1114
+#: ../src/ui/dialog/export.cpp:1111
 msgid "The chosen area to be exported is invalid."
 msgstr "Der zum Exportieren gewählte Bereich ist ungültig."
 
-#: ../src/ui/dialog/export.cpp:1115
+#: ../src/ui/dialog/export.cpp:1112
 msgid "The chosen area to be exported is invalid"
 msgstr "Der zum Exportieren gewählte Bereich ist ungültig"
 
-#: ../src/ui/dialog/export.cpp:1130
+#: ../src/ui/dialog/export.cpp:1127
 #, c-format
 msgid "Directory %s does not exist or is not a directory.\n"
 msgstr "Das Verzeichnis %s existiert nicht oder ist kein Verzeichnis.\n"
 
 #. TRANSLATORS: %1 will be the filename, %2 the width, and %3 the height of the image
-#: ../src/ui/dialog/export.cpp:1144 ../src/ui/dialog/export.cpp:1146
+#: ../src/ui/dialog/export.cpp:1141 ../src/ui/dialog/export.cpp:1143
 msgid "Exporting %1 (%2 x %3)"
 msgstr "Exportiere %1 (%2 x %3)"
 
-#: ../src/ui/dialog/export.cpp:1175
+#: ../src/ui/dialog/export.cpp:1172
 #, c-format
 msgid "Drawing exported to <b>%s</b>."
 msgstr "Zeichnung exportiert als <b>%s</b>."
 
-#: ../src/ui/dialog/export.cpp:1179
+#: ../src/ui/dialog/export.cpp:1176
 msgid "Export aborted."
 msgstr "Export abgebrochen."
 
@@ -16416,8 +16568,8 @@ msgstr "Export abgebrochen."
 msgid "Information"
 msgstr "Information"
 
-#: ../src/ui/dialog/extension-editor.cpp:79 ../src/verbs.cpp:304
-#: ../src/verbs.cpp:323 ../share/extensions/color_HSL_adjust.inx.h:11
+#: ../src/ui/dialog/extension-editor.cpp:79 ../src/verbs.cpp:307
+#: ../src/verbs.cpp:326 ../share/extensions/color_HSL_adjust.inx.h:11
 #: ../share/extensions/color_custom.inx.h:7
 #: ../share/extensions/color_randomize.inx.h:11
 #: ../share/extensions/dots.inx.h:7
@@ -16437,7 +16589,7 @@ msgstr "Information"
 #: ../share/extensions/gcodetools_tools_library.inx.h:18
 #: ../share/extensions/generate_voronoi.inx.h:5
 #: ../share/extensions/gimp_xcf.inx.h:7
-#: ../share/extensions/interp_att_g.inx.h:29
+#: ../share/extensions/interp_att_g.inx.h:32
 #: ../share/extensions/jessyInk_autoTexts.inx.h:8
 #: ../share/extensions/jessyInk_effects.inx.h:13
 #: ../share/extensions/jessyInk_export.inx.h:7
@@ -16469,98 +16621,98 @@ msgstr "Hilfe"
 msgid "Parameters"
 msgstr "Parameter"
 
-#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:531
+#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:527
 msgid "too large for preview"
 msgstr "zu groß für Vorschau"
 
-#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:617
+#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:613
 msgid "Enable preview"
 msgstr "Vorschau einschalten"
 
-#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:739
+#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:729
 #, fuzzy
 msgid "_Open"
 msgstr "Öffnen"
 
-#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:760
-#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:772
-#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:774
-#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:781
-#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:795
+#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:750
+#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:762
+#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:764
+#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:771
+#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:785
 #: ../src/ui/dialog/filedialogimpl-win32.cpp:267
 #: ../src/ui/dialog/filedialogimpl-win32.cpp:398
 msgid "All Files"
 msgstr "Alle Dateitypen"
 
-#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:778
-#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:792
+#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:768
+#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:782
 #: ../src/ui/dialog/filedialogimpl-win32.cpp:268
 msgid "All Inkscape Files"
 msgstr "Alle Inkscape-Dateien"
 
-#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:785
-#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:798
+#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:775
+#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:788
 #: ../src/ui/dialog/filedialogimpl-win32.cpp:269
 msgid "All Images"
 msgstr "Alle Bilder"
 
-#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:788
-#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:801
+#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:778
+#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:791
 #: ../src/ui/dialog/filedialogimpl-win32.cpp:270
 msgid "All Vectors"
 msgstr "Alle Vektorgrafiken"
 
-#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:791
-#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:804
+#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:781
+#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:794
 #: ../src/ui/dialog/filedialogimpl-win32.cpp:271
 msgid "All Bitmaps"
 msgstr "Alle Rastergrafiken"
 
 #. ###### File options
 #. ###### Do we want the .xxx extension automatically added?
-#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:997
-#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:1549
+#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:985
+#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:1552
 msgid "Append filename extension automatically"
 msgstr "Dateinamenserweiterung automatisch anhängen"
 
-#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:1164
-#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:1417
+#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:1171
+#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:1424
 msgid "Guess from extension"
 msgstr "Automatisch bestimmen"
 
-#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:1436
+#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:1443
 msgid "Left edge of source"
 msgstr "Linke Kante der Quelle"
 
-#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:1437
+#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:1444
 msgid "Top edge of source"
 msgstr "Oberkante der Quelle"
 
-#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:1438
+#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:1445
 msgid "Right edge of source"
 msgstr "Rechte Kante der Quelle"
 
-#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:1439
+#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:1446
 msgid "Bottom edge of source"
 msgstr "Unterkante der Quelle"
 
-#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:1440
+#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:1447
 msgid "Source width"
 msgstr "Quellenbreite"
 
-#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:1441
+#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:1448
 msgid "Source height"
 msgstr "Quellenhöhe"
 
-#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:1442
+#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:1449
 msgid "Destination width"
 msgstr "Zielbreite"
 
-#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:1443
+#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:1450
 msgid "Destination height"
 msgstr "Zielhöhe"
 
-#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:1444
+#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:1451
 msgid "Resolution (dots per inch)"
 msgstr "Auflösung (dpi)"
 
@@ -16568,32 +16720,32 @@ msgstr "Auflösung (dpi)"
 #. ## EXTRA WIDGET -- SOURCE SIDE
 #. #########################################
 #. ##### Export options buttons/spinners, etc
-#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:1482
+#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:1485
 #: ../share/extensions/docinfo.inx.h:4 ../share/extensions/dpi90to96.inx.h:2
 #: ../share/extensions/dpi96to90.inx.h:2
 msgid "Document"
 msgstr "Dokument"
 
-#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:1490 ../src/verbs.cpp:170
-#: ../src/widgets/desktop-widget.cpp:1992
+#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:1493 ../src/verbs.cpp:173
+#: ../src/widgets/desktop-widget.cpp:2005
 #: ../share/extensions/printing_marks.inx.h:18
 msgid "Selection"
 msgstr "Auswahl"
 
-#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:1494
+#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:1497
 msgctxt "Export dialog"
 msgid "Custom"
 msgstr "Benutzerdefiniert"
 
-#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:1514
+#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:1517
 msgid "Source"
 msgstr "Quelle"
 
-#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:1534
+#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:1537
 msgid "Cairo"
 msgstr "Cairo"
 
-#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:1537
+#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:1540
 msgid "Antialias"
 msgstr "Kantenglättung"
 
@@ -16609,20 +16761,20 @@ msgstr "Zeige Vorschau"
 msgid "No file selected"
 msgstr "Keine Datei ausgewählt"
 
-#: ../src/ui/dialog/fill-and-stroke.cpp:57
+#: ../src/ui/dialog/fill-and-stroke.cpp:59
 msgid "_Fill"
 msgstr "_Füllung"
 
-#: ../src/ui/dialog/fill-and-stroke.cpp:58
+#: ../src/ui/dialog/fill-and-stroke.cpp:60
 msgid "Stroke _paint"
 msgstr "_Farbe der Kontur"
 
-#: ../src/ui/dialog/fill-and-stroke.cpp:59
+#: ../src/ui/dialog/fill-and-stroke.cpp:61
 msgid "Stroke st_yle"
 msgstr "_Muster der Kontur"
 
 #. TRANSLATORS: this dialog is accessible via menu Filters - Filter editor
-#: ../src/ui/dialog/filter-effects-dialog.cpp:513
+#: ../src/ui/dialog/filter-effects-dialog.cpp:514
 msgid ""
 "This matrix determines a linear transform on color space. Each line affects "
 "one of the color components. Each column determines how much of each color "
@@ -16635,109 +16787,109 @@ msgstr ""
 "konstanten Grundwert der Ausgangskomponenten vor."
 
 # CHECK
-#: ../src/ui/dialog/filter-effects-dialog.cpp:516
+#: ../src/ui/dialog/filter-effects-dialog.cpp:517
 #: ../share/extensions/grid_polar.inx.h:4
 msgctxt "Label"
 msgid "None"
 msgstr "Keine"
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:623
+#: ../src/ui/dialog/filter-effects-dialog.cpp:624
 msgid "Image File"
 msgstr "Bilddatei"
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:626
+#: ../src/ui/dialog/filter-effects-dialog.cpp:627
 msgid "Selected SVG Element"
 msgstr "Gewähltes SVG-Element"
 
 #. TODO: any image, not just svg
-#: ../src/ui/dialog/filter-effects-dialog.cpp:696
+#: ../src/ui/dialog/filter-effects-dialog.cpp:697
 msgid "Select an image to be used as feImage input"
 msgstr "Ein Bild als Eingabe für Bild-Filterbaustein wählen"
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:788
+#: ../src/ui/dialog/filter-effects-dialog.cpp:789
 msgid "This SVG filter effect does not require any parameters."
 msgstr "Dieser SVG-Filtereffekt benötigt keine Parameter."
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:794
+#: ../src/ui/dialog/filter-effects-dialog.cpp:795
 msgid "This SVG filter effect is not yet implemented in Inkscape."
 msgstr "Dieser SVG-Filtereffekt ist noch nicht in Inkscape implementiert."
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:1019
+#: ../src/ui/dialog/filter-effects-dialog.cpp:1025
 msgid "Slope"
 msgstr "Steigung"
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:1020
+#: ../src/ui/dialog/filter-effects-dialog.cpp:1026
 msgid "Intercept"
 msgstr "Schnittpunkt"
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:1023
+#: ../src/ui/dialog/filter-effects-dialog.cpp:1029
 msgid "Amplitude"
 msgstr "Amplitude"
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:1024
+#: ../src/ui/dialog/filter-effects-dialog.cpp:1030
 msgid "Exponent"
 msgstr "Exponent"
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:1120
+#: ../src/ui/dialog/filter-effects-dialog.cpp:1126
 msgid "New transfer function type"
 msgstr "Neuer Übertragungsfunktionstyp"
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:1155
+#: ../src/ui/dialog/filter-effects-dialog.cpp:1161
 msgid "Light Source:"
 msgstr "Lichtquelle:"
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:1172
+#: ../src/ui/dialog/filter-effects-dialog.cpp:1178
 msgid "Direction angle for the light source on the XY plane, in degrees"
 msgstr "Winkel, aus dem das Licht in der XY-Ebene kommt, in °"
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:1173
+#: ../src/ui/dialog/filter-effects-dialog.cpp:1179
 msgid "Direction angle for the light source on the YZ plane, in degrees"
 msgstr "Winkel, aus dem das Licht in der YZ-Ebene kommt, in °"
 
 #. default x:
 #. default y:
 #. default z:
-#: ../src/ui/dialog/filter-effects-dialog.cpp:1176
-#: ../src/ui/dialog/filter-effects-dialog.cpp:1179
+#: ../src/ui/dialog/filter-effects-dialog.cpp:1182
+#: ../src/ui/dialog/filter-effects-dialog.cpp:1185
 msgid "Location:"
 msgstr "Ort:"
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:1176
-#: ../src/ui/dialog/filter-effects-dialog.cpp:1179
 #: ../src/ui/dialog/filter-effects-dialog.cpp:1182
+#: ../src/ui/dialog/filter-effects-dialog.cpp:1185
+#: ../src/ui/dialog/filter-effects-dialog.cpp:1188
 msgid "X coordinate"
 msgstr "X-Koordinate"
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:1176
-#: ../src/ui/dialog/filter-effects-dialog.cpp:1179
 #: ../src/ui/dialog/filter-effects-dialog.cpp:1182
+#: ../src/ui/dialog/filter-effects-dialog.cpp:1185
+#: ../src/ui/dialog/filter-effects-dialog.cpp:1188
 msgid "Y coordinate"
 msgstr "Y-Koordinate"
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:1176
-#: ../src/ui/dialog/filter-effects-dialog.cpp:1179
 #: ../src/ui/dialog/filter-effects-dialog.cpp:1182
+#: ../src/ui/dialog/filter-effects-dialog.cpp:1185
+#: ../src/ui/dialog/filter-effects-dialog.cpp:1188
 msgid "Z coordinate"
 msgstr "Z-Koordinate"
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:1182
+#: ../src/ui/dialog/filter-effects-dialog.cpp:1188
 msgid "Points At"
 msgstr "Zeigt auf"
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:1183
+#: ../src/ui/dialog/filter-effects-dialog.cpp:1189
 msgid "Specular Exponent"
 msgstr "Glanzpunkt-Exponent"
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:1183
+#: ../src/ui/dialog/filter-effects-dialog.cpp:1189
 msgid "Exponent value controlling the focus for the light source"
 msgstr "Exponent bestimmt den Fokus der Lichtquelle"
 
 #. TODO: here I have used 100 degrees as default value. But spec says that if not specified, no limiting cone is applied. So, there should be a way for the user to set a "no limiting cone" option.
-#: ../src/ui/dialog/filter-effects-dialog.cpp:1185
+#: ../src/ui/dialog/filter-effects-dialog.cpp:1191
 msgid "Cone Angle"
 msgstr "Konuswinkel"
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:1185
+#: ../src/ui/dialog/filter-effects-dialog.cpp:1191
 msgid ""
 "This is the angle between the spot light axis (i.e. the axis between the "
 "light source and the point to which it is pointing at) and the spot light "
@@ -16746,120 +16898,120 @@ msgstr ""
 "Öffnungswinkel des Lichtkegels (gemessen vom Zentralstrahl zum Rand). Kein "
 "Licht fällt außerhalb der Grenzen dieses Kegels."
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:1251
+#: ../src/ui/dialog/filter-effects-dialog.cpp:1257
 msgid "New light source"
 msgstr "Neue Lichtquelle"
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:1303
+#: ../src/ui/dialog/filter-effects-dialog.cpp:1309
 msgid "_Duplicate"
 msgstr "_Duplizieren"
 
 #. File
 #. Tag
-#: ../src/ui/dialog/filter-effects-dialog.cpp:1322
-#: ../src/ui/dialog/svg-fonts-dialog.cpp:987 ../src/verbs.cpp:2559
-#: ../src/verbs.cpp:2889
+#: ../src/ui/dialog/filter-effects-dialog.cpp:1328
+#: ../src/ui/dialog/svg-fonts-dialog.cpp:999 ../src/verbs.cpp:2589
+#: ../src/verbs.cpp:2923
 msgid "_New"
 msgstr "_Neu"
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:1337
+#: ../src/ui/dialog/filter-effects-dialog.cpp:1343
 msgid "_Filter"
 msgstr "_Filter"
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:1367
+#: ../src/ui/dialog/filter-effects-dialog.cpp:1373
 msgid "R_ename"
 msgstr "Umb_enennen"
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:1501
+#: ../src/ui/dialog/filter-effects-dialog.cpp:1507
 msgid "Rename filter"
 msgstr "Filter umbenennen"
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:1553
+#: ../src/ui/dialog/filter-effects-dialog.cpp:1559
 msgid "Apply filter"
 msgstr "Filter anwenden"
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:1633
+#: ../src/ui/dialog/filter-effects-dialog.cpp:1644
 msgid "filter"
 msgstr "Filter"
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:1640
+#: ../src/ui/dialog/filter-effects-dialog.cpp:1651
 msgid "Add filter"
 msgstr "Filter hinzufügen"
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:1690
+#: ../src/ui/dialog/filter-effects-dialog.cpp:1701
 msgid "Duplicate filter"
 msgstr "Filter duplizieren"
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:1762
+#: ../src/ui/dialog/filter-effects-dialog.cpp:1772
 msgid "_Effect"
 msgstr "_Effekt"
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:1772
+#: ../src/ui/dialog/filter-effects-dialog.cpp:1782
 msgid "Connections"
 msgstr "Verbindungen"
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:1911
+#: ../src/ui/dialog/filter-effects-dialog.cpp:1921
 msgid "Remove filter primitive"
 msgstr "Filterbaustein entfernen"
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2438
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2450
 msgid "Remove merge node"
 msgstr "Zusammengefassten Knoten löschen"
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2560
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2577
 msgid "Reorder filter primitive"
 msgstr "Filterbausteine umordnen"
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2615
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2632
 msgid "Add Effect:"
 msgstr "Effekt hinzufügen:"
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2616
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2633
 msgid "No effect selected"
 msgstr "Kein Effekt gewählt"
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2617
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2634
 msgid "No filter selected"
 msgstr "Kein Filter gewählt"
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2680
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2697
 msgid "Effect parameters"
 msgstr "Effektparameter"
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2681
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2698
 msgid "Filter General Settings"
 msgstr "Allgemeine Filtereinstellungen"
 
 #. default x:
 #. default y:
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2741
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2758
 msgid "Coordinates:"
 msgstr "Koordinaten:"
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2741
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2758
 msgid "X coordinate of the left corners of filter effects region"
 msgstr "X-Koordinate der linken Ecke des Ausschnitts, auf den Filter wirkt"
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2741
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2758
 msgid "Y coordinate of the upper corners of filter effects region"
 msgstr "Y-Koordinate der obere Ecke des Ausschnitts, auf den Filter wirkt"
 
 # Abmessungen?
 #. default width:
 #. default height:
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2742
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2759
 msgid "Dimensions:"
 msgstr "Dimensionen:"
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2742
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2759
 msgid "Width of filter effects region"
 msgstr "Breite des Filtereffekts"
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2742
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2759
 msgid "Height of filter effects region"
 msgstr "Höhe des Filtereffekts"
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2748
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2765
 msgid ""
 "Indicates the type of matrix operation. The keyword 'matrix' indicates that "
 "a full 5x4 matrix of values will be provided. The other keywords represent "
@@ -16871,41 +17023,41 @@ msgstr ""
 "für oft verwendete Farboperationen bereitstellen, ohne dass eine komplette "
 "Matrix angegeben werden muss."
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2749
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2766
 msgid "Value(s):"
 msgstr "Wert(e):"
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2753
-#: ../src/widgets/desktop-widget.cpp:648
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2770
+#: ../src/widgets/desktop-widget.cpp:662
 msgid "R:"
 msgstr "R:"
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2754
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2771
 #: ../src/ui/widget/color-icc-selector.cpp:158
 msgid "G:"
 msgstr "G:"
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2755
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2772
 msgid "B:"
 msgstr "B:"
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2756
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2773
 msgid "A:"
 msgstr "A:"
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2759
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2799
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2776
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2816
 msgid "Operator:"
 msgstr "Operator:"
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2760
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2777
 msgid "K1:"
 msgstr "K1:"
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2760
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2761
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2762
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2763
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2777
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2778
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2779
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2780
 msgid ""
 "If the arithmetic operation is chosen, each result pixel is computed using "
 "the formula k1*i1*i2 + k2*i1 + k3*i2 + k4 where i1 and i2 are the pixel "
@@ -16915,38 +17067,38 @@ msgstr ""
 "Formel k1*i1*i2 + k2*i1 + k3*i2 + k4 berechnet, wobei i1 und i2 die Werte "
 "der Eingangsbildpunkte sind."
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2761
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2778
 msgid "K2:"
 msgstr "K2:"
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2762
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2779
 msgid "K3:"
 msgstr "K3:"
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2763
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2780
 msgid "K4:"
 msgstr "K4:"
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2766
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2783
 msgid "Size:"
 msgstr "Größe:"
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2766
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2783
 msgid "width of the convolve matrix"
 msgstr "Breite der Faltungsmatrix"
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2766
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2783
 msgid "height of the convolve matrix"
 msgstr "Höhe der Faltungsmatrix"
 
 #. default x:
 #. default y:
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2767
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2784
 #: ../src/ui/dialog/object-attributes.cpp:45
 msgid "Target:"
 msgstr "Ziel:"
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2767
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2784
 msgid ""
 "X coordinate of the target point in the convolve matrix. The convolution is "
 "applied to pixels around this point."
@@ -16954,7 +17106,7 @@ msgstr ""
 "X-Koordinate des Zielpunktes der Faltung. Die Faltungsmatrix wirkt auf Pixel "
 "um diesen Punkt herum."
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2767
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2784
 msgid ""
 "Y coordinate of the target point in the convolve matrix. The convolution is "
 "applied to pixels around this point."
@@ -16963,11 +17115,11 @@ msgstr ""
 "um diesen Punkt herum."
 
 #. TRANSLATORS: for info on "Kernel", see http://en.wikipedia.org/wiki/Kernel_(matrix)
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2769
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2786
 msgid "Kernel:"
 msgstr "Faltungsmatrix:"
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2769
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2786
 msgid ""
 "This matrix describes the convolve operation that is applied to the input "
 "image in order to calculate the pixel colors at the output. Different "
@@ -16983,11 +17135,11 @@ msgstr ""
 "Richtung der Matrixdiagonalen), während eine Matrix mit konstanten Einträgen "
 "(außer 0) eine isotrope Unschärfe erzeugt."
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2771
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2788
 msgid "Divisor:"
 msgstr "Teiler:"
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2771
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2788
 msgid ""
 "After applying the kernelMatrix to the input image to yield a number, that "
 "number is divided by divisor to yield the final destination color value. A "
@@ -16999,11 +17151,11 @@ msgstr ""
 "Ist der Divisor die Summe der Matrixeinträge, so wird das Ergebnis eine "
 "gemittelte Farbintensität aufweisen."
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2772
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2789
 msgid "Bias:"
 msgstr "Grundwert:"
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2772
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2789
 msgid ""
 "This value is added to each component. This is useful to define a constant "
 "value as the zero response of the filter."
@@ -17011,11 +17163,11 @@ msgstr ""
 "Dieser Wert wird zu jeder Komponente hinzu addiert. Dies ergibt eine "
 "Grundantwort des Filters bei leerer Eingabe."
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2773
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2790
 msgid "Edge Mode:"
 msgstr "Kantenmodus:"
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2773
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2790
 msgid ""
 "Determines how to extend the input image as necessary with color values so "
 "that the matrix operations can be applied when the kernel is positioned at "
@@ -17025,13 +17177,13 @@ msgstr ""
 "erweitert wird, damit die Faltungsmatrix bis an die Kanten des Originals "
 "angewendet werden kann."
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2774
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2811
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2791
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2828
 msgid "Preserve Alpha"
 msgstr "Alphawert beibehalten"
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2774
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2811
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2791
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2828
 msgid "If set, the alpha channel won't be altered by this filter primitive."
 msgstr ""
 "Wenn aktiviert, wird der Alphakanal von diesem Filterbaustein nicht "
@@ -17039,22 +17191,22 @@ msgstr ""
 
 # The color itself is not diffuse. It's the color of the diffuse lighting source.
 #. default: white
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2777
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2794
 msgid "Diffuse Color:"
 msgstr "Farbe:"
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2777
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2816
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2794
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2833
 msgid "Defines the color of the light source"
 msgstr "Definiert die Farbe der Lichtquelle"
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2778
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2817
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2795
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2834
 msgid "Surface Scale:"
 msgstr "Oberflächenskalierung:"
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2778
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2817
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2795
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2834
 msgid ""
 "This value amplifies the heights of the bump map defined by the input alpha "
 "channel"
@@ -17062,59 +17214,59 @@ msgstr ""
 "Dieser Wert multipliziert die Oberflächenstruktur, die aus dem Alphakanal "
 "der Eingabe gewonnen wird."
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2779
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2818
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2796
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2835
 msgid "Constant:"
 msgstr "Konstante:"
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2779
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2818
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2796
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2835
 msgid "This constant affects the Phong lighting model."
 msgstr "Diese Größe beeinflusst die Phong-Beleuchtung."
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2780
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2820
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2797
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2837
 msgid "Kernel Unit Length:"
 msgstr "Größe der Faltungsmatrixeinheit:"
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2784
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2801
 msgid "This defines the intensity of the displacement effect."
 msgstr "Dies bestimmt die Stärke des Versatzeffekts."
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2785
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2802
 msgid "X displacement:"
 msgstr "X-Verschiebung:"
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2785
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2802
 msgid "Color component that controls the displacement in the X direction"
 msgstr "Farbkomponente, die den Versatz in X-Richtung bestimmt"
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2786
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2803
 msgid "Y displacement:"
 msgstr "Y-Verschiebung:"
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2786
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2803
 msgid "Color component that controls the displacement in the Y direction"
 msgstr "Farbkomponente, die den Versatz in Y-Richtung bestimmt"
 
 #. default: black
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2789
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2806
 msgid "Flood Color:"
 msgstr "Füllfarbe:"
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2789
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2806
 msgid "The whole filter region will be filled with this color."
 msgstr "Die gesamte Filterregion wird mit dieser Farbe gefüllt."
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2793
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2810
 msgid "Standard Deviation:"
 msgstr "Standardabweichung:"
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2793
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2810
 msgid "The standard deviation for the blur operation."
 msgstr "Die Standardabweichung für die Unschärfeoperation."
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2799
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2816
 msgid ""
 "Erode: performs \"thinning\" of input image.\n"
 "Dilate: performs \"fattenning\" of input image."
@@ -17122,67 +17274,67 @@ msgstr ""
 "Erodieren: \"Verdünnt\" das Eingangsbild.\n"
 "Weiten:\"Verdickt\" das Eingangsbild."
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2803
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2820
 msgid "Source of Image:"
 msgstr "Bildquelle:"
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2812
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2829
 msgid "Delta X:"
 msgstr "Delta X:"
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2812
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2829
 msgid "This is how far the input image gets shifted to the right"
 msgstr "Um diesen Betrag wird das Eingangsbild nach rechts verschoben."
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2813
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2830
 msgid "Delta Y:"
 msgstr "Delta Y:"
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2813
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2830
 msgid "This is how far the input image gets shifted downwards"
 msgstr "Um diesen Betrag wird das Eingangsbild nach unten verschoben."
 
 #. default: white
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2816
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2833
 msgid "Specular Color:"
 msgstr "Glanzpunktfarbe:"
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2819
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2836
 #: ../share/extensions/interp.inx.h:2
 msgid "Exponent:"
 msgstr "Exponent:"
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2819
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2836
 msgid "Exponent for specular term, larger is more \"shiny\"."
 msgstr "Exponent bestimmt Glanzlicht, größer ist \"glänzender\""
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2828
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2845
 msgid ""
 "Indicates whether the filter primitive should perform a noise or turbulence "
 "function."
 msgstr "Zeigt an, ob der Filterbaustein Rauschen oder Turbulenz erzeugt."
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2829
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2846
 msgid "Base Frequency:"
 msgstr "Basisfrequenz:"
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2830
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2847
 msgid "Octaves:"
 msgstr "Oktaven:"
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2831
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2848
 msgid "Seed:"
 msgstr "Startwert:"
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2831
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2848
 msgid "The starting number for the pseudo random number generator."
 msgstr "Startwert des Pseudozufallsgenerators"
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2843
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2860
 msgid "Add filter primitive"
 msgstr "Filterbaustein hinzufügen"
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2858
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2875
 msgid ""
 "The <b>feBlend</b> filter primitive provides 4 image blending modes: screen, "
 "multiply, darken and lighten."
@@ -17190,7 +17342,7 @@ msgstr ""
 "Der <b>Überlagern</b>-Filterbaustein sieht 4 Bild-Misch-Modi vor: Screen, "
 "Multiplizieren, Verdunkeln und Aufhellen."
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2862
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2879
 msgid ""
 "The <b>feColorMatrix</b> filter primitive applies a matrix transformation to "
 "color of each rendered pixel. This allows for effects like turning object to "
@@ -17200,7 +17352,7 @@ msgstr ""
 "die Farben der gerenderten Pixel an. Dies erlaubt Effekte wie Umwandeln in "
 "Graustufen, Modifizieren der Sättigung und Änderung des Farbtons."
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2866
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2883
 msgid ""
 "The <b>feComponentTransfer</b> filter primitive manipulates the input's "
 "color components (red, green, blue, and alpha) according to particular "
@@ -17212,7 +17364,7 @@ msgstr ""
 "festzulegender Transferfunktionen. Dies erlaubt Operationen wie Helligkeits- "
 "und Kontrasteinstellung, Farbbalance und Schwellwerte."
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2870
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2887
 msgid ""
 "The <b>feComposite</b> filter primitive composites two images using one of "
 "the Porter-Duff blending modes or the arithmetic mode described in SVG "
@@ -17225,7 +17377,7 @@ msgstr ""
 "Wesentlichen aus logischen Operationen zwischen den korrespondierenden Pixel-"
 "Werten der Bilder."
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2874
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2891
 msgid ""
 "The <b>feConvolveMatrix</b> lets you specify a Convolution to be applied on "
 "the image. Common effects created using convolution matrices are blur, "
@@ -17240,7 +17392,7 @@ msgstr ""
 "allerdings ist der spezialisierte Effekt schneller und von der Auflösung "
 "unabhängig."
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2878
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2895
 msgid ""
 "The <b>feDiffuseLighting</b> and feSpecularLighting filter primitives create "
 "\"embossed\" shadings.  The input's alpha channel is used to provide depth "
@@ -17252,7 +17404,7 @@ msgstr ""
 "Tiefeninformationen zu erhalten: deckende Bereiche werden angehoben, "
 "transparente abgesenkt."
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2882
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2899
 msgid ""
 "The <b>feDisplacementMap</b> filter primitive displaces the pixels in the "
 "first input using the second input as a displacement map, that shows from "
@@ -17264,7 +17416,7 @@ msgstr ""
 "definiert, woher die Pixel kommen sollen. Klassische Beispiele sind Wirbel- "
 "und Quetscheffekte."
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2886
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2903
 msgid ""
 "The <b>feFlood</b> filter primitive fills the region with a given color and "
 "opacity.  It is usually used as an input to other filters to apply color to "
@@ -17274,7 +17426,7 @@ msgstr ""
 "und Deckkraft. Normalerweise wird dies als Eingang für andere Filter "
 "verwendet, um so Farben ins Spiel zu bringen."
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2890
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2907
 msgid ""
 "The <b>feGaussianBlur</b> filter primitive uniformly blurs its input.  It is "
 "commonly used together with feOffset to create a drop shadow effect."
@@ -17283,7 +17435,7 @@ msgstr ""
 "Er wird normalerweise zusammen mit dem Filterbaustein Versatz benutzt, um "
 "abgesetzte Schatten zu erzeugen."
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2894
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2911
 msgid ""
 "The <b>feImage</b> filter primitive fills the region with an external image "
 "or another part of the document."
@@ -17291,7 +17443,7 @@ msgstr ""
 "Der Filterbaustein <b>Bild</b> füllt eine Region mit einem externen Bild "
 "oder einem anderen Teil des Dokuments."
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2898
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2915
 msgid ""
 "The <b>feMerge</b> filter primitive composites several temporary images "
 "inside the filter primitive to a single image. It uses normal alpha "
@@ -17303,7 +17455,7 @@ msgstr ""
 "zur Verwendung mehrerer „Überlagern“-Filterbausteine im Normalmodus oder "
 "mehrerer „Kombinieren“-Filterbausteine im „Über“-Modus."
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2902
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2919
 msgid ""
 "The <b>feMorphology</b> filter primitive provides erode and dilate effects. "
 "For single-color objects erode makes the object thinner and dilate makes it "
@@ -17313,7 +17465,7 @@ msgstr ""
 "„Weiten“ zur Verfügung. Für einfarbige Objekte wirkt „Erodieren“ ausdünnend "
 "und „Weiten“ verdickend."
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2906
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2923
 msgid ""
 "The <b>feOffset</b> filter primitive offsets the image by an user-defined "
 "amount. For example, this is useful for drop shadows, where the shadow is in "
@@ -17324,7 +17476,7 @@ msgstr ""
 "die sich an einer leicht anderen Position als das eigentliche Objekt "
 "befinden."
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2910
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2927
 msgid ""
 "The <b>feDiffuseLighting</b> and <b>feSpecularLighting</b> filter primitives "
 "create \"embossed\" shadings.  The input's alpha channel is used to provide "
@@ -17336,7 +17488,7 @@ msgstr ""
 "verwendet, um Tiefeninformationen zu erhalten: deckende Bereiche werden "
 "angehoben, transparente abgesenkt."
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2914
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2931
 msgid ""
 "The <b>feTile</b> filter primitive tiles a region with an input graphic. The "
 "source tile is defined by the filter primitive subregion of the input."
@@ -17345,7 +17497,7 @@ msgstr ""
 "Quellgrafik. Die Kachelgröße wird durch die Größe des Filterbausteins am "
 "Eingang bestimmt."
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2918
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2935
 msgid ""
 "The <b>feTurbulence</b> filter primitive renders Perlin noise. This kind of "
 "noise is useful in simulating several nature phenomena like clouds, fire and "
@@ -17355,11 +17507,11 @@ msgstr ""
 "Rauschen kann verwendet werden, um natürliche Phänomene wie Wolken, Feuer "
 "oder Rauch, sowie komplexe Texturen wie Marmor oder Granit nachzubilden."
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2938
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2955
 msgid "Duplicate filter primitive"
 msgstr "Filterbaustein duplizieren"
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:3018
+#: ../src/ui/dialog/filter-effects-dialog.cpp:3035
 msgid "Set filter primitive attribute"
 msgstr "Attribut für Filterbaustein setzen"
 
@@ -17406,7 +17558,7 @@ msgid "Limit search to the current selection"
 msgstr "Suche auf aktuelle Auswahl beschränken"
 
 #: ../src/ui/dialog/find.cpp:71 ../src/ui/dialog/text-edit.cpp:61
-#: ../share/ui/menus.xml.h:17
+#: ../share/ui/menus.xml.h:18
 msgid "_Text"
 msgstr "_Text"
 
@@ -17551,7 +17703,7 @@ msgstr "Spiralen"
 msgid "Search spirals"
 msgstr "Spiralen suchen"
 
-#: ../src/ui/dialog/find.cpp:96 ../src/widgets/toolbox.cpp:1299
+#: ../src/ui/dialog/find.cpp:96 ../src/widgets/toolbox.cpp:1302
 msgid "Paths"
 msgstr "Pfade"
 
@@ -18427,86 +18579,86 @@ msgstr "Bereich:"
 msgid "Append"
 msgstr "Hinzufügen"
 
-#: ../src/ui/dialog/glyphs.cpp:552
+#: ../src/ui/dialog/glyphs.cpp:550
 msgid "Append text"
 msgstr "Text hinzufügen"
 
-#: ../src/ui/dialog/grid-arrange-tab.cpp:340
+#: ../src/ui/dialog/grid-arrange-tab.cpp:338
 msgid "Arrange in a grid"
 msgstr "Gitterförmig anordnen:"
 
-#: ../src/ui/dialog/grid-arrange-tab.cpp:568
+#: ../src/ui/dialog/grid-arrange-tab.cpp:566
 #: ../src/ui/dialog/object-attributes.cpp:63
 #: ../src/ui/dialog/object-attributes.cpp:72
-#: ../src/ui/widget/page-sizer.cpp:230 ../src/widgets/desktop-widget.cpp:635
+#: ../src/ui/widget/page-sizer.cpp:232 ../src/widgets/desktop-widget.cpp:649
 #: ../src/widgets/node-toolbar.cpp:579
 msgid "X:"
 msgstr "X:"
 
-#: ../src/ui/dialog/grid-arrange-tab.cpp:568
+#: ../src/ui/dialog/grid-arrange-tab.cpp:566
 msgid "Horizontal spacing between columns."
 msgstr "Horizontale Abstände zwischen Spalten"
 
-#: ../src/ui/dialog/grid-arrange-tab.cpp:569
+#: ../src/ui/dialog/grid-arrange-tab.cpp:567
 #: ../src/ui/dialog/object-attributes.cpp:64
 #: ../src/ui/dialog/object-attributes.cpp:73
-#: ../src/ui/widget/page-sizer.cpp:231 ../src/widgets/desktop-widget.cpp:636
+#: ../src/ui/widget/page-sizer.cpp:233 ../src/widgets/desktop-widget.cpp:650
 #: ../src/widgets/node-toolbar.cpp:597
 msgid "Y:"
 msgstr "Y:"
 
-#: ../src/ui/dialog/grid-arrange-tab.cpp:569
+#: ../src/ui/dialog/grid-arrange-tab.cpp:567
 msgid "Vertical spacing between rows."
 msgstr "Vertikale Abstände zwischen Zeilen"
 
-#: ../src/ui/dialog/grid-arrange-tab.cpp:611
+#: ../src/ui/dialog/grid-arrange-tab.cpp:609
 msgid "_Rows:"
 msgstr "_Zeilen:"
 
-#: ../src/ui/dialog/grid-arrange-tab.cpp:621
+#: ../src/ui/dialog/grid-arrange-tab.cpp:619
 msgid "Number of rows"
 msgstr "Anzahl der Zeilen"
 
-#: ../src/ui/dialog/grid-arrange-tab.cpp:625
+#: ../src/ui/dialog/grid-arrange-tab.cpp:623
 msgid "Equal _height"
 msgstr "Gleiche Höhe"
 
-#: ../src/ui/dialog/grid-arrange-tab.cpp:636
+#: ../src/ui/dialog/grid-arrange-tab.cpp:634
 msgid "If not set, each row has the height of the tallest object in it"
 msgstr ""
 "Wenn nicht aktiviert, dann hat jede Zeile die Höhe des größten enthaltenen "
 "Objektes"
 
 #. #### Number of columns ####
-#: ../src/ui/dialog/grid-arrange-tab.cpp:653
+#: ../src/ui/dialog/grid-arrange-tab.cpp:651
 msgid "_Columns:"
 msgstr "Spalten:"
 
-#: ../src/ui/dialog/grid-arrange-tab.cpp:663
+#: ../src/ui/dialog/grid-arrange-tab.cpp:661
 msgid "Number of columns"
 msgstr "Anzahl der Spalten"
 
-#: ../src/ui/dialog/grid-arrange-tab.cpp:667
+#: ../src/ui/dialog/grid-arrange-tab.cpp:665
 msgid "Equal _width"
 msgstr "Gleiche Breite"
 
-#: ../src/ui/dialog/grid-arrange-tab.cpp:677
+#: ../src/ui/dialog/grid-arrange-tab.cpp:675
 msgid "If not set, each column has the width of the widest object in it"
 msgstr ""
 "Wenn nicht aktiviert, dann hat jede Spalte die Breite des größten "
 "enthaltenen Objektes"
 
 #. Anchor selection widget
-#: ../src/ui/dialog/grid-arrange-tab.cpp:689
+#: ../src/ui/dialog/grid-arrange-tab.cpp:687
 msgid "Alignment:"
 msgstr "Ausrichtung:"
 
 #. #### Radio buttons to control spacing manually or to fit selection bbox ####
-#: ../src/ui/dialog/grid-arrange-tab.cpp:699
+#: ../src/ui/dialog/grid-arrange-tab.cpp:697
 msgid "_Fit into selection box"
 msgstr "In den Auswahlrahmen _einpassen"
 
-#: ../src/ui/dialog/grid-arrange-tab.cpp:706
+#: ../src/ui/dialog/grid-arrange-tab.cpp:704
 msgid "_Set spacing:"
 msgstr "Abstände setzen:"
 
@@ -18566,53 +18718,53 @@ msgstr "Hilfslinien-ID: %s"
 msgid "Current: %s"
 msgstr "Aktuell: %s"
 
-#: ../src/ui/dialog/icon-preview.cpp:152
+#: ../src/ui/dialog/icon-preview.cpp:151
 #, c-format
 msgid "%d x %d"
 msgstr "%d × %d"
 
-#: ../src/ui/dialog/icon-preview.cpp:164
+#: ../src/ui/dialog/icon-preview.cpp:163
 msgid "Magnified:"
 msgstr "Vergrößert:"
 
-#: ../src/ui/dialog/icon-preview.cpp:232
+#: ../src/ui/dialog/icon-preview.cpp:231
 msgid "Actual Size:"
 msgstr "Tatsächliche Größe:"
 
-#: ../src/ui/dialog/icon-preview.cpp:237
+#: ../src/ui/dialog/icon-preview.cpp:236
 msgctxt "Icon preview window"
 msgid "Sele_ction"
 msgstr "Auswahl"
 
-#: ../src/ui/dialog/icon-preview.cpp:239
+#: ../src/ui/dialog/icon-preview.cpp:238
 msgid "Selection only or whole document"
 msgstr "Nur Auswahl oder ganzes Dokument"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:170
+#: ../src/ui/dialog/inkscape-preferences.cpp:202
 msgid "Show selection cue"
 msgstr "Auswahlmarkierung anzeigen"
 
 # !!! Frage? Passiv formulieren?
-#: ../src/ui/dialog/inkscape-preferences.cpp:171
+#: ../src/ui/dialog/inkscape-preferences.cpp:203
 msgid ""
 "Whether selected objects display a selection cue (the same as in selector)"
 msgstr ""
 "Ob ausgewählte Objekte optisch hervorgehoben werden sollen (wie beim "
 "Auswahlwerkzeug)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:177
+#: ../src/ui/dialog/inkscape-preferences.cpp:209
 msgid "Enable gradient editing"
 msgstr "Farbverlaufsbearbeitung aktiviert"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:178
+#: ../src/ui/dialog/inkscape-preferences.cpp:210
 msgid "Whether selected objects display gradient editing controls"
 msgstr "Ausgewählte Objekte zeigen Farbverlaufs-Anfasser an"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:183
+#: ../src/ui/dialog/inkscape-preferences.cpp:215
 msgid "Conversion to guides uses edges instead of bounding box"
 msgstr "Umwandlung zu Hilfslinien nutzt Objektkanten anstelle von Objektrahmen"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:184
+#: ../src/ui/dialog/inkscape-preferences.cpp:216
 msgid ""
 "Converting an object to guides places these along the object's true edges "
 "(imitating the object's shape), not along the bounding box"
@@ -18620,39 +18772,55 @@ msgstr ""
 "Wird ein Objekt zu Hilfslinien umgewandelt, so gelten die tatsächlichen "
 "Umrisse des Objekts, nicht der Objektrahmen."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:191
+#: ../src/ui/dialog/inkscape-preferences.cpp:223
 msgid "Ctrl+click _dot size:"
 msgstr "Punktgröße bei Strg+Klick:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:191
+#: ../src/ui/dialog/inkscape-preferences.cpp:223
 msgid "times current stroke width"
 msgstr "mal Konturbreite"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:192
+#: ../src/ui/dialog/inkscape-preferences.cpp:224
 msgid "Size of dots created with Ctrl+click (relative to current stroke width)"
 msgstr ""
 "Größe der Punkte, die durch Strg+Klick erzeugt werden (relativ zur aktuellen "
 "Konturbreite)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:200
+#: ../src/ui/dialog/inkscape-preferences.cpp:232
 msgid "Base simplify:"
 msgstr "Basisvereinfachung:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:200
+#: ../src/ui/dialog/inkscape-preferences.cpp:232
 msgid "on dynamic LPE simplify"
 msgstr "beim Vereinfachen über Pfadeffekt"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:201
+#: ../src/ui/dialog/inkscape-preferences.cpp:233
 msgid "Base simplify of dynamic LPE based simplify"
 msgstr ""
 "Basisvereinfachung beim Vereinfachen mit der Pfadeffekt basierten "
 "Vereinfachung"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:216
+#: ../src/ui/dialog/inkscape-preferences.cpp:241
+#, fuzzy
+msgid "Pressure change for new knot:"
+msgstr "Druckwinkel (Grad):"
+
+#: ../src/ui/dialog/inkscape-preferences.cpp:241
+#: ../src/ui/dialog/inkscape-preferences.cpp:1363
+msgid "%"
+msgstr "%"
+
+#: ../src/ui/dialog/inkscape-preferences.cpp:242
+msgid ""
+"Percentage increase / decrease of stylus pressure that is required to create "
+"a new PowerStroke knot."
+msgstr ""
+
+#: ../src/ui/dialog/inkscape-preferences.cpp:256
 msgid "<b>No objects selected</b> to take the style from."
 msgstr "<b>Objekte auswählen</b>, um Stil zu übernehmen."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:225
+#: ../src/ui/dialog/inkscape-preferences.cpp:265
 msgid ""
 "<b>More than one object selected.</b>  Cannot take style from multiple "
 "objects."
@@ -18660,23 +18828,23 @@ msgstr ""
 "<b>Mehr als ein Objekt ausgewählt.</b> Ein Stil kann nicht von mehreren "
 "Objekten übernommen werden."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:261
+#: ../src/ui/dialog/inkscape-preferences.cpp:301
 msgid "Style of new objects"
 msgstr "Stil von neuen Objekten"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:263
+#: ../src/ui/dialog/inkscape-preferences.cpp:303
 msgid "Last used style"
 msgstr "Zuletzt benutzter Stil"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:265
+#: ../src/ui/dialog/inkscape-preferences.cpp:305
 msgid "Apply the style you last set on an object"
 msgstr "Stil anwenden, der zuletzt für ein Objekt gesetzt wurde"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:269
+#: ../src/ui/dialog/inkscape-preferences.cpp:309
 msgid "This tool's own style:"
 msgstr "Stilvorgaben für dieses Werkzeug:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:273
+#: ../src/ui/dialog/inkscape-preferences.cpp:313
 msgid ""
 "Each tool may store its own style to apply to the newly created objects. Use "
 "the button below to set it."
@@ -18685,174 +18853,174 @@ msgstr ""
 "Objekte nutzen. Stilvorgabe mit der unteren Schaltfläche festlegen."
 
 #. style swatch
-#: ../src/ui/dialog/inkscape-preferences.cpp:277
+#: ../src/ui/dialog/inkscape-preferences.cpp:317
 msgid "Take from selection"
 msgstr "Aus Auswahl übernehmen"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:286
+#: ../src/ui/dialog/inkscape-preferences.cpp:326
 msgid "This tool's style of new objects"
 msgstr "Stilvorgaben für dieses Werkzeug für neue Objekte"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:293
+#: ../src/ui/dialog/inkscape-preferences.cpp:333
 msgid "Remember the style of the (first) selected object as this tool's style"
 msgstr ""
 "Stil des (ersten) ausgewählten Objektes zur Stilvorgabe für dieses Werkzeug "
 "machen"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:298
+#: ../src/ui/dialog/inkscape-preferences.cpp:338
 msgid "Tools"
 msgstr "Werkzeuge"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:301
+#: ../src/ui/dialog/inkscape-preferences.cpp:341
 msgid "Bounding box to use"
 msgstr "Zu verwendender Objektrahmen"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:302
+#: ../src/ui/dialog/inkscape-preferences.cpp:342
 msgid "Visual bounding box"
 msgstr "Visueller Objektrahmen"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:304
+#: ../src/ui/dialog/inkscape-preferences.cpp:344
 msgid "This bounding box includes stroke width, markers, filter margins, etc."
 msgstr ""
 "Dieser Objektrahmen berücksichtigt Strichbreiten, Knotenmarkierungen, "
 "Filterränder usw."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:305
+#: ../src/ui/dialog/inkscape-preferences.cpp:345
 msgid "Geometric bounding box"
 msgstr "Geometrischer Objektrahmen"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:307
+#: ../src/ui/dialog/inkscape-preferences.cpp:347
 msgid "This bounding box includes only the bare path"
 msgstr "Dieser Objektrahmen berücksichtigt nur den reinen Pfad"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:309
+#: ../src/ui/dialog/inkscape-preferences.cpp:349
 msgid "Conversion to guides"
 msgstr "Umwandlung in Hilfslinien"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:310
+#: ../src/ui/dialog/inkscape-preferences.cpp:350
 msgid "Keep objects after conversion to guides"
 msgstr "Behalte Objekte nach Umwandlung in Hilfslinien"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:312
+#: ../src/ui/dialog/inkscape-preferences.cpp:352
 msgid ""
 "When converting an object to guides, don't delete the object after the "
 "conversion"
 msgstr "Objekt bleibt erhalten, wenn es in Hilfslinien umgewandelt wird."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:313
+#: ../src/ui/dialog/inkscape-preferences.cpp:353
 msgid "Treat groups as a single object"
 msgstr "Behandle Gruppen als Einzelobjekte"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:315
+#: ../src/ui/dialog/inkscape-preferences.cpp:355
 msgid ""
 "Treat groups as a single object during conversion to guides rather than "
 "converting each child separately"
 msgstr ""
 "Gruppen werden als Ganzes (statt der Einzelteile) zu Hilfslinien umgewandelt."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:317
+#: ../src/ui/dialog/inkscape-preferences.cpp:357
 msgid "Average all sketches"
 msgstr "Aus allen Skizzenlinien mitteln"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:318
+#: ../src/ui/dialog/inkscape-preferences.cpp:358
 msgid "Width is in absolute units"
 msgstr "Breitenangabe in absoluten Einheiten"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:319
+#: ../src/ui/dialog/inkscape-preferences.cpp:359
 msgid "Select new path"
 msgstr "Neuen Pfad auswählen"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:320
+#: ../src/ui/dialog/inkscape-preferences.cpp:360
 msgid "Don't attach connectors to text objects"
 msgstr "Objektverbinder nicht mit Textobjekten verbinden"
 
 #. Selector
-#: ../src/ui/dialog/inkscape-preferences.cpp:323
+#: ../src/ui/dialog/inkscape-preferences.cpp:363
 msgid "Selector"
 msgstr "Auswahlwerkzeug"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:328
+#: ../src/ui/dialog/inkscape-preferences.cpp:368
 msgid "When transforming, show"
 msgstr "Zeige beim Transformieren"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:329
+#: ../src/ui/dialog/inkscape-preferences.cpp:369
 msgid "Objects"
 msgstr "Objekte"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:331
+#: ../src/ui/dialog/inkscape-preferences.cpp:371
 msgid "Show the actual objects when moving or transforming"
 msgstr "Zeige Objekte mit Inhalt beim Verschieben oder Verändern"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:332
+#: ../src/ui/dialog/inkscape-preferences.cpp:372
 msgid "Box outline"
 msgstr "Objektumriss"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:334
+#: ../src/ui/dialog/inkscape-preferences.cpp:374
 msgid "Show only a box outline of the objects when moving or transforming"
 msgstr "Nur einen Objektumriss beim Verschieben oder Verändern anzeigen"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:335
+#: ../src/ui/dialog/inkscape-preferences.cpp:375
 msgid "Per-object selection cue"
 msgstr "Pro Objekt-Auswahl"
 
 # CHECK
-#: ../src/ui/dialog/inkscape-preferences.cpp:336
+#: ../src/ui/dialog/inkscape-preferences.cpp:376
 msgctxt "Selection cue"
 msgid "None"
 msgstr "Keine"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:338
+#: ../src/ui/dialog/inkscape-preferences.cpp:378
 msgid "No per-object selection indication"
 msgstr "Keine Auswahlmarkierung für Objekte"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:339
+#: ../src/ui/dialog/inkscape-preferences.cpp:379
 msgid "Mark"
 msgstr "Markierung"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:341
+#: ../src/ui/dialog/inkscape-preferences.cpp:381
 msgid "Each selected object has a diamond mark in the top left corner"
 msgstr ""
 "Jedes ausgewählte Objekt hat eine diamantförmige Markierung in der linken "
 "oberen Ecke"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:342
+#: ../src/ui/dialog/inkscape-preferences.cpp:382
 msgid "Box"
 msgstr "Objektrahmen"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:344
+#: ../src/ui/dialog/inkscape-preferences.cpp:384
 msgid "Each selected object displays its bounding box"
 msgstr "Jedes gewählte Objekt zeigt seinen Objektrahmen"
 
 #. Node
-#: ../src/ui/dialog/inkscape-preferences.cpp:347
+#: ../src/ui/dialog/inkscape-preferences.cpp:387
 msgid "Node"
 msgstr "Knoten"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:350
+#: ../src/ui/dialog/inkscape-preferences.cpp:390
 msgid "Path outline"
 msgstr "Pfadumriss"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:351
+#: ../src/ui/dialog/inkscape-preferences.cpp:391
 msgid "Path outline color"
 msgstr "Entwurfspfad Farbe"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:352
+#: ../src/ui/dialog/inkscape-preferences.cpp:392
 msgid "Selects the color used for showing the path outline"
 msgstr "Die Farbe in der der Entwurfspfad angezeigt wird."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:353
+#: ../src/ui/dialog/inkscape-preferences.cpp:393
 msgid "Always show outline"
 msgstr "Umriss zeigen"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:354
+#: ../src/ui/dialog/inkscape-preferences.cpp:394
 msgid "Show outlines for all paths, not only invisible paths"
 msgstr "Zeigt Umrandung aller Pfade an, nicht nur von unsichtbaren Pfaden"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:355
+#: ../src/ui/dialog/inkscape-preferences.cpp:395
 msgid "Update outline when dragging nodes"
 msgstr "Umriss beim Ziehen von Knoten aktualisieren"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:356
+#: ../src/ui/dialog/inkscape-preferences.cpp:396
 msgid ""
 "Update the outline when dragging or transforming nodes; if this is off, the "
 "outline will only update when completing a drag"
@@ -18861,11 +19029,11 @@ msgstr ""
 "es deaktiviert ist, wird die Umrandung erst wieder aktualisiert, wenn die "
 "Aktion abgeschlossen ist."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:357
+#: ../src/ui/dialog/inkscape-preferences.cpp:397
 msgid "Update paths when dragging nodes"
 msgstr "Pfad beim Ziehen von Knoten aktualisieren"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:358
+#: ../src/ui/dialog/inkscape-preferences.cpp:398
 msgid ""
 "Update paths when dragging or transforming nodes; if this is off, paths will "
 "only be updated when completing a drag"
@@ -18874,11 +19042,11 @@ msgstr ""
 "deaktiviert ist, wird der Pfad erst aktualisiert, wenn die Aktion "
 "abgeschlossen ist."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:359
+#: ../src/ui/dialog/inkscape-preferences.cpp:399
 msgid "Show path direction on outlines"
 msgstr "Zeige die Pfadrichtung an Außenlinine"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:360
+#: ../src/ui/dialog/inkscape-preferences.cpp:400
 msgid ""
 "Visualize the direction of selected paths by drawing small arrows in the "
 "middle of each outline segment"
@@ -18886,30 +19054,30 @@ msgstr ""
 "Veranschaulichen Sie die Richtung der ausgewählten Pfade, in dem Sie kleine "
 "Pfeile in die Mitte jedes Rand-Segments zeichnen."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:361
+#: ../src/ui/dialog/inkscape-preferences.cpp:401
 msgid "Show temporary path outline"
 msgstr "Zeige temporär Pfadumrandung"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:362
+#: ../src/ui/dialog/inkscape-preferences.cpp:402
 msgid "When hovering over a path, briefly flash its outline"
 msgstr ""
 "Wenn die Maus über den Pfad bewegt wird, wird dessen Entwurfspfad kurz "
 "angezeigt."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:363
+#: ../src/ui/dialog/inkscape-preferences.cpp:403
 msgid "Show temporary outline for selected paths"
 msgstr "Zeige temporär Umrandung für ausgewählte Pfade"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:364
+#: ../src/ui/dialog/inkscape-preferences.cpp:404
 msgid "Show temporary outline even when a path is selected for editing"
 msgstr ""
 "Zeigt temporäre Umrandung an, wenn der Pfad zum Bearbeiten ausgewählt wurde."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:366
+#: ../src/ui/dialog/inkscape-preferences.cpp:406
 msgid "_Flash time:"
 msgstr "_Anzeigedauer:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:366
+#: ../src/ui/dialog/inkscape-preferences.cpp:406
 msgid ""
 "Specifies how long the path outline will be visible after a mouse-over (in "
 "milliseconds); specify 0 to have the outline shown until mouse leaves the "
@@ -18918,23 +19086,23 @@ msgstr ""
 "Bestimmt die Dauer der Pfadanzeige (in Millisekunden). Bei 0 wird der "
 "Entwurfspfad angezeigt bis die Maus den Bereich verlassen hat."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:367
+#: ../src/ui/dialog/inkscape-preferences.cpp:407
 msgid "Editing preferences"
 msgstr "Einstellungen bearbeiten"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:368
+#: ../src/ui/dialog/inkscape-preferences.cpp:408
 msgid "Show transform handles for single nodes"
 msgstr "Zeige Anfasser für einzelne Knoten"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:369
+#: ../src/ui/dialog/inkscape-preferences.cpp:409
 msgid "Show transform handles even when only a single node is selected"
 msgstr "Anfasser anzeigen, wenn nur ein einzelner Knoten ausgewählt ist."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:370
+#: ../src/ui/dialog/inkscape-preferences.cpp:410
 msgid "Deleting nodes preserves shape"
 msgstr "Knoten löschen, Form beibehalten"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:371
+#: ../src/ui/dialog/inkscape-preferences.cpp:411
 msgid ""
 "Move handles next to deleted nodes to resemble original shape; hold Ctrl to "
 "get the other behavior"
@@ -18943,31 +19111,31 @@ msgstr ""
 "Origianlform ähnelt; halten Sie für das andere Verhalten Strg gedrückt"
 
 #. Tweak
-#: ../src/ui/dialog/inkscape-preferences.cpp:374
+#: ../src/ui/dialog/inkscape-preferences.cpp:414
 msgid "Tweak"
 msgstr "Modellieren"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:375
+#: ../src/ui/dialog/inkscape-preferences.cpp:415
 msgid "Object paint style"
 msgstr "Objekt-Farbstil"
 
 #. Zoom
-#: ../src/ui/dialog/inkscape-preferences.cpp:380
-#: ../src/widgets/desktop-widget.cpp:574
+#: ../src/ui/dialog/inkscape-preferences.cpp:420
+#: ../src/widgets/desktop-widget.cpp:588
 msgid "Zoom"
 msgstr "Zoomfaktor"
 
 #. Measure
-#: ../src/ui/dialog/inkscape-preferences.cpp:385 ../src/verbs.cpp:2924
+#: ../src/ui/dialog/inkscape-preferences.cpp:425 ../src/verbs.cpp:2958
 msgctxt "ContextVerb"
 msgid "Measure"
 msgstr "Messen"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:387
+#: ../src/ui/dialog/inkscape-preferences.cpp:427
 msgid "Ignore first and last points"
 msgstr "Anfangs- und Endpunkt ignorieren"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:388
+#: ../src/ui/dialog/inkscape-preferences.cpp:428
 msgid ""
 "The start and end of the measurement tool's control line will not be "
 "considered for calculating lengths. Only lengths between actual curve "
@@ -18978,15 +19146,19 @@ msgstr ""
 "werden angezeigt."
 
 #. Shapes
-#: ../src/ui/dialog/inkscape-preferences.cpp:391
+#: ../src/ui/dialog/inkscape-preferences.cpp:431
 msgid "Shapes"
 msgstr "Formen"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:424
+#: ../src/ui/dialog/inkscape-preferences.cpp:464
+msgid "Pressure sensitivity settings"
+msgstr ""
+
+#: ../src/ui/dialog/inkscape-preferences.cpp:467
 msgid "Sketch mode"
 msgstr "Skizziermodus"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:426
+#: ../src/ui/dialog/inkscape-preferences.cpp:469
 msgid ""
 "If on, the sketch result will be the normal average of all sketches made, "
 "instead of averaging the old result with the new sketch"
@@ -18995,17 +19167,17 @@ msgstr ""
 "statt das alte Ergebnis mit der neuen Linie zu mitteln."
 
 #. Pen
-#: ../src/ui/dialog/inkscape-preferences.cpp:429
-#: ../src/ui/dialog/input.cpp:1311
+#: ../src/ui/dialog/inkscape-preferences.cpp:472
+#: ../src/ui/dialog/input.cpp:1312
 msgid "Pen"
 msgstr "Füller (Linien & Bézierkurven)"
 
 #. Calligraphy
-#: ../src/ui/dialog/inkscape-preferences.cpp:435
+#: ../src/ui/dialog/inkscape-preferences.cpp:478
 msgid "Calligraphy"
 msgstr "Kalligrafie"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:439
+#: ../src/ui/dialog/inkscape-preferences.cpp:482
 msgid ""
 "If on, pen width is in absolute units (px) independent of zoom; otherwise "
 "pen width depends on zoom so that it looks the same at any zoom"
@@ -19014,7 +19186,7 @@ msgstr ""
 "unabhängig vom Zoom; ansonsten hängt die Stiftbreite vom Zoom ab, so dass "
 "sie bei jeder Zoomeinstellung gleich aussieht"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:441
+#: ../src/ui/dialog/inkscape-preferences.cpp:484
 msgid ""
 "If on, each newly created object will be selected (deselecting previous "
 "selection)"
@@ -19023,27 +19195,27 @@ msgstr ""
 "Auswahl ist nicht mehr aktiv)"
 
 #. Text
-#: ../src/ui/dialog/inkscape-preferences.cpp:444 ../src/verbs.cpp:2916
+#: ../src/ui/dialog/inkscape-preferences.cpp:487 ../src/verbs.cpp:2950
 msgctxt "ContextVerb"
 msgid "Text"
 msgstr "Text"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:449
+#: ../src/ui/dialog/inkscape-preferences.cpp:492
 msgid "Show font samples in the drop-down list"
 msgstr "Zeigt Schriftart-Beispiele in der Auswahlliste"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:450
+#: ../src/ui/dialog/inkscape-preferences.cpp:493
 msgid ""
 "Show font samples alongside font names in the drop-down list in Text bar"
 msgstr ""
 "Zeigt Schriftart-Beispiele neben den Schriftartnamen in der Auswahlliste in "
 "der Textwerkzeugleiste"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:452
+#: ../src/ui/dialog/inkscape-preferences.cpp:495
 msgid "Show font substitution warning dialog"
 msgstr "Zeige Warndialog für Schriftersetzung"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:453
+#: ../src/ui/dialog/inkscape-preferences.cpp:496
 msgid ""
 "Show font substitution warning dialog when requested fonts are not available "
 "on the system"
@@ -19051,77 +19223,112 @@ msgstr ""
 "Zeigt Schriftartenersetzungs-Warnmeldung, wenn angeforderte Schriftarten auf "
 "dem System nicht verfügbar sind"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:456
+#: ../src/ui/dialog/inkscape-preferences.cpp:499
 msgid "Pixel"
 msgstr "Pixel"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:456
+#: ../src/ui/dialog/inkscape-preferences.cpp:499
 msgid "Pica"
 msgstr "Pica"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:456
+#: ../src/ui/dialog/inkscape-preferences.cpp:499
 msgid "Millimeter"
 msgstr "Millimeter"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:456
+#: ../src/ui/dialog/inkscape-preferences.cpp:499
 msgid "Centimeter"
 msgstr "Zentimeter"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:456
+#: ../src/ui/dialog/inkscape-preferences.cpp:499
 msgid "Inch"
 msgstr "Zoll"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:456
+#: ../src/ui/dialog/inkscape-preferences.cpp:499
 msgid "Em square"
 msgstr "Em-Quadrat"
 
 #. , _("Ex square"), _("Percent")
 #. , SP_CSS_UNIT_EX, SP_CSS_UNIT_PERCENT
-#: ../src/ui/dialog/inkscape-preferences.cpp:459
+#: ../src/ui/dialog/inkscape-preferences.cpp:502
 msgid "Text units"
 msgstr "Texteinheiten"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:461
+#: ../src/ui/dialog/inkscape-preferences.cpp:504
 msgid "Text size unit type:"
 msgstr "Textgrößen-Einheitstyp:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:462
+#: ../src/ui/dialog/inkscape-preferences.cpp:505
 msgid "Set the type of unit used in the text toolbar and text dialogs"
 msgstr ""
 "Setzt den Typ der Einheit, die in der Text-Werkzeugleiste und in "
 "Textdialogen verwendet wird"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:463
+#: ../src/ui/dialog/inkscape-preferences.cpp:506
 msgid "Always output text size in pixels (px)"
 msgstr "Ausgabe-Textgröße immer in Pixeln (px)"
 
+#. _page_text.add_line( false, "", _font_output_px, "", _("Always convert the text size units above into pixels (px) before saving to file"));
+#: ../src/ui/dialog/inkscape-preferences.cpp:509
+#, fuzzy
+msgid "Font directories"
+msgstr "Auswahlwerkzeug"
+
+#: ../src/ui/dialog/inkscape-preferences.cpp:510
+msgid "Use Inkscape's fonts directory"
+msgstr ""
+
+#: ../src/ui/dialog/inkscape-preferences.cpp:511
+msgid ""
+"Load additional fonts from \"fonts\" directory located in Inkscape's global "
+"\"share\" directory"
+msgstr ""
+
+#: ../src/ui/dialog/inkscape-preferences.cpp:512
+msgid "Use user's fonts directory"
+msgstr ""
+
+#: ../src/ui/dialog/inkscape-preferences.cpp:513
+msgid ""
+"Load additional fonts from \"fonts\" directory located in Inkscape's user "
+"configuration directory"
+msgstr ""
+
+#: ../src/ui/dialog/inkscape-preferences.cpp:515
+#, fuzzy
+msgid "Additional font directories"
+msgstr "Zusätzlicher Postprozessor:"
+
+#: ../src/ui/dialog/inkscape-preferences.cpp:515
+msgid "Load additional fonts from custom locations (one path per line)"
+msgstr ""
+
 #. Spray
-#: ../src/ui/dialog/inkscape-preferences.cpp:469
+#: ../src/ui/dialog/inkscape-preferences.cpp:521
 msgid "Spray"
 msgstr "Spray"
 
 #. Eraser
-#: ../src/ui/dialog/inkscape-preferences.cpp:474
+#: ../src/ui/dialog/inkscape-preferences.cpp:526
 msgid "Eraser"
 msgstr "Radierer"
 
 #. Paint Bucket
-#: ../src/ui/dialog/inkscape-preferences.cpp:479
+#: ../src/ui/dialog/inkscape-preferences.cpp:531
 msgid "Paint Bucket"
 msgstr "Farbeimer"
 
 #. Gradient
-#: ../src/ui/dialog/inkscape-preferences.cpp:485
+#: ../src/ui/dialog/inkscape-preferences.cpp:537
 #: ../src/widgets/gradient-selector.cpp:134
 #: ../src/widgets/gradient-selector.cpp:280
 msgid "Gradient"
 msgstr "Farbverlauf"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:487
+#: ../src/ui/dialog/inkscape-preferences.cpp:539
 msgid "Prevent sharing of gradient definitions"
 msgstr "Keine gemeinsamen Verlaufsdefinitionen"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:489
+#: ../src/ui/dialog/inkscape-preferences.cpp:541
 msgid ""
 "When on, shared gradient definitions are automatically forked on change; "
 "uncheck to allow sharing of gradient definitions so that editing one object "
@@ -19131,11 +19338,11 @@ msgstr ""
 "sobald einer geändert wird. Andernfalls werden bei der Änderung eines "
 "Verlaufes sämtliche Objekte mit dem gleichen Verlauf ebenfalls geändert."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:490
+#: ../src/ui/dialog/inkscape-preferences.cpp:542
 msgid "Use legacy Gradient Editor"
 msgstr "Alten Farbverlaufseditor benutzen"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:492
+#: ../src/ui/dialog/inkscape-preferences.cpp:544
 msgid ""
 "When on, the Gradient Edit button in the Fill & Stroke dialog will show the "
 "legacy Gradient Editor dialog, when off the Gradient Tool will be used"
@@ -19144,11 +19351,11 @@ msgstr ""
 "Kontur Dialog den alten Verlaufs-Editor Dialog, wenn ausgeschaltet, wird das "
 "Verlaufswerkzeug verwendet."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:495
+#: ../src/ui/dialog/inkscape-preferences.cpp:547
 msgid "Linear gradient _angle:"
 msgstr "Winkel des linearen Farbverlaufs"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:496
+#: ../src/ui/dialog/inkscape-preferences.cpp:548
 msgid ""
 "Default angle of new linear gradients in degrees (clockwise from horizontal)"
 msgstr ""
@@ -19156,16 +19363,16 @@ msgstr ""
 "im Uhrzeigersinn)"
 
 #. Dropper
-#: ../src/ui/dialog/inkscape-preferences.cpp:500
+#: ../src/ui/dialog/inkscape-preferences.cpp:552
 msgid "Dropper"
 msgstr "Farbpipette"
 
 #. Connector
-#: ../src/ui/dialog/inkscape-preferences.cpp:505
+#: ../src/ui/dialog/inkscape-preferences.cpp:557
 msgid "Connector"
 msgstr "Objektverbinder"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:508
+#: ../src/ui/dialog/inkscape-preferences.cpp:560
 msgid "If on, connector attachment points will not be shown for text objects"
 msgstr ""
 "Wenn eingeschaltet, dann werden die Einrastpunkte nicht für Textobjekte "
@@ -19173,425 +19380,425 @@ msgstr ""
 
 #. LPETool
 #. disabled, because the LPETool is not finished yet.
-#: ../src/ui/dialog/inkscape-preferences.cpp:513
+#: ../src/ui/dialog/inkscape-preferences.cpp:565
 msgid "LPE Tool"
 msgstr "LPE-Werkzeug"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:520
+#: ../src/ui/dialog/inkscape-preferences.cpp:572
 msgid "Interface"
 msgstr "Benutzeroberfläche"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:523
+#: ../src/ui/dialog/inkscape-preferences.cpp:575
 msgid "System default"
 msgstr "Standardeinstellungen"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:524
+#: ../src/ui/dialog/inkscape-preferences.cpp:576
 msgid "Albanian (sq)"
 msgstr "Albanisch (sq)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:524
+#: ../src/ui/dialog/inkscape-preferences.cpp:576
 msgid "Amharic (am)"
 msgstr "Amharisch (am)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:524
+#: ../src/ui/dialog/inkscape-preferences.cpp:576
 msgid "Arabic (ar)"
 msgstr "Arabisch (ar)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:524
+#: ../src/ui/dialog/inkscape-preferences.cpp:576
 msgid "Armenian (hy)"
 msgstr "Armenisch (hy)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:524
+#: ../src/ui/dialog/inkscape-preferences.cpp:576
 msgid "Assamese (as)"
 msgstr "Assamesisch (as)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:524
+#: ../src/ui/dialog/inkscape-preferences.cpp:576
 msgid "Azerbaijani (az)"
 msgstr "Aserbeidschanisch (az)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:525
+#: ../src/ui/dialog/inkscape-preferences.cpp:577
 msgid "Basque (eu)"
 msgstr "Baskisch (eu)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:525
+#: ../src/ui/dialog/inkscape-preferences.cpp:577
 msgid "Belarusian (be)"
 msgstr "Belorussisch (be)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:525
+#: ../src/ui/dialog/inkscape-preferences.cpp:577
 msgid "Bulgarian (bg)"
 msgstr "Bulgarisch (bg)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:525
+#: ../src/ui/dialog/inkscape-preferences.cpp:577
 msgid "Bengali (bn)"
 msgstr "Bengalesisch (bn)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:525
+#: ../src/ui/dialog/inkscape-preferences.cpp:577
 msgid "Bengali/Bangladesh (bn_BD)"
 msgstr "Bengalesisch (bn_BD)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:525
+#: ../src/ui/dialog/inkscape-preferences.cpp:577
 msgid "Bodo (brx)"
 msgstr "Bodo (brx)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:525
+#: ../src/ui/dialog/inkscape-preferences.cpp:577
 msgid "Breton (br)"
 msgstr "Bretonisch (br)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:526
+#: ../src/ui/dialog/inkscape-preferences.cpp:578
 msgid "Catalan (ca)"
 msgstr "Katalanisch (ca)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:526
+#: ../src/ui/dialog/inkscape-preferences.cpp:578
 msgid "Valencian Catalan (ca@valencia)"
 msgstr "Valencianisches Katalan (ca@valencia)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:526
+#: ../src/ui/dialog/inkscape-preferences.cpp:578
 msgid "Chinese/China (zh_CN)"
 msgstr "Chinesisch/China (zh_CN)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:526
+#: ../src/ui/dialog/inkscape-preferences.cpp:578
 msgid "Chinese/Taiwan (zh_TW)"
 msgstr "Chinesisch/Taiwan (zh_TW)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:526
+#: ../src/ui/dialog/inkscape-preferences.cpp:578
 msgid "Croatian (hr)"
 msgstr "Kroatisch (hr)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:526
+#: ../src/ui/dialog/inkscape-preferences.cpp:578
 msgid "Czech (cs)"
 msgstr "Tschechisch (cs)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:527
+#: ../src/ui/dialog/inkscape-preferences.cpp:579
 msgid "Danish (da)"
 msgstr "Dänisch (da)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:527
+#: ../src/ui/dialog/inkscape-preferences.cpp:579
 msgid "Dogri (doi)"
 msgstr "Dogri (doi)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:527
+#: ../src/ui/dialog/inkscape-preferences.cpp:579
 msgid "Dutch (nl)"
 msgstr "Niderländisch (nl)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:527
+#: ../src/ui/dialog/inkscape-preferences.cpp:579
 msgid "Dzongkha (dz)"
 msgstr "Dzongkha (dz)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:528
+#: ../src/ui/dialog/inkscape-preferences.cpp:580
 msgid "German (de)"
 msgstr "Deutsch (de)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:528
+#: ../src/ui/dialog/inkscape-preferences.cpp:580
 msgid "Greek (el)"
 msgstr "Griechisch (el)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:529
+#: ../src/ui/dialog/inkscape-preferences.cpp:581
 msgid "English (en)"
 msgstr "Englisch (en)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:529
+#: ../src/ui/dialog/inkscape-preferences.cpp:581
 msgid "English/Australia (en_AU)"
 msgstr "Englisch/Australien (en_AU)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:529
+#: ../src/ui/dialog/inkscape-preferences.cpp:581
 msgid "English/Canada (en_CA)"
 msgstr "Englisch/Kanada (en_CA)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:529
+#: ../src/ui/dialog/inkscape-preferences.cpp:581
 msgid "English/Great Britain (en_GB)"
 msgstr "Englisch/Großbritannien (en_GB)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:529
+#: ../src/ui/dialog/inkscape-preferences.cpp:581
 msgid "Pig Latin (en_US@piglatin)"
 msgstr "Pig Latin (en_US@piglatin)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:529
+#: ../src/ui/dialog/inkscape-preferences.cpp:581
 msgid "Esperanto (eo)"
 msgstr "Esperanto (eo)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:529
+#: ../src/ui/dialog/inkscape-preferences.cpp:581
 msgid "Estonian (et)"
 msgstr "Estnisch (et)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:530
+#: ../src/ui/dialog/inkscape-preferences.cpp:582
 msgid "Farsi (fa)"
 msgstr "Farsi (fa)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:530
+#: ../src/ui/dialog/inkscape-preferences.cpp:582
 msgid "Finnish (fi)"
 msgstr "Finnisch (fi)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:530
+#: ../src/ui/dialog/inkscape-preferences.cpp:582
 msgid "French (fr)"
 msgstr "Französisch (fr)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:531
+#: ../src/ui/dialog/inkscape-preferences.cpp:583
 msgid "Galician (gl)"
 msgstr "Galizisch (gl)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:531
+#: ../src/ui/dialog/inkscape-preferences.cpp:583
 msgid "Gujarati (gu)"
 msgstr "Gujarati (gu)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:532
+#: ../src/ui/dialog/inkscape-preferences.cpp:584
 msgid "Hebrew (he)"
 msgstr "Hebräisch (he)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:532
+#: ../src/ui/dialog/inkscape-preferences.cpp:584
 msgid "Hindi (hi)"
 msgstr "Hindi (hi)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:532
+#: ../src/ui/dialog/inkscape-preferences.cpp:584
 msgid "Hungarian (hu)"
 msgstr "Ungarisch (hu)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:533
+#: ../src/ui/dialog/inkscape-preferences.cpp:585
 msgid "Icelandic (is)"
 msgstr "Isländisch (is)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:533
+#: ../src/ui/dialog/inkscape-preferences.cpp:585
 msgid "Indonesian (id)"
 msgstr "Indonesisch (id)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:533
+#: ../src/ui/dialog/inkscape-preferences.cpp:585
 msgid "Irish (ga)"
 msgstr "Irisch (ga)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:533
+#: ../src/ui/dialog/inkscape-preferences.cpp:585
 msgid "Italian (it)"
 msgstr "Italienisch (it)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:534
+#: ../src/ui/dialog/inkscape-preferences.cpp:586
 msgid "Japanese (ja)"
 msgstr "Japanisch (ja)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:535
+#: ../src/ui/dialog/inkscape-preferences.cpp:587
 msgid "Kannada (kn)"
 msgstr "Kannada (kn)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:535
+#: ../src/ui/dialog/inkscape-preferences.cpp:587
 #, fuzzy
 msgid "Kashmiri in Perso-Arabic script (ks@aran)"
 msgstr "Kashmiri in erweiterter arabischer Schrift (ks@aran)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:535
+#: ../src/ui/dialog/inkscape-preferences.cpp:587
 msgid "Kashmiri in Devanagari script (ks@deva)"
 msgstr "Kashmiri in Devanagari-Schrift (ks@deva)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:535
+#: ../src/ui/dialog/inkscape-preferences.cpp:587
 msgid "Khmer (km)"
 msgstr "Khmer (km)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:535
+#: ../src/ui/dialog/inkscape-preferences.cpp:587
 msgid "Kinyarwanda (rw)"
 msgstr "Kinyarwanda (rw)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:535
+#: ../src/ui/dialog/inkscape-preferences.cpp:587
 msgid "Konkani (kok)"
 msgstr "Konkani (kok)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:535
+#: ../src/ui/dialog/inkscape-preferences.cpp:587
 msgid "Konkani in Latin script (kok@latin)"
 msgstr "Konkani in lateinischer Schrift (sr@latin)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:535
+#: ../src/ui/dialog/inkscape-preferences.cpp:587
 msgid "Korean (ko)"
 msgstr "Koreanisch (ko)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:536
+#: ../src/ui/dialog/inkscape-preferences.cpp:588
 msgid "Latvian (lv)"
 msgstr "Lettisch (lv)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:536
+#: ../src/ui/dialog/inkscape-preferences.cpp:588
 msgid "Lithuanian (lt)"
 msgstr "Litauisch (lt)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:537
+#: ../src/ui/dialog/inkscape-preferences.cpp:589
 msgid "Macedonian (mk)"
 msgstr "Mazedonisch (mk)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:537
+#: ../src/ui/dialog/inkscape-preferences.cpp:589
 msgid "Maithili (mai)"
 msgstr "Maithili (mai)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:537
+#: ../src/ui/dialog/inkscape-preferences.cpp:589
 msgid "Malayalam (ml)"
 msgstr "Malayalam (ml)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:537
+#: ../src/ui/dialog/inkscape-preferences.cpp:589
 msgid "Manipuri (mni)"
 msgstr "Meitei (mni)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:537
+#: ../src/ui/dialog/inkscape-preferences.cpp:589
 msgid "Manipuri in Bengali script (mni@beng)"
 msgstr "Manipuri in bengalischer Schrift (mni@beng)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:537
+#: ../src/ui/dialog/inkscape-preferences.cpp:589
 msgid "Marathi (mr)"
 msgstr "Marathi (mr)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:537
+#: ../src/ui/dialog/inkscape-preferences.cpp:589
 msgid "Mongolian (mn)"
 msgstr "Mongolisch (mn)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:538
+#: ../src/ui/dialog/inkscape-preferences.cpp:590
 msgid "Nepali (ne)"
 msgstr "Nepalesisch (ne)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:538
+#: ../src/ui/dialog/inkscape-preferences.cpp:590
 msgid "Norwegian Bokmål (nb)"
 msgstr "Norwegisch/Bokmål (nb)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:538
+#: ../src/ui/dialog/inkscape-preferences.cpp:590
 msgid "Norwegian Nynorsk (nn)"
 msgstr "Norwegisch/Nynorsk (nn)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:539
+#: ../src/ui/dialog/inkscape-preferences.cpp:591
 msgid "Odia (or)"
 msgstr "Orya (or)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:540
+#: ../src/ui/dialog/inkscape-preferences.cpp:592
 msgid "Panjabi (pa)"
 msgstr "Panjabi (pa)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:540
+#: ../src/ui/dialog/inkscape-preferences.cpp:592
 msgid "Polish (pl)"
 msgstr "Polnisch (pl)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:540
+#: ../src/ui/dialog/inkscape-preferences.cpp:592
 msgid "Portuguese (pt)"
 msgstr "Portugisisch(pt)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:540
+#: ../src/ui/dialog/inkscape-preferences.cpp:592
 msgid "Portuguese/Brazil (pt_BR)"
 msgstr "Portugisisch/Brasilien (pt_BR)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:541
+#: ../src/ui/dialog/inkscape-preferences.cpp:593
 msgid "Romanian (ro)"
 msgstr "Rumänisch (ro)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:541
+#: ../src/ui/dialog/inkscape-preferences.cpp:593
 msgid "Russian (ru)"
 msgstr "Russisch (ru)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:542
+#: ../src/ui/dialog/inkscape-preferences.cpp:594
 msgid "Sanskrit (sa)"
 msgstr "Sanskrit (sa)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:542
+#: ../src/ui/dialog/inkscape-preferences.cpp:594
 msgid "Santali (sat)"
 msgstr "Santali (sat)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:542
+#: ../src/ui/dialog/inkscape-preferences.cpp:594
 msgid "Santali in Devanagari script (sat@deva)"
 msgstr "Santali in Devanagari-Schrift (sat@deva)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:542
+#: ../src/ui/dialog/inkscape-preferences.cpp:594
 msgid "Serbian (sr)"
 msgstr "Serbisch (sr)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:542
+#: ../src/ui/dialog/inkscape-preferences.cpp:594
 msgid "Serbian in Latin script (sr@latin)"
 msgstr "Serbisch in lateinischer Schrift (sr@latin)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:543
+#: ../src/ui/dialog/inkscape-preferences.cpp:595
 msgid "Sindhi (sd)"
 msgstr "Sindhi (sd)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:543
+#: ../src/ui/dialog/inkscape-preferences.cpp:595
 msgid "Sindhi in Devanagari script (sd@deva)"
 msgstr "Sindhi in Devanagari-Schrift (sd@deva)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:543
+#: ../src/ui/dialog/inkscape-preferences.cpp:595
 msgid "Slovak (sk)"
 msgstr "Slovakisch (sk)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:543
+#: ../src/ui/dialog/inkscape-preferences.cpp:595
 msgid "Slovenian (sl)"
 msgstr "Slovenisch (sl)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:543
+#: ../src/ui/dialog/inkscape-preferences.cpp:595
 msgid "Spanish (es)"
 msgstr "Spanisch (es)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:543
+#: ../src/ui/dialog/inkscape-preferences.cpp:595
 msgid "Spanish/Mexico (es_MX)"
 msgstr "Spanisch/Mexico (es_MX)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:543
+#: ../src/ui/dialog/inkscape-preferences.cpp:595
 msgid "Swedish (sv)"
 msgstr "Schwedisch (sv)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:544
+#: ../src/ui/dialog/inkscape-preferences.cpp:596
 msgid "Tamil (ta)"
 msgstr "Tamilisch (ta)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:544
+#: ../src/ui/dialog/inkscape-preferences.cpp:596
 msgid "Telugu (te)"
 msgstr "Telugu (te)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:544
+#: ../src/ui/dialog/inkscape-preferences.cpp:596
 msgid "Thai (th)"
 msgstr "Thai (th)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:544
+#: ../src/ui/dialog/inkscape-preferences.cpp:596
 msgid "Turkish (tr)"
 msgstr "Türkisch (tr)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:545
+#: ../src/ui/dialog/inkscape-preferences.cpp:597
 msgid "Ukrainian (uk)"
 msgstr "Ukrainisch (uk)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:545
+#: ../src/ui/dialog/inkscape-preferences.cpp:597
 msgid "Urdu (ur)"
 msgstr "Urdu (ur)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:546
+#: ../src/ui/dialog/inkscape-preferences.cpp:598
 msgid "Vietnamese (vi)"
 msgstr "Vietnamesisch (vi)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:598
+#: ../src/ui/dialog/inkscape-preferences.cpp:650
 msgid "Language (requires restart):"
 msgstr "Sprache (erfordert Neustart)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:599
+#: ../src/ui/dialog/inkscape-preferences.cpp:651
 msgid "Set the language for menus and number formats"
 msgstr "Sprache für Menüs und Zahlenformate setzen"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:602
+#: ../src/ui/dialog/inkscape-preferences.cpp:654
 msgctxt "Icon size"
 msgid "Larger"
 msgstr "Größer"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:602
+#: ../src/ui/dialog/inkscape-preferences.cpp:654
 msgctxt "Icon size"
 msgid "Large"
 msgstr "Groß"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:602
+#: ../src/ui/dialog/inkscape-preferences.cpp:654
 msgctxt "Icon size"
 msgid "Small"
 msgstr "Klein"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:602
+#: ../src/ui/dialog/inkscape-preferences.cpp:654
 msgctxt "Icon size"
 msgid "Smaller"
 msgstr "Kleiner"
 
 # !!! called "Commands Bar" in other places
-#: ../src/ui/dialog/inkscape-preferences.cpp:607
+#: ../src/ui/dialog/inkscape-preferences.cpp:659
 msgid "Toolbox icon size:"
 msgstr "Symbolgröße in der Werkzeugleiste"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:608
+#: ../src/ui/dialog/inkscape-preferences.cpp:660
 msgid "Set the size for the tool icons (requires restart)"
 msgstr "Größe der Werkzeugsymbole verändern (erfordert Neustart)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:611
+#: ../src/ui/dialog/inkscape-preferences.cpp:663
 msgid "Control bar icon size:"
 msgstr "Symbolgröße in Einstellungsleiste"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:612
+#: ../src/ui/dialog/inkscape-preferences.cpp:664
 msgid ""
 "Set the size for the icons in tools' control bars to use (requires restart)"
 msgstr ""
@@ -19599,22 +19806,22 @@ msgstr ""
 "Neustart)"
 
 # !!! called "Commands Bar" in other places
-#: ../src/ui/dialog/inkscape-preferences.cpp:615
+#: ../src/ui/dialog/inkscape-preferences.cpp:667
 msgid "Secondary toolbar icon size:"
 msgstr "Symbolgröße in zweiter Werkzeugleiste"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:616
+#: ../src/ui/dialog/inkscape-preferences.cpp:668
 msgid ""
 "Set the size for the icons in secondary toolbars to use (requires restart)"
 msgstr ""
 "Bestimmt die Größe der Piktogramme in untergeordneten Werkzeugleisten "
 "(erfordert Neustart)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:619
+#: ../src/ui/dialog/inkscape-preferences.cpp:671
 msgid "Work-around color sliders not drawing"
 msgstr "Abhilfe für nicht gezeichnete Farb-Schieberegler"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:621
+#: ../src/ui/dialog/inkscape-preferences.cpp:673
 msgid ""
 "When on, will attempt to work around bugs in certain GTK themes drawing "
 "color sliders"
@@ -19622,26 +19829,26 @@ msgstr ""
 "Wenn gewählt, wird versucht, den Fehler bzgl. nicht gezeichneter Farb-"
 "Schieberegler in manchen GTK-Themen zu umgehen."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:626
+#: ../src/ui/dialog/inkscape-preferences.cpp:678
 msgid "Clear list"
 msgstr "Liste löschen"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:629
+#: ../src/ui/dialog/inkscape-preferences.cpp:681
 msgid "Maximum documents in Open _Recent:"
 msgstr "Länge der \"letzte Dokumente\"-Liste:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:630
+#: ../src/ui/dialog/inkscape-preferences.cpp:682
 msgid ""
 "Set the maximum length of the Open Recent list in the File menu, or clear "
 "the list"
 msgstr ""
 "Die maximale Länge der Liste zuletzt geöffneter Dokumente im Menü „Datei“"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:633
+#: ../src/ui/dialog/inkscape-preferences.cpp:685
 msgid "_Zoom correction factor (in %):"
 msgstr "_Zoom Korrektur (in %)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:634
+#: ../src/ui/dialog/inkscape-preferences.cpp:686
 msgid ""
 "Adjust the slider until the length of the ruler on your screen matches its "
 "real length. This information is used when zooming to 1:1, 1:2, etc., to "
@@ -19651,11 +19858,11 @@ msgstr ""
 "Bildschirm der echten Größe entspricht. Diese Information wird genutzt, um "
 "beim Zoom auf 1:1, 1:2, usw. das Objekt in realistischen Größen darzustellen."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:637
+#: ../src/ui/dialog/inkscape-preferences.cpp:689
 msgid "Enable dynamic relayout for incomplete sections"
 msgstr "Dynamischer Neu-Entwurf für unvollständige Abschnitte"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:639
+#: ../src/ui/dialog/inkscape-preferences.cpp:691
 msgid ""
 "When on, will allow dynamic layout of components that are not completely "
 "finished being refactored"
@@ -19664,11 +19871,11 @@ msgstr ""
 "Komponenten, die noch nicht komplett beendet sind."
 
 #. show infobox
-#: ../src/ui/dialog/inkscape-preferences.cpp:642
+#: ../src/ui/dialog/inkscape-preferences.cpp:694
 msgid "Show filter primitives infobox (requires restart)"
 msgstr "Zeigt Informationen zu den Filterbausteinen (erfordert Neustart)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:644
+#: ../src/ui/dialog/inkscape-preferences.cpp:696
 msgid ""
 "Show icons and descriptions for the filter primitives available at the "
 "filter effects dialog"
@@ -19676,26 +19883,26 @@ msgstr ""
 "Symbole und Beschreibungen für die verfügbaren Filterbausteine im "
 "Filtereffektdialog anzeigen"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:647
-#: ../src/ui/dialog/inkscape-preferences.cpp:655
+#: ../src/ui/dialog/inkscape-preferences.cpp:699
+#: ../src/ui/dialog/inkscape-preferences.cpp:707
 msgid "Icons only"
 msgstr "nur Symbole"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:647
-#: ../src/ui/dialog/inkscape-preferences.cpp:655
+#: ../src/ui/dialog/inkscape-preferences.cpp:699
+#: ../src/ui/dialog/inkscape-preferences.cpp:707
 msgid "Text only"
 msgstr "nur Text"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:647
-#: ../src/ui/dialog/inkscape-preferences.cpp:655
+#: ../src/ui/dialog/inkscape-preferences.cpp:699
+#: ../src/ui/dialog/inkscape-preferences.cpp:707
 msgid "Icons and text"
 msgstr "Symbole und Text"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:652
+#: ../src/ui/dialog/inkscape-preferences.cpp:704
 msgid "Dockbar style (requires restart):"
 msgstr "Dockleistenstil (erfordert Neustart)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:653
+#: ../src/ui/dialog/inkscape-preferences.cpp:705
 msgid ""
 "Selects whether the vertical bars on the dockbar will show text labels, "
 "icons, or both"
@@ -19703,11 +19910,11 @@ msgstr ""
 "Wählt, ob vertikale Leisten auf der Dockleiste Beschriftungen, Symbole oder "
 "beides angezeigen"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:660
+#: ../src/ui/dialog/inkscape-preferences.cpp:712
 msgid "Switcher style (requires restart):"
 msgstr "Stil des Umschalters (erfordert Neustart):"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:661
+#: ../src/ui/dialog/inkscape-preferences.cpp:713
 msgid ""
 "Selects whether the dockbar switcher will show text labels, icons, or both"
 msgstr ""
@@ -19715,102 +19922,104 @@ msgstr ""
 "zeigt"
 
 #. Windows
-#: ../src/ui/dialog/inkscape-preferences.cpp:665
+#: ../src/ui/dialog/inkscape-preferences.cpp:717
 msgid "Save and restore window geometry for each document"
 msgstr "Fenstergeometrie für jedes Dokument speichern und wiederherstellen"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:666
+#: ../src/ui/dialog/inkscape-preferences.cpp:718
 msgid "Remember and use last window's geometry"
 msgstr "Geometrie des letzten Fensters merken und verwenden"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:667
+#: ../src/ui/dialog/inkscape-preferences.cpp:719
 msgid "Don't save window geometry"
 msgstr "Fenstergeometrie nicht speichern"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:669
+#: ../src/ui/dialog/inkscape-preferences.cpp:721
 msgid "Save and restore dialogs status"
 msgstr "Speichern und Wiederherstellen von Dialog-Status"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:670
-#: ../src/ui/dialog/inkscape-preferences.cpp:706
+#: ../src/ui/dialog/inkscape-preferences.cpp:722
+#: ../src/ui/dialog/inkscape-preferences.cpp:763
 msgid "Don't save dialogs status"
 msgstr "Dialogstatus nicht speichern"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:672
-#: ../src/ui/dialog/inkscape-preferences.cpp:714
+#: ../src/ui/dialog/inkscape-preferences.cpp:724
+#: ../src/ui/dialog/inkscape-preferences.cpp:771
 msgid "Dockable"
 msgstr "Andockbar"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:673
-#: ../src/ui/dialog/inkscape-preferences.cpp:716
+#: ../src/ui/dialog/inkscape-preferences.cpp:725
+#: ../src/ui/dialog/inkscape-preferences.cpp:773
 msgid "Floating"
 msgstr "Schwebend"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:676
+#: ../src/ui/dialog/inkscape-preferences.cpp:728
 msgid "Native open/save dialogs"
 msgstr "Native Dialoge für Öffnen/Speichern"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:677
+#: ../src/ui/dialog/inkscape-preferences.cpp:729
 msgid "GTK open/save dialogs"
 msgstr "GTK Dialoge für Öffnen/Speichern"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:679
+#: ../src/ui/dialog/inkscape-preferences.cpp:731
 msgid "Dialogs are hidden in taskbar"
 msgstr "Dialoge werden in der Fensterliste nicht angezeigt"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:680
+#: ../src/ui/dialog/inkscape-preferences.cpp:732
 msgid "Save and restore documents viewport"
 msgstr "Fenstergeometrie für jedes Dokument speichern und wiederherstellen"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:681
+#: ../src/ui/dialog/inkscape-preferences.cpp:733
 msgid "Zoom when window is resized"
 msgstr "Zeichnungsgröße ändern, wenn die Fenstergröße verändert wird"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:682
-msgid "Show close button on dialogs"
-msgstr "Schaltflächen zum Schließen von Dialogen zeigen"
-
-#: ../src/ui/dialog/inkscape-preferences.cpp:683
+#: ../src/ui/dialog/inkscape-preferences.cpp:734
 msgctxt "Dialog on top"
 msgid "None"
 msgstr "Nein"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:685
+#: ../src/ui/dialog/inkscape-preferences.cpp:736
 msgid "Aggressive"
 msgstr "Aggressiv"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:688
+#: ../src/ui/dialog/inkscape-preferences.cpp:739
+#, fuzzy
+msgctxt "Window size"
+msgid "Default"
+msgstr "Standard"
+
+#: ../src/ui/dialog/inkscape-preferences.cpp:740
 msgctxt "Window size"
 msgid "Small"
 msgstr "Klein"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:688
+#: ../src/ui/dialog/inkscape-preferences.cpp:741
 msgctxt "Window size"
 msgid "Large"
 msgstr "Groß"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:688
+#: ../src/ui/dialog/inkscape-preferences.cpp:742
 msgctxt "Window size"
 msgid "Maximized"
 msgstr "Maximiert"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:692
+#: ../src/ui/dialog/inkscape-preferences.cpp:749
 msgid "Default window size:"
 msgstr "Standard Fenstergröße:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:693
+#: ../src/ui/dialog/inkscape-preferences.cpp:750
 msgid "Set the default window size"
 msgstr "Standard Fenstergröße setzen:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:696
+#: ../src/ui/dialog/inkscape-preferences.cpp:753
 msgid "Saving window geometry (size and position)"
 msgstr "Fenstergeometrie speichern (Größe und Position):"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:698
+#: ../src/ui/dialog/inkscape-preferences.cpp:755
 msgid "Let the window manager determine placement of all windows"
 msgstr "Dem Fenstermanager die Platzierung aller Fenster entscheiden lassen"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:700
+#: ../src/ui/dialog/inkscape-preferences.cpp:757
 msgid ""
 "Remember and use the last window's geometry (saves geometry to user "
 "preferences)"
@@ -19818,7 +20027,7 @@ msgstr ""
 "Geometrie des letzten Fensters merken und verwenden (speichert Geometrie in "
 "Benutzereinstellungen)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:702
+#: ../src/ui/dialog/inkscape-preferences.cpp:759
 msgid ""
 "Save and restore window geometry for each document (saves geometry in the "
 "document)"
@@ -19826,11 +20035,11 @@ msgstr ""
 "Fenstergeometrie für jedes Dokument speichern und wiederherstellen "
 "(speichert Geometrie im Dokument)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:704
+#: ../src/ui/dialog/inkscape-preferences.cpp:761
 msgid "Saving dialogs status"
 msgstr "Dialogstatus speichern"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:708
+#: ../src/ui/dialog/inkscape-preferences.cpp:765
 msgid ""
 "Save and restore dialogs status (the last open windows dialogs are saved "
 "when it closes)"
@@ -19838,66 +20047,66 @@ msgstr ""
 "Speichern und Wiederherstellen von Dialog-Status (die letzten offenen "
 "Fenster Dialoge werden gespeichert, wenn sie geschlossen werden)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:712
+#: ../src/ui/dialog/inkscape-preferences.cpp:769
 msgid "Dialog behavior (requires restart)"
 msgstr "Dialogfensterverhalten (erfordert Neustart)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:718
+#: ../src/ui/dialog/inkscape-preferences.cpp:775
 msgid "Desktop integration"
 msgstr "Desktopintegration"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:720
+#: ../src/ui/dialog/inkscape-preferences.cpp:777
 msgid "Use Windows like open and save dialogs"
 msgstr ""
 "Ans Windows-Design angelehnte Dialoge für Öffnen und Speichern benutzen"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:722
+#: ../src/ui/dialog/inkscape-preferences.cpp:779
 msgid "Use GTK open and save dialogs "
 msgstr ""
 "Dialoge der Komponentenbibliothek GTK für Öffnen und Speichern benutzen"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:726
+#: ../src/ui/dialog/inkscape-preferences.cpp:783
 msgid "Dialogs on top:"
 msgstr "Dialoge immer im Vordergrund:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:729
+#: ../src/ui/dialog/inkscape-preferences.cpp:786
 msgid "Dialogs are treated as regular windows"
 msgstr "Dialoge werden wie normale Fenster behandelt"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:731
+#: ../src/ui/dialog/inkscape-preferences.cpp:788
 msgid "Dialogs stay on top of document windows"
 msgstr "Dialoge bleiben vor Dokumentenfenstern"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:733
+#: ../src/ui/dialog/inkscape-preferences.cpp:790
 msgid "Same as Normal but may work better with some window managers"
 msgstr ""
 "Wie „Normal“, aber funktioniert evtl. besser mit manchen Fenstermanagern"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:736
+#: ../src/ui/dialog/inkscape-preferences.cpp:793
 msgid "Dialog Transparency"
 msgstr "Dialog Transparenz"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:738
+#: ../src/ui/dialog/inkscape-preferences.cpp:795
 msgid "_Opacity when focused:"
 msgstr "Deckkraft wenn fokussiert:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:740
+#: ../src/ui/dialog/inkscape-preferences.cpp:797
 msgid "Opacity when _unfocused:"
 msgstr "Deckkraft wenn nicht fokussiert:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:742
+#: ../src/ui/dialog/inkscape-preferences.cpp:799
 msgid "_Time of opacity change animation:"
 msgstr "Zeit der Animation beim Ändern der Deckkraft:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:745
+#: ../src/ui/dialog/inkscape-preferences.cpp:802
 msgid "Miscellaneous"
 msgstr "Verschiedenes"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:748
+#: ../src/ui/dialog/inkscape-preferences.cpp:805
 msgid "Whether dialog windows are to be hidden in the window manager taskbar"
 msgstr "Sollen Dialogfenster in der Fensterliste nicht angezeigt werden?"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:751
+#: ../src/ui/dialog/inkscape-preferences.cpp:808
 msgid ""
 "Zoom drawing when document window is resized, to keep the same area visible "
 "(this is the default which can be changed in any window using the button "
@@ -19908,7 +20117,7 @@ msgstr ""
 "Fenster mit der Schaltfläche über dem rechten Rollbalken geändert werden "
 "kann)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:753
+#: ../src/ui/dialog/inkscape-preferences.cpp:810
 msgid ""
 "Save documents viewport (zoom and panning position). Useful to turn off when "
 "sharing version controlled files."
@@ -19917,101 +20126,97 @@ msgstr ""
 "Nützlich abzuschalten, wenn gemeinsame Versionskontrolle von Dateien "
 "verwendet wird."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:755
-msgid "Whether dialog windows have a close button (requires restart)"
-msgstr "Dialogfenster haben Schaltflächen zum Schließen (erfordert Neustart)"
-
-#: ../src/ui/dialog/inkscape-preferences.cpp:756
+#: ../src/ui/dialog/inkscape-preferences.cpp:811
 msgid "Windows"
 msgstr "Fenster"
 
 #. Grids
-#: ../src/ui/dialog/inkscape-preferences.cpp:759
+#: ../src/ui/dialog/inkscape-preferences.cpp:814
 msgid "Line color when zooming out"
 msgstr "Linienfarbe beim Herauszoomen"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:762
+#: ../src/ui/dialog/inkscape-preferences.cpp:817
 msgid "The gridlines will be shown in minor grid line color"
 msgstr "Die Gitterlinien werden in der Nebengitterlinienfarbe angezeigt"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:764
+#: ../src/ui/dialog/inkscape-preferences.cpp:819
 msgid "The gridlines will be shown in major grid line color"
 msgstr "Die Gitterlinien werden in der Hauptgitterlinienfarbe angezeigt"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:766
+#: ../src/ui/dialog/inkscape-preferences.cpp:821
 msgid "Default grid settings"
 msgstr "Standard-Gittereinstellungen"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:772
-#: ../src/ui/dialog/inkscape-preferences.cpp:797
+#: ../src/ui/dialog/inkscape-preferences.cpp:827
+#: ../src/ui/dialog/inkscape-preferences.cpp:852
 msgid "Grid units:"
 msgstr "Gitter Einheiten:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:777
-#: ../src/ui/dialog/inkscape-preferences.cpp:802
+#: ../src/ui/dialog/inkscape-preferences.cpp:832
+#: ../src/ui/dialog/inkscape-preferences.cpp:857
 msgid "Origin X:"
 msgstr "Ursprung X:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:778
-#: ../src/ui/dialog/inkscape-preferences.cpp:803
+#: ../src/ui/dialog/inkscape-preferences.cpp:833
+#: ../src/ui/dialog/inkscape-preferences.cpp:858
 msgid "Origin Y:"
 msgstr "Ursprung Y:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:783
+#: ../src/ui/dialog/inkscape-preferences.cpp:838
 msgid "Spacing X:"
 msgstr "Abstand X:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:784
-#: ../src/ui/dialog/inkscape-preferences.cpp:806
+#: ../src/ui/dialog/inkscape-preferences.cpp:839
+#: ../src/ui/dialog/inkscape-preferences.cpp:861
 msgid "Spacing Y:"
 msgstr "Abstand Y:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:786
-#: ../src/ui/dialog/inkscape-preferences.cpp:787
-#: ../src/ui/dialog/inkscape-preferences.cpp:811
-#: ../src/ui/dialog/inkscape-preferences.cpp:812
+#: ../src/ui/dialog/inkscape-preferences.cpp:841
+#: ../src/ui/dialog/inkscape-preferences.cpp:842
+#: ../src/ui/dialog/inkscape-preferences.cpp:866
+#: ../src/ui/dialog/inkscape-preferences.cpp:867
 msgid "Minor grid line color:"
 msgstr "Farbe der Nebengitterlinien:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:787
-#: ../src/ui/dialog/inkscape-preferences.cpp:812
+#: ../src/ui/dialog/inkscape-preferences.cpp:842
+#: ../src/ui/dialog/inkscape-preferences.cpp:867
 msgid "Color used for normal grid lines"
 msgstr "Farbe der normalen Gitterlinien"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:788
-#: ../src/ui/dialog/inkscape-preferences.cpp:789
-#: ../src/ui/dialog/inkscape-preferences.cpp:813
-#: ../src/ui/dialog/inkscape-preferences.cpp:814
+#: ../src/ui/dialog/inkscape-preferences.cpp:843
+#: ../src/ui/dialog/inkscape-preferences.cpp:844
+#: ../src/ui/dialog/inkscape-preferences.cpp:868
+#: ../src/ui/dialog/inkscape-preferences.cpp:869
 msgid "Major grid line color:"
 msgstr "Farbe der Hauptgitterlinien:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:789
-#: ../src/ui/dialog/inkscape-preferences.cpp:814
+#: ../src/ui/dialog/inkscape-preferences.cpp:844
+#: ../src/ui/dialog/inkscape-preferences.cpp:869
 msgid "Color used for major (highlighted) grid lines"
 msgstr "Farbe der dicken (hervorgehobenen) Gitterlinien"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:791
-#: ../src/ui/dialog/inkscape-preferences.cpp:816
+#: ../src/ui/dialog/inkscape-preferences.cpp:846
+#: ../src/ui/dialog/inkscape-preferences.cpp:871
 msgid "Major grid line every:"
 msgstr "Hauptgitterlinien alle:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:792
+#: ../src/ui/dialog/inkscape-preferences.cpp:847
 msgid "Show dots instead of lines"
 msgstr "Zeige Punkte anstelle von Linien"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:793
+#: ../src/ui/dialog/inkscape-preferences.cpp:848
 msgid "If set, display dots at gridpoints instead of gridlines"
 msgstr "Punkte anstelle von Gitterlinien verwenden"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:867
+#: ../src/ui/dialog/inkscape-preferences.cpp:922
 msgid "Input/Output"
 msgstr "Eingabe/Ausgabe"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:870
+#: ../src/ui/dialog/inkscape-preferences.cpp:925
 msgid "Use current directory for \"Save As ...\""
 msgstr "Verwende aktuelles Verzeichnis für \"Speichern unter...\""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:872
+#: ../src/ui/dialog/inkscape-preferences.cpp:927
 msgid ""
 "When this option is on, the \"Save as...\" and \"Save a Copy...\" dialogs "
 "will always open in the directory where the currently open document is; when "
@@ -20023,11 +20228,11 @@ msgstr ""
 "Dokuments öffnen. Ist sie deaktiviert, wird das Verzeichnis geöffnet in "
 "welchem die letzte Datei gespeichert wurde."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:874
+#: ../src/ui/dialog/inkscape-preferences.cpp:929
 msgid "Add label comments to printing output"
 msgstr "Beim Ausdruck Bezeichnerkommentare mitdrucken"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:876
+#: ../src/ui/dialog/inkscape-preferences.cpp:931
 msgid ""
 "When on, a comment will be added to the raw print output, marking the "
 "rendered output for an object with its label"
@@ -20035,11 +20240,11 @@ msgstr ""
 "Diese Option fügt der unbehandelten Druckausgabe einen Kommentar hinzu.\n"
 "Das zu druckende Objekt wird mit einem Bezeichner markiert."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:878
+#: ../src/ui/dialog/inkscape-preferences.cpp:933
 msgid "Add default metadata to new documents"
 msgstr "Fügt Standard Metadaten neuen Dokumenten hinzu"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:880
+#: ../src/ui/dialog/inkscape-preferences.cpp:935
 msgid ""
 "Add default metadata to new documents. Default metadata can be set from "
 "Document Properties->Metadata."
@@ -20047,15 +20252,15 @@ msgstr ""
 "Fügt Standardmetadaten in neue Dokumente ein. Standard-Metadaten können über "
 "Dokument-Eigenschaften-> Metadaten gesetzt werden."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:884
+#: ../src/ui/dialog/inkscape-preferences.cpp:939
 msgid "_Grab sensitivity:"
 msgstr "Anfass-Empfindlichkeit:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:884
+#: ../src/ui/dialog/inkscape-preferences.cpp:939
 msgid "pixels (requires restart)"
 msgstr "Pixel (erfordert Neustart)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:885
+#: ../src/ui/dialog/inkscape-preferences.cpp:940
 msgid ""
 "How close on the screen you need to be to an object to be able to grab it "
 "with mouse (in screen pixels)"
@@ -20063,37 +20268,37 @@ msgstr ""
 "Mindestentfernung des Mauszeigers zu einem Objekt, um es zu erfassen (in "
 "Pixeln)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:887
+#: ../src/ui/dialog/inkscape-preferences.cpp:942
 msgid "_Click/drag threshold:"
 msgstr "Schwellwert für Klicken/Ziehen:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:887
-#: ../src/ui/dialog/inkscape-preferences.cpp:1223
-#: ../src/ui/dialog/inkscape-preferences.cpp:1227
-#: ../src/ui/dialog/inkscape-preferences.cpp:1237
+#: ../src/ui/dialog/inkscape-preferences.cpp:942
+#: ../src/ui/dialog/inkscape-preferences.cpp:1278
+#: ../src/ui/dialog/inkscape-preferences.cpp:1282
+#: ../src/ui/dialog/inkscape-preferences.cpp:1292
 msgid "pixels"
 msgstr "Pixel"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:888
+#: ../src/ui/dialog/inkscape-preferences.cpp:943
 msgid ""
 "Maximum mouse drag (in screen pixels) which is considered a click, not a drag"
 msgstr ""
 "Maximale Bewegung des Zeigers (in Pixeln), bei der noch Klicken statt Ziehen "
 "interpretiert wird"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:891
+#: ../src/ui/dialog/inkscape-preferences.cpp:946
 msgid "_Handle size:"
 msgstr "Anfassergröße:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:892
+#: ../src/ui/dialog/inkscape-preferences.cpp:947
 msgid "Set the relative size of node handles"
 msgstr "Relative Größe der Knotenanfasser setzen"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:894
+#: ../src/ui/dialog/inkscape-preferences.cpp:949
 msgid "Use pressure-sensitive tablet (requires restart)"
 msgstr "Druckempfindliches Grafiktablett verwenden (erfordert Neustart)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:896
+#: ../src/ui/dialog/inkscape-preferences.cpp:951
 msgid ""
 "Use the capabilities of a tablet or other pressure-sensitive device. Disable "
 "this only if you have problems with the tablet (you can still use it as a "
@@ -20103,27 +20308,27 @@ msgstr ""
 "Geräts verwenden. Schalten Sie dies nur aus, wenn Sie Probleme mit dem Gerät "
 "haben (Sie können es immer noch als Maus verwenden)."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:898
+#: ../src/ui/dialog/inkscape-preferences.cpp:953
 msgid "Switch tool based on tablet device (requires restart)"
 msgstr "Wechsel Werkzeug abhängig von Tablett-Werkzeug (erfordert Neustart)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:900
+#: ../src/ui/dialog/inkscape-preferences.cpp:955
 msgid ""
 "Change tool as different devices are used on the tablet (pen, eraser, mouse)"
 msgstr ""
 "Wechselt das Werkzeug, wenn auf dem Grafiktablett ein anderes Gerät "
 "verwendet wird (Stift, Radierer, Maus)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:901
+#: ../src/ui/dialog/inkscape-preferences.cpp:956
 msgid "Input devices"
 msgstr "Eingabegeräte"
 
 #. SVG output options
-#: ../src/ui/dialog/inkscape-preferences.cpp:904
+#: ../src/ui/dialog/inkscape-preferences.cpp:959
 msgid "Use named colors"
 msgstr "Farbnamen benutzen"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:905
+#: ../src/ui/dialog/inkscape-preferences.cpp:960
 msgid ""
 "If set, write the CSS name of the color when available (e.g. 'red' or "
 "'magenta') instead of the numeric value"
@@ -20131,23 +20336,23 @@ msgstr ""
 "Benutzt, wenn möglich, die CSS-Farbnamen (z.B. 'red', 'magenta') anstelle "
 "von nummerischen Werten."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:907
+#: ../src/ui/dialog/inkscape-preferences.cpp:962
 msgid "XML formatting"
 msgstr "XML-Format"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:909
+#: ../src/ui/dialog/inkscape-preferences.cpp:964
 msgid "Inline attributes"
 msgstr "Attribute kürzen"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:910
+#: ../src/ui/dialog/inkscape-preferences.cpp:965
 msgid "Put attributes on the same line as the element tag"
 msgstr "Schreibt Attribute in die gleiche Zeile wie das Element-Tag."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:913
+#: ../src/ui/dialog/inkscape-preferences.cpp:968
 msgid "_Indent, spaces:"
 msgstr "E_inzug, Leerzeichen:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:913
+#: ../src/ui/dialog/inkscape-preferences.cpp:968
 msgid ""
 "The number of spaces to use for indenting nested elements; set to 0 for no "
 "indentation"
@@ -20155,28 +20360,28 @@ msgstr ""
 "Die Anzahl an Leerstellen die zum einrücken untergeordneter Elemente genutzt "
 "werden soll. Mit 0 werden keine Leerstellen eingefügt."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:915
+#: ../src/ui/dialog/inkscape-preferences.cpp:970
 msgid "Path data"
 msgstr "Pfaddaten"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:918
+#: ../src/ui/dialog/inkscape-preferences.cpp:973
 msgid "Absolute"
 msgstr "Absolut"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:918
+#: ../src/ui/dialog/inkscape-preferences.cpp:973
 msgid "Relative"
 msgstr "Relativ"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:918
-#: ../src/ui/dialog/inkscape-preferences.cpp:1202
+#: ../src/ui/dialog/inkscape-preferences.cpp:973
+#: ../src/ui/dialog/inkscape-preferences.cpp:1257
 msgid "Optimized"
 msgstr "Optimiert"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:922
+#: ../src/ui/dialog/inkscape-preferences.cpp:977
 msgid "Path string format:"
 msgstr "Pfad-Zeichenkettenformat:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:922
+#: ../src/ui/dialog/inkscape-preferences.cpp:977
 msgid ""
 "Path data should be written: only with absolute coordinates, only with "
 "relative coordinates, or optimized for string length (mixed absolute and "
@@ -20186,11 +20391,11 @@ msgstr ""
 "relativen Koordinaten oder optimiert für die Textlänge (Mischung absoluter "
 "und relativer Koordinaten)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:924
+#: ../src/ui/dialog/inkscape-preferences.cpp:979
 msgid "Force repeat commands"
 msgstr "Erzwinge Kommandowiederholung"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:925
+#: ../src/ui/dialog/inkscape-preferences.cpp:980
 msgid ""
 "Force repeating of the same path command (for example, 'L 1,2 L 3,4' instead "
 "of 'L 1,2 3,4')"
@@ -20198,23 +20403,23 @@ msgstr ""
 "Erzwingt die Wiederholung von Pfad-Kommandos (z.B. 'L 1,2 L 3,4' anstatt 'L "
 "1,2 3,4')"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:927
+#: ../src/ui/dialog/inkscape-preferences.cpp:982
 msgid "Numbers"
 msgstr "Zahlen"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:930
+#: ../src/ui/dialog/inkscape-preferences.cpp:985
 msgid "_Numeric precision:"
 msgstr "Genauigkeit:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:930
+#: ../src/ui/dialog/inkscape-preferences.cpp:985
 msgid "Significant figures of the values written to the SVG file"
 msgstr "Maßgebliche Zahlen der Werte, die in die SVG-Datei geschrieben werden"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:933
+#: ../src/ui/dialog/inkscape-preferences.cpp:988
 msgid "Minimum _exponent:"
 msgstr "Minimal _Exponent:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:933
+#: ../src/ui/dialog/inkscape-preferences.cpp:988
 msgid ""
 "The smallest number written to SVG is 10 to the power of this exponent; "
 "anything smaller is written as zero"
@@ -20224,17 +20429,17 @@ msgstr ""
 
 #. Code to add controls for attribute checking options
 #. Add incorrect style properties options
-#: ../src/ui/dialog/inkscape-preferences.cpp:938
+#: ../src/ui/dialog/inkscape-preferences.cpp:993
 msgid "Improper Attributes Actions"
 msgstr "Unsachgemäße Attribut-Aktionen"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:940
-#: ../src/ui/dialog/inkscape-preferences.cpp:948
-#: ../src/ui/dialog/inkscape-preferences.cpp:956
+#: ../src/ui/dialog/inkscape-preferences.cpp:995
+#: ../src/ui/dialog/inkscape-preferences.cpp:1003
+#: ../src/ui/dialog/inkscape-preferences.cpp:1011
 msgid "Print warnings"
 msgstr "Drucke Warnungen"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:941
+#: ../src/ui/dialog/inkscape-preferences.cpp:996
 msgid ""
 "Print warning if invalid or non-useful attributes found. Database files "
 "located in inkscape_data_dir/attributes."
@@ -20242,20 +20447,20 @@ msgstr ""
 "Gebe Warnung aus, wenn ungültige oder nicht-nützliche Attribute gefunden "
 "werden. Datenbank-Dateien liegen in inkscape_data_dir/Attribute."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:942
+#: ../src/ui/dialog/inkscape-preferences.cpp:997
 msgid "Remove attributes"
 msgstr "Attribute löschen"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:943
+#: ../src/ui/dialog/inkscape-preferences.cpp:998
 msgid "Delete invalid or non-useful attributes from element tag"
 msgstr "Löscht ungültige oder nicht-nützliche Attribute vom Element-Tag"
 
 #. Add incorrect style properties options
-#: ../src/ui/dialog/inkscape-preferences.cpp:946
+#: ../src/ui/dialog/inkscape-preferences.cpp:1001
 msgid "Inappropriate Style Properties Actions"
 msgstr "Unangemessene Stileigenschaften-Aktionen"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:949
+#: ../src/ui/dialog/inkscape-preferences.cpp:1004
 msgid ""
 "Print warning if inappropriate style properties found (i.e. 'font-family' "
 "set on a <rect>). Database files located in inkscape_data_dir/attributes."
@@ -20264,21 +20469,21 @@ msgstr ""
 "'Schrift-Familie' auf einem <rect> gesetzt). Datenbank-Dateien liegen in "
 "inkscape_data_dir/Attribute."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:950
-#: ../src/ui/dialog/inkscape-preferences.cpp:958
+#: ../src/ui/dialog/inkscape-preferences.cpp:1005
+#: ../src/ui/dialog/inkscape-preferences.cpp:1013
 msgid "Remove style properties"
 msgstr "Stileigenschaften löschen"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:951
+#: ../src/ui/dialog/inkscape-preferences.cpp:1006
 msgid "Delete inappropriate style properties"
 msgstr "Unpassende Stileigenschaften löschen"
 
 #. Add default or inherited style properties options
-#: ../src/ui/dialog/inkscape-preferences.cpp:954
+#: ../src/ui/dialog/inkscape-preferences.cpp:1009
 msgid "Non-useful Style Properties Actions"
 msgstr "Nicht-nützliche Stileigenschafts-Aktionen"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:957
+#: ../src/ui/dialog/inkscape-preferences.cpp:1012
 msgid ""
 "Print warning if redundant style properties found (i.e. if a property has "
 "the default value and a different value is not inherited or if value is the "
@@ -20290,19 +20495,19 @@ msgstr ""
 "vererbt wird oder wenn ein Wert der gleiche ist, wenn er vererbt würde). "
 "Datenbank-Dateien liegen in inkscape_data_dir/Attribute."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:959
+#: ../src/ui/dialog/inkscape-preferences.cpp:1014
 msgid "Delete redundant style properties"
 msgstr "Redundante Stileigenschaften löschen"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:961
+#: ../src/ui/dialog/inkscape-preferences.cpp:1016
 msgid "Check Attributes and Style Properties on"
 msgstr "Überprüfen Sie Attribute und Style-Eigenschaften auf"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:963
+#: ../src/ui/dialog/inkscape-preferences.cpp:1018
 msgid "Reading"
 msgstr "Lesen"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:964
+#: ../src/ui/dialog/inkscape-preferences.cpp:1019
 msgid ""
 "Check attributes and style properties on reading in SVG files (including "
 "those internal to Inkscape which will slow down startup)"
@@ -20311,11 +20516,11 @@ msgstr ""
 "Dateien (einschließlich derjenigen internen von Inkscape die den Start "
 "verlangsamen)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:965
+#: ../src/ui/dialog/inkscape-preferences.cpp:1020
 msgid "Editing"
 msgstr "Bearbeiten"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:966
+#: ../src/ui/dialog/inkscape-preferences.cpp:1021
 msgid ""
 "Check attributes and style properties while editing SVG files (may slow down "
 "Inkscape, mostly useful for debugging)"
@@ -20323,42 +20528,42 @@ msgstr ""
 "Überprüfen Sie die Attribute und Style-Eigenschaften während der Bearbeitung "
 "von SVG-Dateien (kann Inkscape verlangsamen, meist nützlich zur Fehlersuche)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:967
+#: ../src/ui/dialog/inkscape-preferences.cpp:1022
 msgid "Writing"
 msgstr "Schreiben"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:968
+#: ../src/ui/dialog/inkscape-preferences.cpp:1023
 msgid "Check attributes and style properties on writing out SVG files"
 msgstr ""
 "Überprüfen Sie die Attribut- und Style-Eigenschaften beim Schreiben von SVG-"
 "Dateien"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:970
+#: ../src/ui/dialog/inkscape-preferences.cpp:1025
 msgid "SVG output"
 msgstr "SVG-Ausgabe"
 
 #. TRANSLATORS: see http://www.newsandtech.com/issues/2004/03-04/pt/03-04_rendering.htm
-#: ../src/ui/dialog/inkscape-preferences.cpp:976
+#: ../src/ui/dialog/inkscape-preferences.cpp:1031
 msgid "Perceptual"
 msgstr "Wahrnehmung"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:976
+#: ../src/ui/dialog/inkscape-preferences.cpp:1031
 msgid "Relative Colorimetric"
 msgstr "Relative Farbmetrik"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:976
+#: ../src/ui/dialog/inkscape-preferences.cpp:1031
 msgid "Absolute Colorimetric"
 msgstr "Absolute Farbmetrik"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:980
+#: ../src/ui/dialog/inkscape-preferences.cpp:1035
 msgid "(Note: Color management has been disabled in this build)"
 msgstr "(Hinweis: Farbmanagement wurde in diesem Build deaktiviert)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:984
+#: ../src/ui/dialog/inkscape-preferences.cpp:1039
 msgid "Display adjustment"
 msgstr "Anzeigeanpassungen"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:993
+#: ../src/ui/dialog/inkscape-preferences.cpp:1048
 #, c-format
 msgid ""
 "The ICC profile to use to calibrate display output.\n"
@@ -20367,113 +20572,113 @@ msgstr ""
 "ICC-Profil, das zum Kalibrieren der Anzeige genutzt werden soll.\n"
 "Durchsuchte Verzeichnisse:%s"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:994
+#: ../src/ui/dialog/inkscape-preferences.cpp:1049
 msgid "Display profile:"
 msgstr "Anzeigeprofil:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:999
+#: ../src/ui/dialog/inkscape-preferences.cpp:1054
 msgid "Retrieve profile from display"
 msgstr "Profil von Anzeige ermitteln"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1002
+#: ../src/ui/dialog/inkscape-preferences.cpp:1057
 msgid "Retrieve profiles from those attached to displays via XICC"
 msgstr "Ermittle Profil von angeschlossenen Anzeigegeräten mittels XICC."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1004
+#: ../src/ui/dialog/inkscape-preferences.cpp:1059
 msgid "Retrieve profiles from those attached to displays"
 msgstr "Ermittle Profil von angeschlossenen Anzeigegeräten."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1009
+#: ../src/ui/dialog/inkscape-preferences.cpp:1064
 msgid "Display rendering intent:"
 msgstr "Anzeigenversatz"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1010
+#: ../src/ui/dialog/inkscape-preferences.cpp:1065
 msgid "The rendering intent to use to calibrate display output"
 msgstr ""
 "Geräte-Wiedergabe-Bedeutung wird genutzt, um die Ausgabe zu kalibrieren."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1012
+#: ../src/ui/dialog/inkscape-preferences.cpp:1067
 msgid "Proofing"
 msgstr "Druckprobe"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1014
+#: ../src/ui/dialog/inkscape-preferences.cpp:1069
 msgid "Simulate output on screen"
 msgstr "Simulieren der Ausgabe auf dem Bildschirm"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1016
+#: ../src/ui/dialog/inkscape-preferences.cpp:1071
 msgid "Simulates output of target device"
 msgstr "Simulieren der Ausgabe auf dem Zielgerät"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1018
+#: ../src/ui/dialog/inkscape-preferences.cpp:1073
 msgid "Mark out of gamut colors"
 msgstr "Farben der Farbskala hervorheben"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1020
+#: ../src/ui/dialog/inkscape-preferences.cpp:1075
 msgid "Highlights colors that are out of gamut for the target device"
 msgstr "Hebe Farben hervor die nicht im Farbbereich des Ausgabegerätes liegen."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1027
+#: ../src/ui/dialog/inkscape-preferences.cpp:1082
 msgid "Out of gamut warning color:"
 msgstr "Farbe für Farbbereichswarnung:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1028
+#: ../src/ui/dialog/inkscape-preferences.cpp:1083
 msgid "Selects the color used for out of gamut warning"
 msgstr "Bestimmt die Farbe die für Farbbereichswarnungen genutzt werden soll."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1030
+#: ../src/ui/dialog/inkscape-preferences.cpp:1085
 msgid "Device profile:"
 msgstr "Geräteprofil:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1031
+#: ../src/ui/dialog/inkscape-preferences.cpp:1086
 msgid "The ICC profile to use to simulate device output"
 msgstr "ICC-Profil für Simulation der Geräteausgabe."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1034
+#: ../src/ui/dialog/inkscape-preferences.cpp:1089
 msgid "Device rendering intent:"
 msgstr "Gerätewiedergabe-Bedeutung"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1035
+#: ../src/ui/dialog/inkscape-preferences.cpp:1090
 msgid "The rendering intent to use to calibrate device output"
 msgstr ""
 "Geräte-Wiedergabe-Bedeutung wird genutzt, um die Ausgabe zu kalibrieren."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1037
+#: ../src/ui/dialog/inkscape-preferences.cpp:1092
 msgid "Black point compensation"
 msgstr "Schwarzpunktanpassung"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1039
+#: ../src/ui/dialog/inkscape-preferences.cpp:1094
 msgid "Enables black point compensation"
 msgstr "Ermöglicht Schwarzpunktkompensation"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1041
+#: ../src/ui/dialog/inkscape-preferences.cpp:1096
 msgid "Preserve black"
 msgstr "Schwarzwert beibehalten"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1048
+#: ../src/ui/dialog/inkscape-preferences.cpp:1103
 msgid "(LittleCMS 1.15 or later required)"
 msgstr "(LittleCMS 1.15 oder neuer wird benötigt)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1050
+#: ../src/ui/dialog/inkscape-preferences.cpp:1105
 msgid "Preserve K channel in CMYK -> CMYK transforms"
 msgstr "Lässt K-Kanal in CMYK -> CMYK Transformation unverändert."
 
 # CHECK
-#: ../src/ui/dialog/inkscape-preferences.cpp:1064
+#: ../src/ui/dialog/inkscape-preferences.cpp:1119
 #: ../src/ui/widget/color-icc-selector.cpp:372
 #: ../src/ui/widget/color-icc-selector.cpp:671
 msgid "<none>"
 msgstr "<keins>"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1109
+#: ../src/ui/dialog/inkscape-preferences.cpp:1164
 msgid "Color management"
 msgstr "Farb-Management"
 
 #. Autosave options
-#: ../src/ui/dialog/inkscape-preferences.cpp:1112
+#: ../src/ui/dialog/inkscape-preferences.cpp:1167
 msgid "Enable autosave (requires restart)"
 msgstr "Automatisches Speichern (erfordert Neustart)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1113
+#: ../src/ui/dialog/inkscape-preferences.cpp:1168
 msgid ""
 "Automatically save the current document(s) at a given interval, thus "
 "minimizing loss in case of a crash"
@@ -20481,12 +20686,12 @@ msgstr ""
 "Speichert das Dokument in bestimmten Zeitabständen. Dadurch kann der "
 "Verlust, der durch Programmabstürze entsteht, verringert werden."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1119
+#: ../src/ui/dialog/inkscape-preferences.cpp:1174
 msgctxt "Filesystem"
 msgid "Autosave _directory:"
 msgstr "Ver_zeichnis für automatisches Speichern:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1119
+#: ../src/ui/dialog/inkscape-preferences.cpp:1174
 msgid ""
 "The directory where autosaves will be written. This should be an absolute "
 "path (starts with / on UNIX or a drive letter such as C: on Windows). "
@@ -20495,21 +20700,21 @@ msgstr ""
 "sollte ein absoluter Pfad sein (startet mit / bei UNIX und einem "
 "Laufwerksbuchstaben wir C: bei Windows)."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1121
+#: ../src/ui/dialog/inkscape-preferences.cpp:1176
 msgid "_Interval (in minutes):"
 msgstr "Zeitabstand (in Minuten):"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1121
+#: ../src/ui/dialog/inkscape-preferences.cpp:1176
 msgid "Interval (in minutes) at which document will be autosaved"
 msgstr ""
 "In diesen Zeitabständen (in Minuten) wird das Dokument automatisch "
 "gespeichert."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1123
+#: ../src/ui/dialog/inkscape-preferences.cpp:1178
 msgid "_Maximum number of autosaves:"
 msgstr "Maximale Anzahl an Sicherungen:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1123
+#: ../src/ui/dialog/inkscape-preferences.cpp:1178
 msgid ""
 "Maximum number of autosaved files; use this to limit the storage space used"
 msgstr ""
@@ -20528,15 +20733,15 @@ msgstr ""
 #. _autosave_autosave_interval.signal_changed().connect( sigc::ptr_fun(inkscape_autosave_init), TRUE );
 #.
 #. -----------
-#: ../src/ui/dialog/inkscape-preferences.cpp:1138
+#: ../src/ui/dialog/inkscape-preferences.cpp:1193
 msgid "Autosave"
 msgstr "Automatische Sicherung"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1142
+#: ../src/ui/dialog/inkscape-preferences.cpp:1197
 msgid "Open Clip Art Library _Server Name:"
 msgstr "Open Clip Art Library Servername:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1143
+#: ../src/ui/dialog/inkscape-preferences.cpp:1198
 msgid ""
 "The server name of the Open Clip Art Library webdav server; it's used by the "
 "Import and Export to OCAL function"
@@ -20544,35 +20749,35 @@ msgstr ""
 "Der Servername des \"Open Clip Art Library\" Webdav Servers. Dieser wird "
 "beim Im- und Export zur OCAL verwendet."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1145
+#: ../src/ui/dialog/inkscape-preferences.cpp:1200
 msgid "Open Clip Art Library _Username:"
 msgstr "Open Clip Art Library Benutzername:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1146
+#: ../src/ui/dialog/inkscape-preferences.cpp:1201
 msgid "The username used to log into Open Clip Art Library"
 msgstr "Der Benutzername zum einloggen in die Open Clip Art Library."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1148
+#: ../src/ui/dialog/inkscape-preferences.cpp:1203
 msgid "Open Clip Art Library _Password:"
 msgstr "Open Clip Art Library Kennwort:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1149
+#: ../src/ui/dialog/inkscape-preferences.cpp:1204
 msgid "The password used to log into Open Clip Art Library"
 msgstr "Das Passwort zum einloggen in die Open Clip Art Library."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1150
+#: ../src/ui/dialog/inkscape-preferences.cpp:1205
 msgid "Open Clip Art"
 msgstr "Login bei Open Clip Art"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1155
+#: ../src/ui/dialog/inkscape-preferences.cpp:1210
 msgid "Behavior"
 msgstr "Verhalten"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1159
+#: ../src/ui/dialog/inkscape-preferences.cpp:1214
 msgid "_Simplification threshold:"
 msgstr "Schwellwert für Vereinfachungen:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1160
+#: ../src/ui/dialog/inkscape-preferences.cpp:1215
 msgid ""
 "How strong is the Node tool's Simplify command by default. If you invoke "
 "this command several times in quick succession, it will act more and more "
@@ -20582,47 +20787,47 @@ msgstr ""
 "mehrmals schnell hintereinander ausgeführt, erhöht sich die Stärke; kurze "
 "Pause dazwischen setzt den Schwellwert zurück."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1162
+#: ../src/ui/dialog/inkscape-preferences.cpp:1217
 msgid "Color stock markers the same color as object"
 msgstr ""
 "Standard-Knotenmarkierung in der gleichen Farbe wie das Objekt einfärben"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1163
+#: ../src/ui/dialog/inkscape-preferences.cpp:1218
 msgid "Color custom markers the same color as object"
 msgstr ""
 "Färbe die benutzerdefinierten Marker in der gleichen Farbe wie das Objekt"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1164
-#: ../src/ui/dialog/inkscape-preferences.cpp:1387
+#: ../src/ui/dialog/inkscape-preferences.cpp:1219
+#: ../src/ui/dialog/inkscape-preferences.cpp:1447
 msgid "Update marker color when object color changes"
 msgstr "Aktualisiert die Marker Farbe, wenn das Objekt die Farbe ändert"
 
 #. Selecting options
-#: ../src/ui/dialog/inkscape-preferences.cpp:1167
+#: ../src/ui/dialog/inkscape-preferences.cpp:1222
 msgid "Select in all layers"
 msgstr "In allen Ebenen auswählen"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1168
+#: ../src/ui/dialog/inkscape-preferences.cpp:1223
 msgid "Select only within current layer"
 msgstr "Nur innerhalb der aktuellen Ebene auswählen"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1169
+#: ../src/ui/dialog/inkscape-preferences.cpp:1224
 msgid "Select in current layer and sublayers"
 msgstr "Nur innerhalb der aktuellen Ebene und Unterebenen auswählen"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1170
+#: ../src/ui/dialog/inkscape-preferences.cpp:1225
 msgid "Ignore hidden objects and layers"
 msgstr "Ausgeblendete Objekte und Ebenen ignorieren"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1171
+#: ../src/ui/dialog/inkscape-preferences.cpp:1226
 msgid "Ignore locked objects and layers"
 msgstr "Gesperrte Objekte und Ebenen ignorieren"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1172
+#: ../src/ui/dialog/inkscape-preferences.cpp:1227
 msgid "Deselect upon layer change"
 msgstr "Auswahl bei Ebenenwechsel aufheben"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1175
+#: ../src/ui/dialog/inkscape-preferences.cpp:1230
 msgid ""
 "Uncheck this to be able to keep the current objects selected when the "
 "current layer changes"
@@ -20630,20 +20835,20 @@ msgstr ""
 "Dieses abwählen um Objekte ausgewählt zu lassen, wenn die aktuelle Ebene "
 "geändert wird"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1177
+#: ../src/ui/dialog/inkscape-preferences.cpp:1232
 msgid "Ctrl+A, Tab, Shift+Tab"
 msgstr "Strg+A, Tab, Umschalt+Tab"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1179
+#: ../src/ui/dialog/inkscape-preferences.cpp:1234
 msgid "Make keyboard selection commands work on objects in all layers"
 msgstr "Tastaturkommandos zur Auswahl wirken auf Objekte aller Ebenen"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1181
+#: ../src/ui/dialog/inkscape-preferences.cpp:1236
 msgid "Make keyboard selection commands work on objects in current layer only"
 msgstr ""
 "Tastaturkommandos zur Auswahl wirken nur auf Objekte in der aktuellen Ebene"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1183
+#: ../src/ui/dialog/inkscape-preferences.cpp:1238
 msgid ""
 "Make keyboard selection commands work on objects in current layer and all "
 "its sublayers"
@@ -20651,7 +20856,7 @@ msgstr ""
 "Tastaturkommandos zur Auswahl wirken auf Objekte in der aktuellen Ebene und "
 "aller ihrer Unterebenen"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1185
+#: ../src/ui/dialog/inkscape-preferences.cpp:1240
 msgid ""
 "Uncheck this to be able to select objects that are hidden (either by "
 "themselves or by being in a hidden layer)"
@@ -20659,7 +20864,7 @@ msgstr ""
 "Dieses abwählen, damit ausgeblendete Objekte ausgewählt werden können (gilt "
 "auch für Objekte in ausgeblendeten Ebenen/Gruppierungen)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1187
+#: ../src/ui/dialog/inkscape-preferences.cpp:1242
 msgid ""
 "Uncheck this to be able to select objects that are locked (either by "
 "themselves or by being in a locked layer)"
@@ -20667,77 +20872,77 @@ msgstr ""
 "Dieses abwählen damit gesperrte Objekte ausgewählt werden können (gilt auch "
 "für Objekte in gesperrten Ebenen/Gruppierungen)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1189
+#: ../src/ui/dialog/inkscape-preferences.cpp:1244
 msgid "Wrap when cycling objects in z-order"
 msgstr "Beim drehen von Objekten in Z-Ordnung einwickeln."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1191
+#: ../src/ui/dialog/inkscape-preferences.cpp:1246
 msgid "Alt+Scroll Wheel"
 msgstr "Alt+Scroll-Rad"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1193
+#: ../src/ui/dialog/inkscape-preferences.cpp:1248
 msgid "Wrap around at start and end when cycling objects in z-order"
 msgstr ""
 "Beim drehen von Objekten in Z-Ordnung um den Start- und Endpunkt einwickeln."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1195
+#: ../src/ui/dialog/inkscape-preferences.cpp:1250
 msgid "Selecting"
 msgstr "Auswählen"
 
 #. Transforms options
-#: ../src/ui/dialog/inkscape-preferences.cpp:1198
+#: ../src/ui/dialog/inkscape-preferences.cpp:1253
 #: ../src/widgets/select-toolbar.cpp:554
 msgid "Scale stroke width"
 msgstr "Breite der Kontur skalieren"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1199
+#: ../src/ui/dialog/inkscape-preferences.cpp:1254
 msgid "Scale rounded corners in rectangles"
 msgstr "Abgerundete Ecken in Rechtecken mitskalieren"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1200
+#: ../src/ui/dialog/inkscape-preferences.cpp:1255
 msgid "Transform gradients"
 msgstr "Farbverläufe transformieren"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1201
+#: ../src/ui/dialog/inkscape-preferences.cpp:1256
 msgid "Transform patterns"
 msgstr "Füllmuster transformieren"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1203
+#: ../src/ui/dialog/inkscape-preferences.cpp:1258
 msgid "Preserved"
 msgstr "Beibehalten"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1206
+#: ../src/ui/dialog/inkscape-preferences.cpp:1261
 #: ../src/widgets/select-toolbar.cpp:555
 msgid "When scaling objects, scale the stroke width by the same proportion"
 msgstr ""
 "Wenn Objekte skaliert werden, dann wird die Breite der Kontur ebenso "
 "skaliert."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1208
+#: ../src/ui/dialog/inkscape-preferences.cpp:1263
 #: ../src/widgets/select-toolbar.cpp:566
 msgid "When scaling rectangles, scale the radii of rounded corners"
 msgstr ""
 "Wenn Rechtecke skaliert werden, dann werden die Radien von abgerundeten "
 "Ecken ebenso mitskaliert."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1210
+#: ../src/ui/dialog/inkscape-preferences.cpp:1265
 #: ../src/widgets/select-toolbar.cpp:577
 msgid "Move gradients (in fill or stroke) along with the objects"
 msgstr ""
 "Farbverläufe (in Füllung oder Konturen) zusammen mit den Objekten "
 "transformieren"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1212
+#: ../src/ui/dialog/inkscape-preferences.cpp:1267
 #: ../src/widgets/select-toolbar.cpp:588
 msgid "Move patterns (in fill or stroke) along with the objects"
 msgstr ""
 "Muster (in Füllung oder Konturen) zusammen mit den Objekten transformieren"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1213
+#: ../src/ui/dialog/inkscape-preferences.cpp:1268
 msgid "Store transformation"
 msgstr "Transformation speichern:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1215
+#: ../src/ui/dialog/inkscape-preferences.cpp:1270
 msgid ""
 "If possible, apply transformation to objects without adding a transform= "
 "attribute"
@@ -20745,19 +20950,19 @@ msgstr ""
 "Wenn möglich, dann werden Transformationen auf Objekte angewendet, ohne ein "
 "transform=-Attribut hinzuzufügen."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1217
+#: ../src/ui/dialog/inkscape-preferences.cpp:1272
 msgid "Always store transformation as a transform= attribute on objects"
 msgstr "Transformationen immer als transform=-Attribute speichern."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1219
+#: ../src/ui/dialog/inkscape-preferences.cpp:1274
 msgid "Transforms"
 msgstr "Transformationen"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1223
+#: ../src/ui/dialog/inkscape-preferences.cpp:1278
 msgid "Mouse _wheel scrolls by:"
 msgstr "Mausrad rollt um:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1224
+#: ../src/ui/dialog/inkscape-preferences.cpp:1279
 msgid ""
 "One mouse wheel notch scrolls by this distance in screen pixels "
 "(horizontally with Shift)"
@@ -20765,23 +20970,23 @@ msgstr ""
 "Eine Stufe des Maus-Rades rollt um die angegebene Distanz in Pixeln "
 "(horizontal mit Umschalt)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1225
+#: ../src/ui/dialog/inkscape-preferences.cpp:1280
 msgid "Ctrl+arrows"
 msgstr "Strg+Pfeile"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1227
+#: ../src/ui/dialog/inkscape-preferences.cpp:1282
 msgid "Sc_roll by:"
 msgstr "Rolle um:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1228
+#: ../src/ui/dialog/inkscape-preferences.cpp:1283
 msgid "Pressing Ctrl+arrow key scrolls by this distance (in screen pixels)"
 msgstr "Strg+Pfeiltasten rollen um diese Distanz (in Pixeln)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1230
+#: ../src/ui/dialog/inkscape-preferences.cpp:1285
 msgid "_Acceleration:"
 msgstr "Beschleunigung:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1231
+#: ../src/ui/dialog/inkscape-preferences.cpp:1286
 msgid ""
 "Pressing and holding Ctrl+arrow will gradually speed up scrolling (0 for no "
 "acceleration)"
@@ -20789,15 +20994,15 @@ msgstr ""
 "Drücken von Strg+Pfeiltaste erhöht zunehmend die Rollgeschwindigkeit (0 "
 "bedeutet „keine Beschleunigung“)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1232
+#: ../src/ui/dialog/inkscape-preferences.cpp:1287
 msgid "Autoscrolling"
 msgstr "Automatisches Rollen"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1234
+#: ../src/ui/dialog/inkscape-preferences.cpp:1289
 msgid "_Speed:"
 msgstr "Geschwindigkeit:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1235
+#: ../src/ui/dialog/inkscape-preferences.cpp:1290
 msgid ""
 "How fast the canvas autoscrolls when you drag beyond canvas edge (0 to turn "
 "autoscroll off)"
@@ -20805,12 +21010,12 @@ msgstr ""
 "Geschwindigkeit mit der die Arbeitsfläche verschoben wird, wenn der Zeiger "
 "ihren Rand überschreitet (0: Autorollen ist deaktiviert)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1237
+#: ../src/ui/dialog/inkscape-preferences.cpp:1292
 #: ../src/ui/dialog/tracedialog.cpp:520 ../src/ui/dialog/tracedialog.cpp:719
 msgid "_Threshold:"
 msgstr "Schwellwer_t:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1238
+#: ../src/ui/dialog/inkscape-preferences.cpp:1293
 msgid ""
 "How far (in screen pixels) you need to be from the canvas edge to trigger "
 "autoscroll; positive is outside the canvas, negative is within the canvas"
@@ -20819,23 +21024,23 @@ msgstr ""
 "Autorollen aktiv ist: positive Werte liegen außerhalb, negative Werte "
 "innerhalb der Arbeitsfläche"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1239
+#: ../src/ui/dialog/inkscape-preferences.cpp:1294
 msgid "Mouse move pans when Space is pressed"
 msgstr ""
 "Bewegen der Maus verschiebt die Arbeitsfläche, wenn die Leertaste gedrückt "
 "ist."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1241
+#: ../src/ui/dialog/inkscape-preferences.cpp:1296
 msgid "When on, pressing and holding Space and dragging pans canvas"
 msgstr ""
 "Wenn aktiviert, wird die Arbeitsfläche beim Bewegen der Maus verschoben "
 "während die Leertaste gehalten wird"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1242
+#: ../src/ui/dialog/inkscape-preferences.cpp:1297
 msgid "Mouse wheel zooms by default"
 msgstr "Standardmäßig zoomt das Mausrad"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1244
+#: ../src/ui/dialog/inkscape-preferences.cpp:1299
 msgid ""
 "When on, mouse wheel zooms without Ctrl and scrolls canvas with Ctrl; when "
 "off, it zooms with Ctrl and scrolls without Ctrl"
@@ -20843,55 +21048,55 @@ msgstr ""
 "Wenn aktiviert kann mit dem Mausrad die Ansicht vergrößert/verkleinert "
 "werden. Ist dies deaktiviert benötigt man dazu Strg+Mausrad."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1245
+#: ../src/ui/dialog/inkscape-preferences.cpp:1300
 msgid "Scrolling"
 msgstr "Rollen"
 
 #. Snapping options
-#: ../src/ui/dialog/inkscape-preferences.cpp:1248
+#: ../src/ui/dialog/inkscape-preferences.cpp:1303
 msgid "Snap indicator"
 msgstr "Einrast-Indikator"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1250
+#: ../src/ui/dialog/inkscape-preferences.cpp:1305
 msgid "Enable snap indicator"
 msgstr "Einrast-Indikator aktivieren"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1252
+#: ../src/ui/dialog/inkscape-preferences.cpp:1307
 msgid "After snapping, a symbol is drawn at the point that has snapped"
 msgstr ""
 "Nach dem Einrasten wird ein Symbol an der Stelle, die einrastete, gezeichnet."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1257
+#: ../src/ui/dialog/inkscape-preferences.cpp:1312
 msgid "Snap indicator persistence (in seconds):"
 msgstr "Anzeigedauer des Einrast-Indikators (in Sekunden)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1258
+#: ../src/ui/dialog/inkscape-preferences.cpp:1313
 msgid ""
 "Controls how long the snap indicator message will be shown, before it "
 "disappears"
 msgstr ""
 "Bestimmt wie lange die Einrast-Indikator-Benachrichtigung angezeigt wird."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1260
+#: ../src/ui/dialog/inkscape-preferences.cpp:1315
 msgid "What should snap"
 msgstr "Woran einrasten"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1262
+#: ../src/ui/dialog/inkscape-preferences.cpp:1317
 msgid "Only snap the node closest to the pointer"
 msgstr "Nur an dem Knoten einrasten, der dem Zeiger am nächsten ist."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1264
+#: ../src/ui/dialog/inkscape-preferences.cpp:1319
 msgid ""
 "Only try to snap the node that is initially closest to the mouse pointer"
 msgstr ""
 "Nur versuchen an dem Knoten einzurasten, der dem Mauszeiger zu Beginn am "
 "nächsten ist."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1267
+#: ../src/ui/dialog/inkscape-preferences.cpp:1322
 msgid "_Weight factor:"
 msgstr "Gewichtungsfaktor:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1268
+#: ../src/ui/dialog/inkscape-preferences.cpp:1323
 msgid ""
 "When multiple snap solutions are found, then Inkscape can either prefer the "
 "closest transformation (when set to 0), or prefer the node that was "
@@ -20901,11 +21106,11 @@ msgstr ""
 "Transformation anwenden (wenn auf 0 gesetzt) oder am Knoten, der dem "
 "Mauszeiger am nähesten ist (wenn auf 1 gesetzt) einrasten."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1270
+#: ../src/ui/dialog/inkscape-preferences.cpp:1325
 msgid "Snap the mouse pointer when dragging a constrained knot"
 msgstr "Rastet den Mauszeiger ein, wenn ein festgesetzter Knoten gezogen wird."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1272
+#: ../src/ui/dialog/inkscape-preferences.cpp:1327
 msgid ""
 "When dragging a knot along a constraint line, then snap the position of the "
 "mouse pointer instead of snapping the projection of the knot onto the "
@@ -20914,15 +21119,15 @@ msgstr ""
 "Wird ein Knoten entlang einer festgesetzten Linie gezogen, dann rastet der "
 "Mauszeiger statt der Projektion des Knotens auf der Linie ein."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1274
+#: ../src/ui/dialog/inkscape-preferences.cpp:1329
 msgid "Delayed snap"
 msgstr "Zeitverzögertes Einrasten"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1277
+#: ../src/ui/dialog/inkscape-preferences.cpp:1332
 msgid "Delay (in seconds):"
 msgstr "Verzögerung (Sekunden):"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1278
+#: ../src/ui/dialog/inkscape-preferences.cpp:1333
 msgid ""
 "Postpone snapping as long as the mouse is moving, and then wait an "
 "additional fraction of a second. This additional delay is specified here. "
@@ -20932,16 +21137,16 @@ msgstr ""
 "danach, unterdrücken. Diese zusätzliche Verzögerung wird hier festgelegt. "
 "Ist sie Null oder sehr klein erfolgt sofortiges Einrasten."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1280
+#: ../src/ui/dialog/inkscape-preferences.cpp:1335
 msgid "Snapping"
 msgstr "Einrasten"
 
 #. nudgedistance is limited to 1000 in select-context.cpp: use the same limit here
-#: ../src/ui/dialog/inkscape-preferences.cpp:1285
+#: ../src/ui/dialog/inkscape-preferences.cpp:1340
 msgid "_Arrow keys move by:"
 msgstr "Pfeiltasten bewegen um:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1286
+#: ../src/ui/dialog/inkscape-preferences.cpp:1341
 msgid ""
 "Pressing an arrow key moves selected object(s) or node(s) by this distance"
 msgstr ""
@@ -20949,31 +21154,31 @@ msgstr ""
 "Knoten) um diese Entfernung (in SVG-Pixeln)"
 
 #. defaultscale is limited to 1000 in select-context.cpp: use the same limit here
-#: ../src/ui/dialog/inkscape-preferences.cpp:1289
+#: ../src/ui/dialog/inkscape-preferences.cpp:1344
 msgid "> and < _scale by:"
 msgstr "> und < skalieren um:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1290
+#: ../src/ui/dialog/inkscape-preferences.cpp:1345
 msgid "Pressing > or < scales selection up or down by this increment"
 msgstr ""
 "Drücken von > oder < skaliert die ausgewählten Elemente um diesen Wert "
 "größer oder kleiner (in SVG-Pixeln)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1292
+#: ../src/ui/dialog/inkscape-preferences.cpp:1347
 msgid "_Inset/Outset by:"
 msgstr "Schrumpfen/Erweitern um:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1293
+#: ../src/ui/dialog/inkscape-preferences.cpp:1348
 msgid "Inset and Outset commands displace the path by this distance"
 msgstr ""
 "Schrumpfungs- und Erweiterungsbefehle verändern den Pfad um diese Distanz "
 "(in SVG-Pixeln)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1294
+#: ../src/ui/dialog/inkscape-preferences.cpp:1349
 msgid "Compass-like display of angles"
 msgstr "Anzeige von Winkeln wie bei einem Kompass"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1296
+#: ../src/ui/dialog/inkscape-preferences.cpp:1351
 msgid ""
 "When on, angles are displayed with 0 at north, 0 to 360 range, positive "
 "clockwise; otherwise with 0 at east, -180 to 180 range, positive "
@@ -20984,22 +21189,22 @@ msgstr ""
 "-180 bis 180, positiv entgegen dem Uhrzeigersinn"
 
 # CHECK
-#: ../src/ui/dialog/inkscape-preferences.cpp:1298
+#: ../src/ui/dialog/inkscape-preferences.cpp:1353
 msgctxt "Rotation angle"
 msgid "None"
 msgstr "Keine"
 
 # !!! need %s
-#: ../src/ui/dialog/inkscape-preferences.cpp:1302
+#: ../src/ui/dialog/inkscape-preferences.cpp:1357
 msgid "_Rotation snaps every:"
 msgstr "D_rehung rastet ein alle:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1302
-#: ../src/ui/dialog/inkscape-preferences.cpp:1311
+#: ../src/ui/dialog/inkscape-preferences.cpp:1357
+#: ../src/ui/dialog/inkscape-preferences.cpp:1366
 msgid "degrees"
 msgstr "Grad"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1303
+#: ../src/ui/dialog/inkscape-preferences.cpp:1358
 msgid ""
 "Rotating with Ctrl pressed snaps every that much degrees; also, pressing "
 "[ or ] rotates by this amount"
@@ -21007,11 +21212,11 @@ msgstr ""
 "Drehung mit gedrückter Strg-Taste lässt das Objekt mit dieser Gradrastung "
 "einrasten; die Tasten [ oder ] haben den gleichen Effekt"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1304
+#: ../src/ui/dialog/inkscape-preferences.cpp:1359
 msgid "Relative snapping of guideline angles"
 msgstr "Relatives Einrasten von Hilfslinienwinkeln"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1306
+#: ../src/ui/dialog/inkscape-preferences.cpp:1361
 msgid ""
 "When on, the snap angles when rotating a guideline will be relative to the "
 "original angle"
@@ -21019,17 +21224,11 @@ msgstr ""
 "Wenn eingeschaltet, wird der Einrastwinkel beim Drehen einer Hilfslinie "
 "relativ zum ursprünglichen Winkel"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1308
+#: ../src/ui/dialog/inkscape-preferences.cpp:1363
 msgid "_Zoom in/out by:"
 msgstr "Zoomfaktor vergrößern/verkleinern um:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1308
-#: ../src/ui/dialog/objects.cpp:1651
-#: ../src/ui/widget/filter-effect-chooser.cpp:23
-msgid "%"
-msgstr "%"
-
-#: ../src/ui/dialog/inkscape-preferences.cpp:1309
+#: ../src/ui/dialog/inkscape-preferences.cpp:1364
 msgid ""
 "Zoom tool click, +/- keys, and middle click zoom in and out by this "
 "multiplier"
@@ -21038,55 +21237,55 @@ msgstr ""
 "Maustaste betätigen, damit sich die Zoomgröße um diesen Faktor ändert"
 
 # !!! need %s
-#: ../src/ui/dialog/inkscape-preferences.cpp:1311
+#: ../src/ui/dialog/inkscape-preferences.cpp:1366
 #, fuzzy
 msgid "_Rotate canvas by:"
 msgstr "D_rehung rastet ein alle:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1312
+#: ../src/ui/dialog/inkscape-preferences.cpp:1367
 #, fuzzy
 msgid "Rotate canvas clockwise and counter-clockwise by this amount."
 msgstr "Entgegen Uhrzeigersinn drehen"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1313
+#: ../src/ui/dialog/inkscape-preferences.cpp:1368
 msgid "Steps"
 msgstr "Schritte"
 
 #. Clones options
-#: ../src/ui/dialog/inkscape-preferences.cpp:1316
+#: ../src/ui/dialog/inkscape-preferences.cpp:1371
 msgid "Move in parallel"
 msgstr "parallel verschoben"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1318
+#: ../src/ui/dialog/inkscape-preferences.cpp:1373
 msgid "Stay unmoved"
 msgstr "unbewegt bleiben"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1320
+#: ../src/ui/dialog/inkscape-preferences.cpp:1375
 msgid "Move according to transform"
 msgstr "sich entsprechend des transform=-Attributs bewegen"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1322
+#: ../src/ui/dialog/inkscape-preferences.cpp:1377
 msgid "Are unlinked"
 msgstr "ihre Verbindung zum Original verlieren"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1324
+#: ../src/ui/dialog/inkscape-preferences.cpp:1379
 msgid "Are deleted"
 msgstr "ebenso gelöscht"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1327
+#: ../src/ui/dialog/inkscape-preferences.cpp:1382
 msgid "Moving original: clones and linked offsets"
 msgstr "Verschiebe Original: Klone und verbundener Versatz"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1329
+#: ../src/ui/dialog/inkscape-preferences.cpp:1384
 msgid "Clones are translated by the same vector as their original"
 msgstr "Klone werden mit demselben Vektor wie das Original verschoben."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1331
+#: ../src/ui/dialog/inkscape-preferences.cpp:1386
 msgid "Clones preserve their positions when their original is moved"
 msgstr ""
 "Klone bleiben an ihren Positionen, während das Original verschoben wird."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1333
+#: ../src/ui/dialog/inkscape-preferences.cpp:1388
 msgid ""
 "Each clone moves according to the value of its transform= attribute; for "
 "example, a rotated clone will move in a different direction than its original"
@@ -21095,27 +21294,27 @@ msgstr ""
 "Attributs. Ein rotierter Klon wird sich zum Beispiel in eine andere Richtung "
 "als das Original drehen."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1334
+#: ../src/ui/dialog/inkscape-preferences.cpp:1389
 msgid "Deleting original: clones"
 msgstr "Lösche Original: Klone"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1336
+#: ../src/ui/dialog/inkscape-preferences.cpp:1391
 msgid "Orphaned clones are converted to regular objects"
 msgstr "Klone ohne Original werden zu regulären Objekten umgewandelt."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1338
+#: ../src/ui/dialog/inkscape-preferences.cpp:1393
 msgid "Orphaned clones are deleted along with their original"
 msgstr "Klone werden zusammen mit ihrem Original gelöscht."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1340
+#: ../src/ui/dialog/inkscape-preferences.cpp:1395
 msgid "Duplicating original+clones/linked offset"
 msgstr "Duplizieren Original+Klone/verbundener Versatz"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1342
+#: ../src/ui/dialog/inkscape-preferences.cpp:1397
 msgid "Relink duplicated clones"
 msgstr "Duplizierte Klone neu verbinden"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1344
+#: ../src/ui/dialog/inkscape-preferences.cpp:1399
 msgid ""
 "When duplicating a selection containing both a clone and its original "
 "(possibly in groups), relink the duplicated clone to the duplicated original "
@@ -21125,30 +21324,45 @@ msgstr ""
 "sind verbinde die kopierten Klone mit den kopierten Originalen anstatt mit "
 "den alten Originalen."
 
+#: ../src/ui/dialog/inkscape-preferences.cpp:1401
+#, fuzzy
+msgid "Unlinking clones"
+msgstr "Klonverbindung auftrennen"
+
+#: ../src/ui/dialog/inkscape-preferences.cpp:1402
+msgid "Path operations unlink clones"
+msgstr ""
+
+#: ../src/ui/dialog/inkscape-preferences.cpp:1404
+msgid ""
+"The following path operations will unlink clones: Stroke to path, Object to "
+"path, Boolean operations, Combine, Break apart"
+msgstr ""
+
 #. TRANSLATORS: Heading for the Inkscape Preferences "Clones" Page
-#: ../src/ui/dialog/inkscape-preferences.cpp:1347
+#: ../src/ui/dialog/inkscape-preferences.cpp:1407
 msgid "Clones"
 msgstr "Klone"
 
 #. Clip paths and masks options
-#: ../src/ui/dialog/inkscape-preferences.cpp:1350
+#: ../src/ui/dialog/inkscape-preferences.cpp:1410
 msgid "When applying, use the topmost selected object as clippath/mask"
 msgstr ""
 "Das oberste ausgewählte Objekt soll als Ausschneidepfad oder Maske verwendet "
 "werden."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1352
+#: ../src/ui/dialog/inkscape-preferences.cpp:1412
 msgid ""
 "Uncheck this to use the bottom selected object as the clipping path or mask"
 msgstr ""
 "Häkchen entfernen, um das unterste ausgewählte Objekt als Ausschneidepfad "
 "oder Maske zu verwenden"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1353
+#: ../src/ui/dialog/inkscape-preferences.cpp:1413
 msgid "Remove clippath/mask object after applying"
 msgstr "Ausschneidepfad/Maske nach dem Anwenden entfernen"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1355
+#: ../src/ui/dialog/inkscape-preferences.cpp:1415
 msgid ""
 "After applying, remove the object used as the clipping path or mask from the "
 "drawing"
@@ -21156,62 +21370,62 @@ msgstr ""
 "Das Objekt, welches als Ausschneidepfad oder Maske verwendet wird, nach dem "
 "Anwenden aus der Zeichnung löschen"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1357
+#: ../src/ui/dialog/inkscape-preferences.cpp:1417
 msgid "Before applying"
 msgstr "Vor dem Anwenden"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1359
+#: ../src/ui/dialog/inkscape-preferences.cpp:1419
 msgid "Do not group clipped/masked objects"
 msgstr "Kein Gruppieren ausgeschnittener/maskierter Objekte"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1360
+#: ../src/ui/dialog/inkscape-preferences.cpp:1420
 msgid "Put every clipped/masked object in its own group"
 msgstr ""
 "Jedes ausgeschnittene/maskierte Objekt in seiner eigenen Gruppe anlegen"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1361
+#: ../src/ui/dialog/inkscape-preferences.cpp:1421
 msgid "Put all clipped/masked objects into one group"
 msgstr ""
 "Alle ausgeschnittenen/maskierten Objekte in einer einzelne Gruppe ablegen"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1364
+#: ../src/ui/dialog/inkscape-preferences.cpp:1424
 msgid "Apply clippath/mask to every object"
 msgstr "Ausschneidepfad/Maske auf jedes Objekt anwenden"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1367
+#: ../src/ui/dialog/inkscape-preferences.cpp:1427
 msgid "Apply clippath/mask to groups containing single object"
 msgstr ""
 "Ausschneidepfad/Maske auf neue Gruppen anwenden, die jeweils ein "
 "Einzelobjekt beinhalten"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1370
+#: ../src/ui/dialog/inkscape-preferences.cpp:1430
 msgid "Apply clippath/mask to group containing all objects"
 msgstr ""
 "Ausschneidepfad/Maske auf eine neue Gruppe anwenden, die alle Objekte "
 "beinhaltet"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1372
+#: ../src/ui/dialog/inkscape-preferences.cpp:1432
 msgid "After releasing"
 msgstr "Nach dem Lösen:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1374
+#: ../src/ui/dialog/inkscape-preferences.cpp:1434
 msgid "Ungroup automatically created groups"
 msgstr "Gruppierung automatisch erstellter Gruppen aufheben"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1376
+#: ../src/ui/dialog/inkscape-preferences.cpp:1436
 msgid "Ungroup groups created when setting clip/mask"
 msgstr "Gruppierung aufheben beim Setzen von (Ausschneide-)Maske"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1378
+#: ../src/ui/dialog/inkscape-preferences.cpp:1438
 msgid "Clippaths and masks"
 msgstr "Ausschneidepfade und Masken"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1381
+#: ../src/ui/dialog/inkscape-preferences.cpp:1441
 msgid "Stroke Style Markers"
 msgstr "Strich-Stilmarkierungen"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1383
-#: ../src/ui/dialog/inkscape-preferences.cpp:1385
+#: ../src/ui/dialog/inkscape-preferences.cpp:1443
+#: ../src/ui/dialog/inkscape-preferences.cpp:1445
 msgid ""
 "Stroke color same as object, fill color either object fill color or marker "
 "fill color"
@@ -21219,50 +21433,50 @@ msgstr ""
 "Konturfarbe wie Objekt, Füllfarbe entweder Objekt-Füllfarbe oder "
 "Knotenmarkierung-Füllfarbe"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1389
+#: ../src/ui/dialog/inkscape-preferences.cpp:1449
 #: ../share/extensions/hershey.inx.h:27
 msgid "Markers"
 msgstr "Knotenmarkierungen"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1392
+#: ../src/ui/dialog/inkscape-preferences.cpp:1452
 msgid "Document cleanup"
 msgstr "Dokumentbereinigung"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1393
-#: ../src/ui/dialog/inkscape-preferences.cpp:1395
+#: ../src/ui/dialog/inkscape-preferences.cpp:1453
+#: ../src/ui/dialog/inkscape-preferences.cpp:1455
 msgid "Remove unused swatches when doing a document cleanup"
 msgstr "Entferne unbenutzte Swatches bei der Dokumentenbereinigung"
 
 #. tooltip
-#: ../src/ui/dialog/inkscape-preferences.cpp:1396
+#: ../src/ui/dialog/inkscape-preferences.cpp:1456
 msgid "Cleanup"
 msgstr "Bereinigen"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1404
+#: ../src/ui/dialog/inkscape-preferences.cpp:1464
 msgid "Number of _Threads:"
 msgstr "Anzahl der Threads:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1404
-#: ../src/ui/dialog/inkscape-preferences.cpp:1936
+#: ../src/ui/dialog/inkscape-preferences.cpp:1464
+#: ../src/ui/dialog/inkscape-preferences.cpp:1992
 msgid "(requires restart)"
 msgstr "(erfordert Neustart)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1405
+#: ../src/ui/dialog/inkscape-preferences.cpp:1465
 msgid "Configure number of processors/threads to use when rendering filters"
 msgstr ""
 "Konfiguration der Anzahl an Prozessoren/Threads, die für das Rendern von "
 "Filtern genutzt werden sollen"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1409
+#: ../src/ui/dialog/inkscape-preferences.cpp:1469
 msgid "Rendering _cache size:"
 msgstr "Rendering-Cachegröße:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1409
+#: ../src/ui/dialog/inkscape-preferences.cpp:1469
 msgctxt "mebibyte (2^20 bytes) abbreviation"
 msgid "MiB"
 msgstr "MiB"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1409
+#: ../src/ui/dialog/inkscape-preferences.cpp:1469
 msgid ""
 "Set the amount of memory per document which can be used to store rendered "
 "parts of the drawing for later reuse; set to zero to disable caching"
@@ -21271,17 +21485,12 @@ msgstr ""
 "gerenderte Teile der Zeichnung zur späteren Wiederverwendungzu sichern; auf "
 "Null setzen, um Cachen zu deaktivieren"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1413
+#: ../src/ui/dialog/inkscape-preferences.cpp:1473
 #, fuzzy
 msgid "Rendering tile multiplier:"
 msgstr "Rendering-Cachegröße:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1413
-#, fuzzy
-msgid "requires restart"
-msgstr "(erfordert Neustart)"
-
-#: ../src/ui/dialog/inkscape-preferences.cpp:1413
+#: ../src/ui/dialog/inkscape-preferences.cpp:1474
 msgid ""
 "Set the relative size of tiles used to render the canvas. The larger the "
 "value, the bigger the tile size."
@@ -21289,37 +21498,37 @@ msgstr ""
 
 #. blur quality
 #. filter quality
-#: ../src/ui/dialog/inkscape-preferences.cpp:1416
-#: ../src/ui/dialog/inkscape-preferences.cpp:1440
+#: ../src/ui/dialog/inkscape-preferences.cpp:1477
+#: ../src/ui/dialog/inkscape-preferences.cpp:1501
 msgid "Best quality (slowest)"
 msgstr "Beste Qualität (am langsamsten)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1418
-#: ../src/ui/dialog/inkscape-preferences.cpp:1442
+#: ../src/ui/dialog/inkscape-preferences.cpp:1479
+#: ../src/ui/dialog/inkscape-preferences.cpp:1503
 msgid "Better quality (slower)"
 msgstr "Gute Qualität (langsamer)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1420
-#: ../src/ui/dialog/inkscape-preferences.cpp:1444
+#: ../src/ui/dialog/inkscape-preferences.cpp:1481
+#: ../src/ui/dialog/inkscape-preferences.cpp:1505
 msgid "Average quality"
 msgstr "Durchschnittliche Qualität"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1422
-#: ../src/ui/dialog/inkscape-preferences.cpp:1446
+#: ../src/ui/dialog/inkscape-preferences.cpp:1483
+#: ../src/ui/dialog/inkscape-preferences.cpp:1507
 msgid "Lower quality (faster)"
 msgstr "Niedrigere Qualität (schneller)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1424
-#: ../src/ui/dialog/inkscape-preferences.cpp:1448
+#: ../src/ui/dialog/inkscape-preferences.cpp:1485
+#: ../src/ui/dialog/inkscape-preferences.cpp:1509
 msgid "Lowest quality (fastest)"
 msgstr "Niedrigste Qualität (am schnellsten)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1427
+#: ../src/ui/dialog/inkscape-preferences.cpp:1488
 msgid "Gaussian blur quality for display"
 msgstr "Anzeigequalität des Gaußschen Weichzeichners"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1429
-#: ../src/ui/dialog/inkscape-preferences.cpp:1453
+#: ../src/ui/dialog/inkscape-preferences.cpp:1490
+#: ../src/ui/dialog/inkscape-preferences.cpp:1514
 msgid ""
 "Best quality, but display may be very slow at high zooms (bitmap export "
 "always uses best quality)"
@@ -21327,125 +21536,125 @@ msgstr ""
 "Beste Qualität, aber die Anzeige kann bei hohen Zoomstufen sehr langsam sein "
 "(Bitmap-Export verwendet immer diese Einstellung)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1431
-#: ../src/ui/dialog/inkscape-preferences.cpp:1455
+#: ../src/ui/dialog/inkscape-preferences.cpp:1492
+#: ../src/ui/dialog/inkscape-preferences.cpp:1516
 msgid "Better quality, but slower display"
 msgstr "Bessere Qualität, aber langsamere Anzeige"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1433
-#: ../src/ui/dialog/inkscape-preferences.cpp:1457
+#: ../src/ui/dialog/inkscape-preferences.cpp:1494
+#: ../src/ui/dialog/inkscape-preferences.cpp:1518
 msgid "Average quality, acceptable display speed"
 msgstr "Durchschnittliche Qualität, akzeptable Geschwindigkeit der Anzeige"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1435
-#: ../src/ui/dialog/inkscape-preferences.cpp:1459
+#: ../src/ui/dialog/inkscape-preferences.cpp:1496
+#: ../src/ui/dialog/inkscape-preferences.cpp:1520
 msgid "Lower quality (some artifacts), but display is faster"
 msgstr "Niedrigere Qualität (einige Artefakte), aber schnellere Anzeige"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1437
-#: ../src/ui/dialog/inkscape-preferences.cpp:1461
+#: ../src/ui/dialog/inkscape-preferences.cpp:1498
+#: ../src/ui/dialog/inkscape-preferences.cpp:1522
 msgid "Lowest quality (considerable artifacts), but display is fastest"
 msgstr "Niedrigste Qualität (beträchtliche Artefakte), aber schnellste Anzeige"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1451
+#: ../src/ui/dialog/inkscape-preferences.cpp:1512
 msgid "Filter effects quality for display"
 msgstr "Effekt-Qualität für Anzeige:"
 
 #. build custom preferences tab
-#: ../src/ui/dialog/inkscape-preferences.cpp:1463
-#: ../src/ui/dialog/print.cpp:204
+#: ../src/ui/dialog/inkscape-preferences.cpp:1524
+#: ../src/ui/dialog/print.cpp:207
 msgid "Rendering"
 msgstr "Rendern"
 
 #. Note: /options/bitmapoversample removed with Cairo renderer
-#: ../src/ui/dialog/inkscape-preferences.cpp:1469 ../src/verbs.cpp:151
-#: ../src/widgets/calligraphy-toolbar.cpp:626
+#: ../src/ui/dialog/inkscape-preferences.cpp:1530 ../src/verbs.cpp:154
+#: ../src/widgets/calligraphy-toolbar.cpp:606
 msgid "Edit"
 msgstr "Bearbeiten"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1470
+#: ../src/ui/dialog/inkscape-preferences.cpp:1531
 msgid "Automatically reload bitmaps"
 msgstr "Automatisches Aktualisieren von Bildern"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1472
+#: ../src/ui/dialog/inkscape-preferences.cpp:1533
 msgid "Automatically reload linked images when file is changed on disk"
 msgstr "Bilder neu laden, wenn diese auf dem Datenträger geändert wurden."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1474
+#: ../src/ui/dialog/inkscape-preferences.cpp:1535
 msgid "_Bitmap editor:"
 msgstr "_Bitmap-Editor:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1476
-#: ../share/extensions/guillotine.inx.h:5 ../share/extensions/plotter.inx.h:65
+#: ../src/ui/dialog/inkscape-preferences.cpp:1537
+#: ../share/extensions/guillotine.inx.h:5 ../share/extensions/plotter.inx.h:67
 #: ../share/extensions/prepare_file_save_as.inx.h:2
 #: ../share/extensions/prepare_print_win32_vector.inx.h:2
 #: ../share/extensions/print_win32_vector.inx.h:2
 msgid "Export"
 msgstr "Exportieren"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1478
+#: ../src/ui/dialog/inkscape-preferences.cpp:1539
 msgid "Default export _resolution:"
 msgstr "Standard-Exportauflösung:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1479
+#: ../src/ui/dialog/inkscape-preferences.cpp:1540
 msgid "Default bitmap resolution (in dots per inch) in the Export dialog"
 msgstr ""
 "Bevorzugte Auflösung der Bitmap (Punkte pro Zoll) im Exportieren-Dialog"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1480
+#: ../src/ui/dialog/inkscape-preferences.cpp:1541
 #: ../src/ui/dialog/xml-tree.cpp:911
 msgid "Create"
 msgstr "Erstellen"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1482
+#: ../src/ui/dialog/inkscape-preferences.cpp:1543
 msgid "Resolution for Create Bitmap _Copy:"
 msgstr "Auflösung für Bitmap-_Kopie erstellen:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1483
+#: ../src/ui/dialog/inkscape-preferences.cpp:1544
 msgid "Resolution used by the Create Bitmap Copy command"
 msgstr "Auflösung von Bildern die mit \"Kopiere als Bitmap\" erstellt werden."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1486
+#: ../src/ui/dialog/inkscape-preferences.cpp:1547
 msgid "Ask about linking and scaling when importing"
 msgstr "Nach Verknüpfung und Skalierung beim Importieren fragen"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1488
+#: ../src/ui/dialog/inkscape-preferences.cpp:1549
 msgid "Pop-up linking and scaling dialog when importing bitmap image."
 msgstr ""
 "Dialog für Verknüpfung und Skalierung beim Importieren von Bitmaps anzeigen."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1494
+#: ../src/ui/dialog/inkscape-preferences.cpp:1555
 msgid "Bitmap link:"
 msgstr "Bitmap-Verknüpfung:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1501
+#: ../src/ui/dialog/inkscape-preferences.cpp:1562
 msgid "Bitmap scale (image-rendering):"
 msgstr "Bitmap Skalierung (image-rendering)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1506
+#: ../src/ui/dialog/inkscape-preferences.cpp:1567
 msgid "Default _import resolution:"
 msgstr "Standard-Importauflösung:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1507
+#: ../src/ui/dialog/inkscape-preferences.cpp:1568
 msgid "Default bitmap resolution (in dots per inch) for bitmap import"
 msgstr "Standard-Bitmapauflösung (Punkte pro Zoll) für Bitmap-Import"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1508
+#: ../src/ui/dialog/inkscape-preferences.cpp:1569
 msgid "Override file resolution"
 msgstr "Dateiauflösung überschreiben"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1510
+#: ../src/ui/dialog/inkscape-preferences.cpp:1571
 msgid "Use default bitmap resolution in favor of information from file"
 msgstr ""
 "Verwenden Sie Standard-Bitmap-Auflösung zu Gunsten von Informationen aus der "
 "Datei"
 
 #. rendering outlines for pixmap image tags
-#: ../src/ui/dialog/inkscape-preferences.cpp:1514
+#: ../src/ui/dialog/inkscape-preferences.cpp:1575
 msgid "Images in Outline Mode"
 msgstr "Bilder im Umrissmodus"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1515
+#: ../src/ui/dialog/inkscape-preferences.cpp:1576
 msgid ""
 "When active will render images while in outline mode instead of a red box "
 "with an x. This is useful for manual tracing."
@@ -21453,11 +21662,11 @@ msgstr ""
 "Bei Aktivierung werden Bilder als Umgrenzung anstelle eines roten Rechtecks "
 "mit X dargestellt. Nützlich für manuelles Nachzeichnen."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1517
+#: ../src/ui/dialog/inkscape-preferences.cpp:1578
 msgid "Bitmaps"
 msgstr "Bitmaps"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1529
+#: ../src/ui/dialog/inkscape-preferences.cpp:1590
 msgid ""
 "Select a file of predefined shortcuts to use. Any customized shortcuts you "
 "create will be added separately to "
@@ -21465,25 +21674,25 @@ msgstr ""
 "Wählen Sie eine Datei mit vorderfinierten Tastenkürzeln. Jeder "
 "benutzerdefinierte Kürzel, der erstellt wird, wird separat hinzugefügt zu"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1532
+#: ../src/ui/dialog/inkscape-preferences.cpp:1593
 msgid "Shortcut file:"
 msgstr "Tastenkürzel-Datei:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1535
+#: ../src/ui/dialog/inkscape-preferences.cpp:1596
 #: ../src/ui/dialog/template-load-tab.cpp:43
 msgid "Search:"
 msgstr "Suchen:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1547
+#: ../src/ui/dialog/inkscape-preferences.cpp:1608
 msgid "Shortcut"
 msgstr "Tastenkürzel"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1548
-#: ../src/ui/widget/page-sizer.cpp:270
+#: ../src/ui/dialog/inkscape-preferences.cpp:1609
+#: ../src/ui/widget/page-sizer.cpp:271
 msgid "Description"
 msgstr "Beschreibung"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1591
+#: ../src/ui/dialog/inkscape-preferences.cpp:1652
 msgid ""
 "Remove all your customized keyboard shortcuts, and revert to the shortcuts "
 "in the shortcut file listed above"
@@ -21491,46 +21700,46 @@ msgstr ""
 "Alle individuellen Tastenkürzel entfernen und zurück zu den Tastenkürzeln in "
 "der oben aufgeführten Tastenkürzel-Datei"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1595
+#: ../src/ui/dialog/inkscape-preferences.cpp:1656
 msgid "Import ..."
 msgstr "_Importieren ..."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1595
+#: ../src/ui/dialog/inkscape-preferences.cpp:1656
 msgid "Import custom keyboard shortcuts from a file"
 msgstr "Importieren einer benutzerdefinierten Tastenkürzel-Datei"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1598
+#: ../src/ui/dialog/inkscape-preferences.cpp:1659
 msgid "Export ..."
 msgstr "Exportieren ..."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1598
+#: ../src/ui/dialog/inkscape-preferences.cpp:1659
 msgid "Export custom keyboard shortcuts to a file"
 msgstr "Benutzerdefinierte Tastenkürzel in eine Datei exportieren"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1608
+#: ../src/ui/dialog/inkscape-preferences.cpp:1669
 msgid "Keyboard Shortcuts"
 msgstr "Tastenkürzel"
 
 #. Find this group in the tree
-#: ../src/ui/dialog/inkscape-preferences.cpp:1771
+#: ../src/ui/dialog/inkscape-preferences.cpp:1832
 msgid "Misc"
 msgstr "Sonstiges"
 
 # CHECK
-#: ../src/ui/dialog/inkscape-preferences.cpp:1877
+#: ../src/ui/dialog/inkscape-preferences.cpp:1938
 msgctxt "Spellchecker language"
 msgid "None"
 msgstr "Keine"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1898
+#: ../src/ui/dialog/inkscape-preferences.cpp:1959
 msgid "Set the main spell check language"
 msgstr "Setzen der Hauptsprache der Rechtschreibprüfung"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1901
+#: ../src/ui/dialog/inkscape-preferences.cpp:1962
 msgid "Second language:"
 msgstr "Zweite Sprache:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1902
+#: ../src/ui/dialog/inkscape-preferences.cpp:1963
 msgid ""
 "Set the second spell check language; checking will only stop on words "
 "unknown in ALL chosen languages"
@@ -21538,11 +21747,11 @@ msgstr ""
 "Setzen der zweiten Sprache der Rechtschreibprüfung; die Prüfung stoppt nur "
 "bei Wörtern, die in allen ausgewählten Sprachen unbekannt sind."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1905
+#: ../src/ui/dialog/inkscape-preferences.cpp:1966
 msgid "Third language:"
 msgstr "Dritte Sprache:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1906
+#: ../src/ui/dialog/inkscape-preferences.cpp:1967
 msgid ""
 "Set the third spell check language; checking will only stop on words unknown "
 "in ALL chosen languages"
@@ -21550,31 +21759,31 @@ msgstr ""
 "Festlegen der dritten Sprache der Rechtschreibprüfung; die Prüfung stoppt "
 "nur bei Wörtern, die in allen ausgewählten Sprachen unbekannt sind."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1908
+#: ../src/ui/dialog/inkscape-preferences.cpp:1969
 msgid "Ignore words with digits"
 msgstr "Wörter mit Zahlen ignorieren"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1910
+#: ../src/ui/dialog/inkscape-preferences.cpp:1971
 msgid "Ignore words containing digits, such as \"R2D2\""
 msgstr "Wörter mit Zahlen ignorieren, wie \"R2D2\""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1912
+#: ../src/ui/dialog/inkscape-preferences.cpp:1973
 msgid "Ignore words in ALL CAPITALS"
 msgstr "Wörter in GROSSGESCHRIEBEN ignorieren"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1914
+#: ../src/ui/dialog/inkscape-preferences.cpp:1975
 msgid "Ignore words in all capitals, such as \"IUPAC\""
 msgstr "Wörter ignorieren, die GROSSGESCHRIEBEN sind, wie \"IUPAC\""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1916
+#: ../src/ui/dialog/inkscape-preferences.cpp:1977
 msgid "Spellcheck"
 msgstr "Rechtschreibprüfung"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1936
+#: ../src/ui/dialog/inkscape-preferences.cpp:1992
 msgid "Latency _skew:"
 msgstr "Latenz-_Schrägstellung:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1937
+#: ../src/ui/dialog/inkscape-preferences.cpp:1993
 msgid ""
 "Factor by which the event clock is skewed from the actual time (0.9766 on "
 "some systems)"
@@ -21582,11 +21791,11 @@ msgstr ""
 "Faktor, um den die Ereigniszeit gegenüber der Systemzeit verlangsamt wird "
 "(0,9766 auf manchen Systemen)"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1939
+#: ../src/ui/dialog/inkscape-preferences.cpp:1995
 msgid "Pre-render named icons"
 msgstr "Symbole mit Namen im Voraus rendern"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1941
+#: ../src/ui/dialog/inkscape-preferences.cpp:1997
 msgid ""
 "When on, named icons will be rendered before displaying the ui. This is for "
 "working around bugs in GTK+ named icon notification"
@@ -21595,160 +21804,160 @@ msgstr ""
 "wird. Damit werden Fehler in der GTK+-Hinweisen zu benannten Symbolen "
 "umgangen."
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1949
+#: ../src/ui/dialog/inkscape-preferences.cpp:2001
 msgid "System info"
 msgstr "Systeminformation"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1953
+#: ../src/ui/dialog/inkscape-preferences.cpp:2005
 msgid "User config: "
 msgstr "Benutzerkonfiguration: "
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1953
+#: ../src/ui/dialog/inkscape-preferences.cpp:2005
 msgid "Location of users configuration"
 msgstr "Ort der Benutzerkonfiguration"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1957
+#: ../src/ui/dialog/inkscape-preferences.cpp:2009
 msgid "User preferences: "
 msgstr "Benutzereinstellungen: "
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1957
+#: ../src/ui/dialog/inkscape-preferences.cpp:2009
 msgid "Location of the users preferences file"
 msgstr "Ort der Benutzer-Einstellungsdatei"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1961
+#: ../src/ui/dialog/inkscape-preferences.cpp:2013
 msgid "User extensions: "
 msgstr "Benutzererweiterungen: "
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1961
+#: ../src/ui/dialog/inkscape-preferences.cpp:2013
 msgid "Location of the users extensions"
 msgstr "Ort der Benutzererweiterungen"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1965
+#: ../src/ui/dialog/inkscape-preferences.cpp:2017
 msgid "User cache: "
 msgstr "Benutzer-Cache: "
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1965
+#: ../src/ui/dialog/inkscape-preferences.cpp:2017
 msgid "Location of users cache"
 msgstr "Ort des Benutzer-Caches"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1973
+#: ../src/ui/dialog/inkscape-preferences.cpp:2025
 msgid "Temporary files: "
 msgstr "Temporäre Dateien: "
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1973
+#: ../src/ui/dialog/inkscape-preferences.cpp:2025
 msgid "Location of the temporary files used for autosave"
 msgstr "Ort der temp. Dateien, die für die autom. Speicherung verwendet werden"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1977
+#: ../src/ui/dialog/inkscape-preferences.cpp:2029
 msgid "Inkscape data: "
 msgstr "Inkscape-Daten:"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1977
+#: ../src/ui/dialog/inkscape-preferences.cpp:2029
 msgid "Location of Inkscape data"
 msgstr "Ort der Inkscape-Daten"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1981
+#: ../src/ui/dialog/inkscape-preferences.cpp:2033
 msgid "Inkscape extensions: "
 msgstr "Inkscape-Erweiterungen: "
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1981
+#: ../src/ui/dialog/inkscape-preferences.cpp:2033
 msgid "Location of the Inkscape extensions"
 msgstr "Ort der Inkscape-Erweiterungen"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1990
+#: ../src/ui/dialog/inkscape-preferences.cpp:2043
 msgid "System data: "
 msgstr "Systemdaten: "
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1990
+#: ../src/ui/dialog/inkscape-preferences.cpp:2043
 msgid "Locations of system data"
 msgstr "Ort der Systemdaten"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:2014
+#: ../src/ui/dialog/inkscape-preferences.cpp:2057
 msgid "Icon theme: "
 msgstr "Symbolthema: "
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:2014
+#: ../src/ui/dialog/inkscape-preferences.cpp:2057
 msgid "Locations of icon themes"
 msgstr "Ort der Symbolthemen"
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:2016
+#: ../src/ui/dialog/inkscape-preferences.cpp:2059
 msgid "System"
 msgstr "System"
 
-#: ../src/ui/dialog/input.cpp:345 ../src/ui/dialog/input.cpp:366
-#: ../src/ui/dialog/input.cpp:1467 ../src/widgets/toolbox.cpp:227
+#: ../src/ui/dialog/input.cpp:346 ../src/ui/dialog/input.cpp:367
+#: ../src/ui/dialog/input.cpp:1468 ../src/widgets/toolbox.cpp:227
 msgid "Disabled"
 msgstr "Deaktiviert"
 
-#: ../src/ui/dialog/input.cpp:346
+#: ../src/ui/dialog/input.cpp:347
 msgctxt "Input device"
 msgid "Screen"
 msgstr "Bildschirm"
 
-#: ../src/ui/dialog/input.cpp:347 ../src/ui/dialog/input.cpp:368
+#: ../src/ui/dialog/input.cpp:348 ../src/ui/dialog/input.cpp:369
 msgid "Window"
 msgstr "Fenster"
 
-#: ../src/ui/dialog/input.cpp:578
+#: ../src/ui/dialog/input.cpp:579
 msgid "Test Area"
 msgstr "Testfläche"
 
-#: ../src/ui/dialog/input.cpp:579
+#: ../src/ui/dialog/input.cpp:580
 msgid "Axis"
 msgstr "Achse"
 
-#: ../src/ui/dialog/input.cpp:651 ../share/extensions/svgcalendar.inx.h:2
+#: ../src/ui/dialog/input.cpp:652 ../share/extensions/svgcalendar.inx.h:2
 msgid "Configuration"
 msgstr "Konfiguration"
 
-#: ../src/ui/dialog/input.cpp:652
+#: ../src/ui/dialog/input.cpp:653
 msgid "Hardware"
 msgstr "Hardware"
 
-#: ../src/ui/dialog/input.cpp:665
+#: ../src/ui/dialog/input.cpp:666
 msgid "Link:"
 msgstr "Verknüpfung:"
 
 # CHECK
-#: ../src/ui/dialog/input.cpp:667 ../src/ui/dialog/input.cpp:668
-#: ../src/ui/dialog/input.cpp:1397 ../src/ui/widget/color-scales.cpp:43
+#: ../src/ui/dialog/input.cpp:668 ../src/ui/dialog/input.cpp:669
+#: ../src/ui/dialog/input.cpp:1398 ../src/ui/widget/color-scales.cpp:43
 #: ../share/extensions/plotter.inx.h:24
 msgid "None"
 msgstr "Keine"
 
-#: ../src/ui/dialog/input.cpp:674
+#: ../src/ui/dialog/input.cpp:675
 msgid "Axes count:"
 msgstr "Achsenanzahl:"
 
-#: ../src/ui/dialog/input.cpp:680
+#: ../src/ui/dialog/input.cpp:681
 msgid "axis:"
 msgstr "Achse:"
 
-#: ../src/ui/dialog/input.cpp:693
+#: ../src/ui/dialog/input.cpp:694
 msgid "Button count:"
 msgstr "Anzahl Tasten:"
 
-#: ../src/ui/dialog/input.cpp:842
+#: ../src/ui/dialog/input.cpp:843
 msgid "Tablet"
 msgstr "Grafiktablett"
 
-#: ../src/ui/dialog/input.cpp:871 ../src/ui/dialog/input.cpp:1754
+#: ../src/ui/dialog/input.cpp:872 ../src/ui/dialog/input.cpp:1755
 msgid "pad"
 msgstr "Unterlage"
 
-#: ../src/ui/dialog/input.cpp:913
+#: ../src/ui/dialog/input.cpp:914
 msgid "_Use pressure-sensitive tablet (requires restart)"
 msgstr "Druckempfindliches Grafiktablett verwenden (erfordert Neustart)"
 
-#: ../src/ui/dialog/input.cpp:918
+#: ../src/ui/dialog/input.cpp:919
 msgid "Axes"
 msgstr "Achsen"
 
-#: ../src/ui/dialog/input.cpp:919
+#: ../src/ui/dialog/input.cpp:920
 msgid "Keys"
 msgstr "Schlüssel"
 
-#: ../src/ui/dialog/input.cpp:996
+#: ../src/ui/dialog/input.cpp:997
 msgid ""
 "A device can be 'Disabled', its co-ordinates mapped to the whole 'Screen', "
 "or to a single (usually focused) 'Window'"
@@ -21757,26 +21966,26 @@ msgstr ""
 "gesamten 'Bildschirm' gemappt oder in ein einzelnes (normalerweise das "
 "aktive) 'Fenster'"
 
-#: ../src/ui/dialog/input.cpp:1442 ../src/widgets/calligraphy-toolbar.cpp:578
-#: ../src/widgets/spray-toolbar.cpp:311 ../src/widgets/spray-toolbar.cpp:427
-#: ../src/widgets/spray-toolbar.cpp:476 ../src/widgets/tweak-toolbar.cpp:372
+#: ../src/ui/dialog/input.cpp:1443 ../src/widgets/calligraphy-toolbar.cpp:549
+#: ../src/widgets/spray-toolbar.cpp:311 ../src/widgets/spray-toolbar.cpp:425
+#: ../src/widgets/spray-toolbar.cpp:474 ../src/widgets/tweak-toolbar.cpp:372
 msgid "Pressure"
 msgstr "Druck"
 
-#: ../src/ui/dialog/input.cpp:1442
+#: ../src/ui/dialog/input.cpp:1443
 msgid "X tilt"
 msgstr "X-Neigung"
 
-#: ../src/ui/dialog/input.cpp:1442
+#: ../src/ui/dialog/input.cpp:1443
 msgid "Y tilt"
 msgstr "Y-Neigung"
 
-#: ../src/ui/dialog/input.cpp:1442 ../src/ui/widget/color-wheel-selector.cpp:25
+#: ../src/ui/dialog/input.cpp:1443 ../src/ui/widget/color-wheel-selector.cpp:25
 msgid "Wheel"
 msgstr "Farbrad"
 
 # CHECK
-#: ../src/ui/dialog/input.cpp:1451
+#: ../src/ui/dialog/input.cpp:1452
 msgctxt "Input device axe"
 msgid "None"
 msgstr "Keine"
@@ -21836,8 +22045,8 @@ msgstr "Ebene umbenennen"
 
 #. TODO: find an unused layer number, forming name from _("Layer ") + "%d"
 #: ../src/ui/dialog/layer-properties.cpp:326
-#: ../src/ui/dialog/layer-properties.cpp:382 ../src/verbs.cpp:189
-#: ../src/verbs.cpp:2496
+#: ../src/ui/dialog/layer-properties.cpp:382 ../src/verbs.cpp:192
+#: ../src/verbs.cpp:2526
 msgid "Layer"
 msgstr "Ebene"
 
@@ -21845,7 +22054,7 @@ msgstr "Ebene"
 msgid "_Rename"
 msgstr "_Umbenennen"
 
-#: ../src/ui/dialog/layer-properties.cpp:340 ../src/ui/dialog/layers.cpp:756
+#: ../src/ui/dialog/layer-properties.cpp:340 ../src/ui/dialog/layers.cpp:761
 msgid "Rename layer"
 msgstr "Ebene umbenennen"
 
@@ -21887,41 +22096,41 @@ msgstr "Ebene sperren"
 msgid "Unlock layer"
 msgstr "Ebene entsperren"
 
-#: ../src/ui/dialog/layers.cpp:622 ../src/ui/dialog/objects.cpp:852
-#: ../src/verbs.cpp:1471
+#: ../src/ui/dialog/layers.cpp:627 ../src/ui/dialog/objects.cpp:867
+#: ../src/verbs.cpp:1493
 msgid "Toggle layer solo"
 msgstr "Sichtbarkeit der aktuellen Ebene umschalten"
 
-#: ../src/ui/dialog/layers.cpp:625 ../src/ui/dialog/objects.cpp:855
-#: ../src/verbs.cpp:1495
+#: ../src/ui/dialog/layers.cpp:630 ../src/ui/dialog/objects.cpp:870
+#: ../src/verbs.cpp:1517
 msgid "Lock other layers"
 msgstr "Andere Ebenen sperren"
 
-#: ../src/ui/dialog/layers.cpp:728
+#: ../src/ui/dialog/layers.cpp:733
 msgid "Move layer"
 msgstr "Ebene verschieben"
 
-#: ../src/ui/dialog/layers.cpp:886
+#: ../src/ui/dialog/layers.cpp:894
 msgctxt "Layers"
 msgid "New"
 msgstr "Neu"
 
-#: ../src/ui/dialog/layers.cpp:891
+#: ../src/ui/dialog/layers.cpp:899
 msgctxt "Layers"
 msgid "Bot"
 msgstr "Unten"
 
-#: ../src/ui/dialog/layers.cpp:897
+#: ../src/ui/dialog/layers.cpp:905
 msgctxt "Layers"
 msgid "Dn"
 msgstr "Runter"
 
-#: ../src/ui/dialog/layers.cpp:903
+#: ../src/ui/dialog/layers.cpp:911
 msgctxt "Layers"
 msgid "Up"
 msgstr "Hoch"
 
-#: ../src/ui/dialog/layers.cpp:909
+#: ../src/ui/dialog/layers.cpp:917
 msgctxt "Layers"
 msgid "Top"
 msgstr "Oben"
@@ -21946,57 +22155,57 @@ msgstr "Aktuellen Pfadeffekt anheben"
 msgid "Lower the current path effect"
 msgstr "Aktuellen Pfadeffekt absenken"
 
-#: ../src/ui/dialog/livepatheffect-editor.cpp:311
+#: ../src/ui/dialog/livepatheffect-editor.cpp:313
 msgid "Unknown effect is applied"
 msgstr "Unbekannter Effekt wurde angewendet"
 
-#: ../src/ui/dialog/livepatheffect-editor.cpp:314
+#: ../src/ui/dialog/livepatheffect-editor.cpp:316
 msgid "Click button to add an effect"
 msgstr "Schaltfläche klicken, um Effekt hinzuzufügen"
 
-#: ../src/ui/dialog/livepatheffect-editor.cpp:329
+#: ../src/ui/dialog/livepatheffect-editor.cpp:331
 msgid "Click add button to convert clone"
 msgstr "Klicken Sie auf Hinzufügen, um Klon zu konvertieren"
 
-#: ../src/ui/dialog/livepatheffect-editor.cpp:334
-#: ../src/ui/dialog/livepatheffect-editor.cpp:338
-#: ../src/ui/dialog/livepatheffect-editor.cpp:347
+#: ../src/ui/dialog/livepatheffect-editor.cpp:336
+#: ../src/ui/dialog/livepatheffect-editor.cpp:340
+#: ../src/ui/dialog/livepatheffect-editor.cpp:349
 msgid "Select a path or shape"
 msgstr "Wähle einen Pfad oder Form"
 
-#: ../src/ui/dialog/livepatheffect-editor.cpp:343
+#: ../src/ui/dialog/livepatheffect-editor.cpp:345
 msgid "Only one item can be selected"
 msgstr "Nur ein Element kann ausgewählt werden"
 
-#: ../src/ui/dialog/livepatheffect-editor.cpp:375
+#: ../src/ui/dialog/livepatheffect-editor.cpp:377
 msgid "Unknown effect"
 msgstr "Unbekannter Effekt wurde angewendet"
 
-#: ../src/ui/dialog/livepatheffect-editor.cpp:451
+#: ../src/ui/dialog/livepatheffect-editor.cpp:453
 msgid "Create and apply path effect"
 msgstr "Pfadeffekt erstellen und anwenden"
 
-#: ../src/ui/dialog/livepatheffect-editor.cpp:491
+#: ../src/ui/dialog/livepatheffect-editor.cpp:493
 msgid "Create and apply Clone original path effect"
 msgstr "Erstellen und Anwenden des Original-Klonen-Pfadeffekts"
 
-#: ../src/ui/dialog/livepatheffect-editor.cpp:513
+#: ../src/ui/dialog/livepatheffect-editor.cpp:515
 msgid "Remove path effect"
 msgstr "Pfadeffekt entfernen"
 
-#: ../src/ui/dialog/livepatheffect-editor.cpp:531
+#: ../src/ui/dialog/livepatheffect-editor.cpp:533
 msgid "Move path effect up"
 msgstr "Pfadeffekt nach oben verschieben"
 
-#: ../src/ui/dialog/livepatheffect-editor.cpp:548
+#: ../src/ui/dialog/livepatheffect-editor.cpp:550
 msgid "Move path effect down"
 msgstr "Pfadeffekt nach unten verschieben"
 
-#: ../src/ui/dialog/livepatheffect-editor.cpp:603
+#: ../src/ui/dialog/livepatheffect-editor.cpp:605
 msgid "Activate path effect"
 msgstr "Pfadeffekt aktivieren"
 
-#: ../src/ui/dialog/livepatheffect-editor.cpp:603
+#: ../src/ui/dialog/livepatheffect-editor.cpp:605
 msgid "Deactivate path effect"
 msgstr "Pfadeffekt deaktivieren"
 
@@ -22040,34 +22249,34 @@ msgstr "%1:"
 msgid "Modify Node Position"
 msgstr "Knotenposition anpassen"
 
-#: ../src/ui/dialog/memory.cpp:97
+#: ../src/ui/dialog/memory.cpp:98
 msgid "Heap"
 msgstr "Heap"
 
-#: ../src/ui/dialog/memory.cpp:98
+#: ../src/ui/dialog/memory.cpp:99
 msgid "In Use"
 msgstr "Benutzt"
 
 #. TRANSLATORS: "Slack" refers to memory which is in the heap but currently unused.
 #. More typical usage is to call this memory "free" rather than "slack".
-#: ../src/ui/dialog/memory.cpp:101
+#: ../src/ui/dialog/memory.cpp:102
 msgid "Slack"
 msgstr "Ungenutzt; reserviert"
 
-#: ../src/ui/dialog/memory.cpp:102
+#: ../src/ui/dialog/memory.cpp:103
 msgid "Total"
 msgstr "Gesamt"
 
-#: ../src/ui/dialog/memory.cpp:142 ../src/ui/dialog/memory.cpp:148
-#: ../src/ui/dialog/memory.cpp:155 ../src/ui/dialog/memory.cpp:187
+#: ../src/ui/dialog/memory.cpp:143 ../src/ui/dialog/memory.cpp:149
+#: ../src/ui/dialog/memory.cpp:156 ../src/ui/dialog/memory.cpp:188
 msgid "Unknown"
 msgstr "Unbekannt"
 
-#: ../src/ui/dialog/memory.cpp:168
+#: ../src/ui/dialog/memory.cpp:169
 msgid "Combined"
 msgstr "Kombiniert"
 
-#: ../src/ui/dialog/memory.cpp:210
+#: ../src/ui/dialog/memory.cpp:218
 msgid "Recalculate"
 msgstr "Neu berechnen"
 
@@ -22199,8 +22408,8 @@ msgid "Check to make the object insensitive (not selectable by mouse)"
 msgstr "Aktivieren macht das Objekt unempfindlich (nicht durch Maus anwählbar)"
 
 #. Button for setting the object's id, label, title and description.
-#: ../src/ui/dialog/object-properties.cpp:237 ../src/verbs.cpp:2874
-#: ../src/verbs.cpp:2880
+#: ../src/ui/dialog/object-properties.cpp:237 ../src/verbs.cpp:2904
+#: ../src/verbs.cpp:2912
 msgid "_Set"
 msgstr "_Setzen"
 
@@ -22258,97 +22467,97 @@ msgstr "Objekte ausblenden"
 msgid "Unhide object"
 msgstr "Ausgeblendete Objekte anzeigen"
 
-#: ../src/ui/dialog/objects.cpp:882
+#: ../src/ui/dialog/objects.cpp:897
 msgid "Unhide objects"
 msgstr "Objekte einblenden"
 
-#: ../src/ui/dialog/objects.cpp:882
+#: ../src/ui/dialog/objects.cpp:897
 msgid "Hide objects"
 msgstr "Objekte ausblenden"
 
-#: ../src/ui/dialog/objects.cpp:902
+#: ../src/ui/dialog/objects.cpp:917
 msgid "Lock objects"
 msgstr "Objekte sperren"
 
-#: ../src/ui/dialog/objects.cpp:902
+#: ../src/ui/dialog/objects.cpp:917
 msgid "Unlock objects"
 msgstr "Objekte entsperren"
 
-#: ../src/ui/dialog/objects.cpp:914
+#: ../src/ui/dialog/objects.cpp:929
 msgid "Layer to group"
 msgstr "Ebene zu Gruppe"
 
-#: ../src/ui/dialog/objects.cpp:914
+#: ../src/ui/dialog/objects.cpp:929
 msgid "Group to layer"
 msgstr "Gruppe zu Ebene"
 
-#: ../src/ui/dialog/objects.cpp:1112
+#: ../src/ui/dialog/objects.cpp:1127
 msgid "Moved objects"
 msgstr "Verschobene Objekte"
 
-#: ../src/ui/dialog/objects.cpp:1361 ../src/ui/dialog/tags.cpp:838
-#: ../src/ui/dialog/tags.cpp:845
+#: ../src/ui/dialog/objects.cpp:1376 ../src/ui/dialog/tags.cpp:842
+#: ../src/ui/dialog/tags.cpp:849
 msgid "Rename object"
 msgstr "Objekt umbenennen"
 
-#: ../src/ui/dialog/objects.cpp:1468
+#: ../src/ui/dialog/objects.cpp:1483
 msgid "Set object highlight color"
 msgstr "Markierungsfarbe des Objekts festlegen"
 
-#: ../src/ui/dialog/objects.cpp:1478
+#: ../src/ui/dialog/objects.cpp:1493
 msgid "Set object opacity"
 msgstr "Deckkraft des Objekts festlegen"
 
-#: ../src/ui/dialog/objects.cpp:1507
+#: ../src/ui/dialog/objects.cpp:1522
 msgid "Set object blend mode"
 msgstr "Mischmodus des Objekts festlegen"
 
-#: ../src/ui/dialog/objects.cpp:1576
+#: ../src/ui/dialog/objects.cpp:1592
 msgid "Set object blur"
 msgstr "Unschärfe des Objekts festlegen"
 
 # New objects dialog from ponyscape: single letter to describe state of the object in header of the table: visible
-#: ../src/ui/dialog/objects.cpp:1642
+#: ../src/ui/dialog/objects.cpp:1658
 msgctxt "Visibility"
 msgid "V"
 msgstr "S"
 
-#: ../src/ui/dialog/objects.cpp:1643
+#: ../src/ui/dialog/objects.cpp:1659
 msgctxt "Lock"
 msgid "L"
 msgstr "L"
 
 # New objects dialog from ponyscape: single letter to describe state of the object in header of the table: type (layer, group or object)
-#: ../src/ui/dialog/objects.cpp:1644
+#: ../src/ui/dialog/objects.cpp:1660
 msgctxt "Type"
 msgid "T"
 msgstr "T"
 
-#: ../src/ui/dialog/objects.cpp:1645
+#: ../src/ui/dialog/objects.cpp:1661
 msgctxt "Clip and mask"
 msgid "CM"
 msgstr "M"
 
 # New objects dialog from ponyscape: single letter to describe state of the object in header of the table: color of path outline in node tool (de: Pfadfarbe)
-#: ../src/ui/dialog/objects.cpp:1646
+#: ../src/ui/dialog/objects.cpp:1662
 msgctxt "Highlight"
 msgid "HL"
 msgstr "F"
 
-#: ../src/ui/dialog/objects.cpp:1647
+#: ../src/ui/dialog/objects.cpp:1663
 msgid "Label"
 msgstr "Name"
 
 #. In order to get tooltips on header, we must create our own label.
-#: ../src/ui/dialog/objects.cpp:1683
+#: ../src/ui/dialog/objects.cpp:1691
 msgid "Toggle visibility of Layer, Group, or Object."
 msgstr "Sichtbarkeit von Ebene, Gruppe oder Objekt umschalten."
 
-#: ../src/ui/dialog/objects.cpp:1696
+#: ../src/ui/dialog/objects.cpp:1704
 msgid "Toggle lock of Layer, Group, or Object."
 msgstr "Sperre von Ebene, Gruppe oder Objekt umschalten."
 
-#: ../src/ui/dialog/objects.cpp:1708
+#: ../src/ui/dialog/objects.cpp:1716
 msgid ""
 "Type: Layer, Group, or Object. Clicking on Layer or Group icon, toggles "
 "between the two types."
@@ -22356,11 +22565,11 @@ msgstr ""
 "Typ: Ebene, Gruppe oder Objekt. Mit einem Klick auf das Symbol für Ebene "
 "oder Gruppe zwischen beiden Typen umschalten"
 
-#: ../src/ui/dialog/objects.cpp:1727
+#: ../src/ui/dialog/objects.cpp:1735
 msgid "Is object clipped and/or masked?"
 msgstr "Ist das Objekt ausgeschnitten oder maskiert?"
 
-#: ../src/ui/dialog/objects.cpp:1738
+#: ../src/ui/dialog/objects.cpp:1746
 msgid ""
 "Highlight color of outline in Node tool. Click to set. If alpha is zero, use "
 "inherited color."
@@ -22368,7 +22577,7 @@ msgstr ""
 "Farbe des Pfades beim Bearbeiten mit dem Knotenwerkzeug. Klicken zum Ändern. "
 "Bei einem Alpha-Wert von Null wird die Farbe geerbt."
 
-#: ../src/ui/dialog/objects.cpp:1749
+#: ../src/ui/dialog/objects.cpp:1757
 msgid ""
 "Layer/Group/Object label (inkscape:label). Double-click to set. Default "
 "value is object 'id'."
@@ -22376,82 +22585,82 @@ msgstr ""
 "Name für Ebene/Gruppe/Objekt (inkscape:label). Doppelklicken zum Ändern. "
 "Standardwert ist die ID des Objektes."
 
-#: ../src/ui/dialog/objects.cpp:1857
+#: ../src/ui/dialog/objects.cpp:1819
 msgid "Add layer..."
 msgstr "Ebe_ne hinzufügen..."
 
-#: ../src/ui/dialog/objects.cpp:1864
+#: ../src/ui/dialog/objects.cpp:1826
 msgid "Remove object"
 msgstr "Objekt entfernen"
 
-#: ../src/ui/dialog/objects.cpp:1872
+#: ../src/ui/dialog/objects.cpp:1834
 msgid "Move To Bottom"
 msgstr "Nach ganz unten absenken"
 
-#: ../src/ui/dialog/objects.cpp:1896
+#: ../src/ui/dialog/objects.cpp:1858
 msgid "Move To Top"
 msgstr "Nach ganz oben anheben"
 
-#: ../src/ui/dialog/objects.cpp:1904
+#: ../src/ui/dialog/objects.cpp:1866
 msgid "Collapse All"
 msgstr "Alle zusammenklappen"
 
-#: ../src/ui/dialog/objects.cpp:1918
+#: ../src/ui/dialog/objects.cpp:1880
 msgid "Rename"
 msgstr "Umbenennen"
 
 # Make selected layer the only visible one.
-#: ../src/ui/dialog/objects.cpp:1924
+#: ../src/ui/dialog/objects.cpp:1886
 msgid "Solo"
 msgstr "Nur diese Ebene anzeigen"
 
-#: ../src/ui/dialog/objects.cpp:1925
+#: ../src/ui/dialog/objects.cpp:1887
 msgid "Show All"
 msgstr "Alle anzeigen"
 
 # !!! mnemonics
-#: ../src/ui/dialog/objects.cpp:1926
+#: ../src/ui/dialog/objects.cpp:1888
 msgid "Hide All"
 msgstr "Alle ausblenden"
 
-#: ../src/ui/dialog/objects.cpp:1930
+#: ../src/ui/dialog/objects.cpp:1892
 msgid "Lock Others"
 msgstr "Andere sperren"
 
 # !!! mnemonics
-#: ../src/ui/dialog/objects.cpp:1931
+#: ../src/ui/dialog/objects.cpp:1893
 msgid "Lock All"
 msgstr "Alle sperren"
 
 # !!! mnemonics
 #. LockAndHide
-#: ../src/ui/dialog/objects.cpp:1932 ../src/verbs.cpp:3193
+#: ../src/ui/dialog/objects.cpp:1894 ../src/verbs.cpp:3227
 msgid "Unlock All"
 msgstr "Alle entsperren"
 
-#: ../src/ui/dialog/objects.cpp:1936
+#: ../src/ui/dialog/objects.cpp:1898
 msgid "Up"
 msgstr "Nach oben"
 
-#: ../src/ui/dialog/objects.cpp:1937
+#: ../src/ui/dialog/objects.cpp:1899
 msgid "Down"
 msgstr "Nach unten"
 
-#: ../src/ui/dialog/objects.cpp:1946
+#: ../src/ui/dialog/objects.cpp:1908
 msgid "Set Clip"
 msgstr "Ausschneidemaske setzen"
 
 #. will never be implemented
 #. _watching.push_back( &_addPopupItem( targetDesktop, SP_VERB_OBJECT_SET_INVERSE_CLIPPATH, 0, "Set Inverse Clip", (int)BUTTON_SETINVCLIP ) );
-#: ../src/ui/dialog/objects.cpp:1952
+#: ../src/ui/dialog/objects.cpp:1914
 msgid "Unset Clip"
 msgstr "Ausschneidemaske freigeben"
 
-#: ../src/ui/dialog/objects.cpp:1957
+#: ../src/ui/dialog/objects.cpp:1919
 msgid "Unset Mask"
 msgstr "Maske freigeben"
 
-#: ../src/ui/dialog/objects.cpp:1979
+#: ../src/ui/dialog/objects.cpp:1941
 msgid "Select Highlight Color"
 msgstr "Hervorhebungsfarbe:"
 
@@ -22483,19 +22692,19 @@ msgstr "Keine Beschreibung"
 msgid "Searching clipart..."
 msgstr "Suche Clipart..."
 
-#: ../src/ui/dialog/ocaldialogs.cpp:969 ../src/ui/dialog/ocaldialogs.cpp:990
+#: ../src/ui/dialog/ocaldialogs.cpp:991
 msgid "Could not connect to the Open Clip Art Library"
 msgstr "Konnte nicht zu Open Clip Art Library verbinden"
 
-#: ../src/ui/dialog/ocaldialogs.cpp:1015
+#: ../src/ui/dialog/ocaldialogs.cpp:1016
 msgid "Could not parse search results"
 msgstr "Konnte Suchergebnisse nicht analysieren"
 
-#: ../src/ui/dialog/ocaldialogs.cpp:1047
+#: ../src/ui/dialog/ocaldialogs.cpp:1048
 msgid "No clipart named <b>%1</b> was found."
 msgstr "Kein Clipart mit Namen <b>%1</b> gefunden."
 
-#: ../src/ui/dialog/ocaldialogs.cpp:1049
+#: ../src/ui/dialog/ocaldialogs.cpp:1050
 msgid ""
 "Please make sure all keywords are spelled correctly, or try again with "
 "different keywords."
@@ -22503,7 +22712,7 @@ msgstr ""
 "Bitte stellen Sie sicher, dass alle Schlüsselwörter richtig eingegeben "
 "wurden, oder versuchen Sie es mit anderen Suchbegriffen."
 
-#: ../src/ui/dialog/ocaldialogs.cpp:1082
+#: ../src/ui/dialog/ocaldialogs.cpp:1083
 msgid "Search"
 msgstr "Suchen"
 
@@ -22585,7 +22794,7 @@ msgid "Reset all settings to defaults"
 msgstr "Alle Einstellungen auf Standard zurücksetzen"
 
 #. ## The OK button
-#: ../src/ui/dialog/pixelartdialog.cpp:293 ../src/ui/dialog/spellcheck.cpp:70
+#: ../src/ui/dialog/pixelartdialog.cpp:293 ../src/ui/dialog/spellcheck.cpp:68
 #: ../src/ui/dialog/tracedialog.cpp:815
 msgid "_Stop"
 msgstr "_Stopp"
@@ -22708,25 +22917,25 @@ msgstr "In der Auswahl konnte keine Ellipse gefunden werden"
 msgid "Arrange on ellipse"
 msgstr "Auf Ellipse anordnen"
 
-#: ../src/ui/dialog/print.cpp:100
+#: ../src/ui/dialog/print.cpp:103
 msgid "Could not open temporary PNG for bitmap printing"
 msgstr "Konnte temporäres PNG für Rasterdruck nicht öffnen"
 
-#: ../src/ui/dialog/print.cpp:127
+#: ../src/ui/dialog/print.cpp:130
 msgid "Could not set up Document"
 msgstr "Dokument konnte nicht eingerichtet werden"
 
 # CairoRenderContext ist Eigenname?
-#: ../src/ui/dialog/print.cpp:131
+#: ../src/ui/dialog/print.cpp:134
 msgid "Failed to set CairoRenderContext"
 msgstr "Fehler beim Setzen von CairoRenderContext"
 
 #. set up dialog title, based on document name
-#: ../src/ui/dialog/print.cpp:169
+#: ../src/ui/dialog/print.cpp:172
 msgid "SVG Document"
 msgstr "SVG-Dokument"
 
-#: ../src/ui/dialog/print.cpp:170
+#: ../src/ui/dialog/print.cpp:173
 msgid "Print"
 msgstr "Drucken"
 
@@ -22755,73 +22964,73 @@ msgstr "Beschreibung:"
 msgid "Keywords: "
 msgstr "Schlüsselwörter:"
 
-#: ../src/ui/dialog/spellcheck.cpp:65
+#: ../src/ui/dialog/spellcheck.cpp:63
 msgid "_Accept"
 msgstr "_Bestätigen"
 
-#: ../src/ui/dialog/spellcheck.cpp:66
+#: ../src/ui/dialog/spellcheck.cpp:64
 msgid "_Ignore once"
 msgstr "Einmal _ignorieren"
 
-#: ../src/ui/dialog/spellcheck.cpp:67
+#: ../src/ui/dialog/spellcheck.cpp:65
 msgid "_Ignore"
 msgstr "_Ignorieren"
 
-#: ../src/ui/dialog/spellcheck.cpp:68
+#: ../src/ui/dialog/spellcheck.cpp:66
 msgid "A_dd"
 msgstr "Hinzufügen"
 
-#: ../src/ui/dialog/spellcheck.cpp:71
+#: ../src/ui/dialog/spellcheck.cpp:69
 msgid "_Start"
 msgstr "_Start"
 
-#: ../src/ui/dialog/spellcheck.cpp:101
+#: ../src/ui/dialog/spellcheck.cpp:99
 msgid "Suggestions:"
 msgstr "Vorschläge:"
 
-#: ../src/ui/dialog/spellcheck.cpp:116
+#: ../src/ui/dialog/spellcheck.cpp:114
 msgid "Accept the chosen suggestion"
 msgstr "Akzeptiere den gewählten Vorschlag"
 
-#: ../src/ui/dialog/spellcheck.cpp:117
+#: ../src/ui/dialog/spellcheck.cpp:115
 msgid "Ignore this word only once"
 msgstr "Ignoriere das Wort nur einmal"
 
-#: ../src/ui/dialog/spellcheck.cpp:118
+#: ../src/ui/dialog/spellcheck.cpp:116
 msgid "Ignore this word in this session"
 msgstr "Ignoriere das Wort in dieser Sitzung"
 
-#: ../src/ui/dialog/spellcheck.cpp:119
+#: ../src/ui/dialog/spellcheck.cpp:117
 msgid "Add this word to the chosen dictionary"
 msgstr "Dieses Wort dem gewählten Wörterbuch hinzufügen"
 
-#: ../src/ui/dialog/spellcheck.cpp:133
+#: ../src/ui/dialog/spellcheck.cpp:131
 msgid "Stop the check"
 msgstr "Überprüfung stoppen"
 
-#: ../src/ui/dialog/spellcheck.cpp:134
+#: ../src/ui/dialog/spellcheck.cpp:132
 msgid "Start the check"
 msgstr "Überprüfung starten"
 
-#: ../src/ui/dialog/spellcheck.cpp:452
+#: ../src/ui/dialog/spellcheck.cpp:427
 #, c-format
 msgid "<b>Finished</b>, <b>%d</b> words added to dictionary"
 msgstr "<b>Beendet</b>, <b>%d</b> Wörter zum Wörterbuch hinzugefügt"
 
-#: ../src/ui/dialog/spellcheck.cpp:454
+#: ../src/ui/dialog/spellcheck.cpp:429
 msgid "<b>Finished</b>, nothing suspicious found"
 msgstr "<b>Beendet</b>, nichts ungewöhnliches gefunden"
 
-#: ../src/ui/dialog/spellcheck.cpp:570
+#: ../src/ui/dialog/spellcheck.cpp:544
 #, c-format
 msgid "Not in dictionary (%s): <b>%s</b>"
 msgstr "Nicht im Wörterbuch (%s): <b>%s</b>"
 
-#: ../src/ui/dialog/spellcheck.cpp:719
+#: ../src/ui/dialog/spellcheck.cpp:693
 msgid "<i>Checking...</i>"
 msgstr "<i>Überprüfung...</i>"
 
-#: ../src/ui/dialog/spellcheck.cpp:788
+#: ../src/ui/dialog/spellcheck.cpp:762
 msgid "Fix spelling"
 msgstr "Korrigiere Rechtschreibung"
 
@@ -22856,284 +23065,449 @@ msgstr "SVG-Schrift-Attribut setzen"
 msgid "Adjust kerning value"
 msgstr "Unterschneidung anpassen"
 
-#: ../src/ui/dialog/svg-fonts-dialog.cpp:452
+#: ../src/ui/dialog/svg-fonts-dialog.cpp:464
 #, fuzzy
 msgid "Font Attributes"
 msgstr "Attribute festlegen"
 
-#: ../src/ui/dialog/svg-fonts-dialog.cpp:453
+#: ../src/ui/dialog/svg-fonts-dialog.cpp:465
 msgid "Horiz. Advance X"
 msgstr ""
 
-#: ../src/ui/dialog/svg-fonts-dialog.cpp:454
+#: ../src/ui/dialog/svg-fonts-dialog.cpp:466
 #, fuzzy
 msgid "Horiz. Origin X "
 msgstr "Ursprung X:"
 
-#: ../src/ui/dialog/svg-fonts-dialog.cpp:455
+#: ../src/ui/dialog/svg-fonts-dialog.cpp:467
 #, fuzzy
 msgid "Horiz. Origin Y "
 msgstr "Ursprung Y"
 
-#: ../src/ui/dialog/svg-fonts-dialog.cpp:456
+#: ../src/ui/dialog/svg-fonts-dialog.cpp:468
 #, fuzzy
 msgid "Font Face Attributes"
 msgstr "Bildattribute festlegen"
 
-#: ../src/ui/dialog/svg-fonts-dialog.cpp:457
+#: ../src/ui/dialog/svg-fonts-dialog.cpp:469
 msgid "Family Name:"
 msgstr "Font-Familienname:"
 
-#: ../src/ui/dialog/svg-fonts-dialog.cpp:458
+#: ../src/ui/dialog/svg-fonts-dialog.cpp:470
 #, fuzzy
 msgid "Units per em"
 msgstr "SVG-Benutzereinheiten pro "
 
-#: ../src/ui/dialog/svg-fonts-dialog.cpp:459
+#: ../src/ui/dialog/svg-fonts-dialog.cpp:471
 #, fuzzy
 msgid "Ascent:"
 msgstr "Aufsteigend:"
 
-#: ../src/ui/dialog/svg-fonts-dialog.cpp:460
+#: ../src/ui/dialog/svg-fonts-dialog.cpp:472
 #, fuzzy
 msgid "Descent:"
 msgstr "Absteigend:"
 
-#: ../src/ui/dialog/svg-fonts-dialog.cpp:461
+#: ../src/ui/dialog/svg-fonts-dialog.cpp:473
 #, fuzzy
 msgid "Cap Height:"
 msgstr "Deckelhöhe:"
 
-#: ../src/ui/dialog/svg-fonts-dialog.cpp:462
+#: ../src/ui/dialog/svg-fonts-dialog.cpp:474
 #, fuzzy
 msgid "x Height:"
 msgstr "Höhe:"
 
-#: ../src/ui/dialog/svg-fonts-dialog.cpp:535
+#: ../src/ui/dialog/svg-fonts-dialog.cpp:547
 msgid "glyph"
 msgstr "Glyphe"
 
 #. SPGlyph* glyph =
-#: ../src/ui/dialog/svg-fonts-dialog.cpp:567
+#: ../src/ui/dialog/svg-fonts-dialog.cpp:579
 msgid "Add glyph"
 msgstr "Glyphe hinzufügen"
 
-#: ../src/ui/dialog/svg-fonts-dialog.cpp:598
-#: ../src/ui/dialog/svg-fonts-dialog.cpp:640
+#: ../src/ui/dialog/svg-fonts-dialog.cpp:610
+#: ../src/ui/dialog/svg-fonts-dialog.cpp:652
 msgid "Select a <b>path</b> to define the curves of a glyph"
 msgstr "Wählen Sie einen <b>Pfad</b> aus, der die Form der Glyphe bestimmt."
 
-#: ../src/ui/dialog/svg-fonts-dialog.cpp:606
-#: ../src/ui/dialog/svg-fonts-dialog.cpp:648
+#: ../src/ui/dialog/svg-fonts-dialog.cpp:618
+#: ../src/ui/dialog/svg-fonts-dialog.cpp:660
 msgid "The selected object does not have a <b>path</b> description."
 msgstr "Ausgewähltes Objekt ist <b>kein Pfad</b>!"
 
-#: ../src/ui/dialog/svg-fonts-dialog.cpp:613
+#: ../src/ui/dialog/svg-fonts-dialog.cpp:625
 msgid "No glyph selected in the SVGFonts dialog."
 msgstr "Keine Glyphe gewählt im SVGFonts-Dialog"
 
-#: ../src/ui/dialog/svg-fonts-dialog.cpp:624
-#: ../src/ui/dialog/svg-fonts-dialog.cpp:662
+#: ../src/ui/dialog/svg-fonts-dialog.cpp:636
+#: ../src/ui/dialog/svg-fonts-dialog.cpp:674
 msgid "Set glyph curves"
 msgstr "Glyphenform festlegen"
 
-#: ../src/ui/dialog/svg-fonts-dialog.cpp:681
+#: ../src/ui/dialog/svg-fonts-dialog.cpp:693
 msgid "Reset missing-glyph"
 msgstr "Fehlende Glyphe zurücksetzen"
 
-#: ../src/ui/dialog/svg-fonts-dialog.cpp:697
+#: ../src/ui/dialog/svg-fonts-dialog.cpp:709
 msgid "Edit glyph name"
 msgstr "Name der Glyphe bearbeiten"
 
-#: ../src/ui/dialog/svg-fonts-dialog.cpp:711
+#: ../src/ui/dialog/svg-fonts-dialog.cpp:723
 msgid "Set glyph unicode"
 msgstr "Unicode der Glyphe wählen"
 
-#: ../src/ui/dialog/svg-fonts-dialog.cpp:728
+#: ../src/ui/dialog/svg-fonts-dialog.cpp:740
 #, fuzzy
 msgid "Set glyph advance"
 msgstr "Unicode der Glyphe wählen"
 
-#: ../src/ui/dialog/svg-fonts-dialog.cpp:743
+#: ../src/ui/dialog/svg-fonts-dialog.cpp:755
 msgid "Remove font"
 msgstr "Schrift entfernen"
 
-#: ../src/ui/dialog/svg-fonts-dialog.cpp:760
+#: ../src/ui/dialog/svg-fonts-dialog.cpp:772
 msgid "Remove glyph"
 msgstr "Glyphe entfernen"
 
-#: ../src/ui/dialog/svg-fonts-dialog.cpp:777
+#: ../src/ui/dialog/svg-fonts-dialog.cpp:789
 msgid "Remove kerning pair"
 msgstr "Unterschneidungspaar entfernen"
 
-#: ../src/ui/dialog/svg-fonts-dialog.cpp:787
+#: ../src/ui/dialog/svg-fonts-dialog.cpp:799
 msgid "Missing Glyph:"
 msgstr "Fehlende Glyphe:"
 
-#: ../src/ui/dialog/svg-fonts-dialog.cpp:791
+#: ../src/ui/dialog/svg-fonts-dialog.cpp:803
 msgid "From selection..."
 msgstr "Aus Auswahl übernehmen"
 
-#: ../src/ui/dialog/svg-fonts-dialog.cpp:804
+#: ../src/ui/dialog/svg-fonts-dialog.cpp:816
 msgid "Glyph name"
 msgstr "Name der Glyphe"
 
-#: ../src/ui/dialog/svg-fonts-dialog.cpp:805
+#: ../src/ui/dialog/svg-fonts-dialog.cpp:817
 msgid "Matching string"
 msgstr "Übereinstimmende Zeichenkette"
 
-#: ../src/ui/dialog/svg-fonts-dialog.cpp:806
+#: ../src/ui/dialog/svg-fonts-dialog.cpp:818
 #, fuzzy
 msgid "Advance"
 msgstr "Abbrechen"
 
-#: ../src/ui/dialog/svg-fonts-dialog.cpp:808
+#: ../src/ui/dialog/svg-fonts-dialog.cpp:820
 msgid "Add Glyph"
 msgstr "Glyphe hinzufügen"
 
-#: ../src/ui/dialog/svg-fonts-dialog.cpp:815
+#: ../src/ui/dialog/svg-fonts-dialog.cpp:827
 msgid "Get curves from selection..."
 msgstr "Kurven von der Auswahl erhalten..."
 
-#: ../src/ui/dialog/svg-fonts-dialog.cpp:867
+#: ../src/ui/dialog/svg-fonts-dialog.cpp:879
 msgid "Add kerning pair"
 msgstr "Unterschneidungspaar hinzufügen"
 
 #. Kerning Setup:
-#: ../src/ui/dialog/svg-fonts-dialog.cpp:875
+#: ../src/ui/dialog/svg-fonts-dialog.cpp:887
 msgid "Kerning Setup"
 msgstr "Unterschneidungseinstellung:"
 
-#: ../src/ui/dialog/svg-fonts-dialog.cpp:877
+#: ../src/ui/dialog/svg-fonts-dialog.cpp:889
 msgid "1st Glyph:"
 msgstr "1. Glyphe:"
 
-#: ../src/ui/dialog/svg-fonts-dialog.cpp:879
+#: ../src/ui/dialog/svg-fonts-dialog.cpp:891
 msgid "2nd Glyph:"
 msgstr "2. Glyphe:"
 
-#: ../src/ui/dialog/svg-fonts-dialog.cpp:882
+#: ../src/ui/dialog/svg-fonts-dialog.cpp:894
 msgid "Add pair"
 msgstr "Paarung hinzufügen"
 
-#: ../src/ui/dialog/svg-fonts-dialog.cpp:894
+#: ../src/ui/dialog/svg-fonts-dialog.cpp:906
 msgid "First Unicode range"
 msgstr "Erster Unicodebereich"
 
-#: ../src/ui/dialog/svg-fonts-dialog.cpp:895
+#: ../src/ui/dialog/svg-fonts-dialog.cpp:907
 msgid "Second Unicode range"
 msgstr "Zweiter Unicode-Bereich"
 
-#: ../src/ui/dialog/svg-fonts-dialog.cpp:902
+#: ../src/ui/dialog/svg-fonts-dialog.cpp:914
 msgid "Kerning value:"
 msgstr "Unterschneidungswert:"
 
-#: ../src/ui/dialog/svg-fonts-dialog.cpp:959
+#: ../src/ui/dialog/svg-fonts-dialog.cpp:971
 msgid "Set font family"
 msgstr "Schriftfamilie setzen"
 
-#: ../src/ui/dialog/svg-fonts-dialog.cpp:968
+#: ../src/ui/dialog/svg-fonts-dialog.cpp:980
 msgid "font"
 msgstr "Schrift"
 
 #. select_font(font);
-#: ../src/ui/dialog/svg-fonts-dialog.cpp:982
+#: ../src/ui/dialog/svg-fonts-dialog.cpp:994
 msgid "Add font"
 msgstr "Schrift hinzufügen"
 
-#: ../src/ui/dialog/svg-fonts-dialog.cpp:1004 ../src/ui/dialog/text-edit.cpp:60
+#: ../src/ui/dialog/svg-fonts-dialog.cpp:1016 ../src/ui/dialog/text-edit.cpp:60
 msgid "_Font"
 msgstr "Schrift"
 
-#: ../src/ui/dialog/svg-fonts-dialog.cpp:1012
+#: ../src/ui/dialog/svg-fonts-dialog.cpp:1024
 msgid "_Global Settings"
 msgstr "_Globale Einstellungen"
 
-#: ../src/ui/dialog/svg-fonts-dialog.cpp:1013
+#: ../src/ui/dialog/svg-fonts-dialog.cpp:1025
 msgid "_Glyphs"
 msgstr "_Glyphen"
 
-#: ../src/ui/dialog/svg-fonts-dialog.cpp:1014
+#: ../src/ui/dialog/svg-fonts-dialog.cpp:1026
 msgid "_Kerning"
 msgstr "_Unterschneidung"
 
-#: ../src/ui/dialog/svg-fonts-dialog.cpp:1021
-#: ../src/ui/dialog/svg-fonts-dialog.cpp:1022
+#: ../src/ui/dialog/svg-fonts-dialog.cpp:1033
+#: ../src/ui/dialog/svg-fonts-dialog.cpp:1034
 msgid "Sample Text"
 msgstr "Beispieltext"
 
-#: ../src/ui/dialog/svg-fonts-dialog.cpp:1026
+#: ../src/ui/dialog/svg-fonts-dialog.cpp:1038
 msgid "Preview Text:"
 msgstr "Textvorschau:"
 
-#: ../src/ui/dialog/swatches.cpp:195 ../src/ui/tools/gradient-tool.cpp:359
-#: ../src/ui/tools/gradient-tool.cpp:457 ../src/widgets/gradient-vector.cpp:765
+#: ../src/ui/dialog/swatches.cpp:207 ../src/ui/tools/gradient-tool.cpp:359
+#: ../src/ui/tools/gradient-tool.cpp:446 ../src/widgets/gradient-vector.cpp:744
 msgid "Add gradient stop"
 msgstr "Zwischenfarbe zum Farbverlauf hinzufügen"
 
 #. TRANSLATORS: An item in context menu on a colour in the swatches
-#: ../src/ui/dialog/swatches.cpp:250
+#: ../src/ui/dialog/swatches.cpp:262
 msgid "Set fill"
 msgstr "Füllung festlegen"
 
 #. TRANSLATORS: An item in context menu on a colour in the swatches
-#: ../src/ui/dialog/swatches.cpp:258
+#: ../src/ui/dialog/swatches.cpp:270
 msgid "Set stroke"
 msgstr "Kontur festlegen"
 
-#: ../src/ui/dialog/swatches.cpp:279
+#: ../src/ui/dialog/swatches.cpp:291
 msgid "Edit..."
 msgstr "Bearbeiten..."
 
 # !!! not the best translation
-#: ../src/ui/dialog/swatches.cpp:291
+#: ../src/ui/dialog/swatches.cpp:303
 msgid "Convert"
 msgstr "Konvertieren"
 
+#: ../src/ui/dialog/swatches.cpp:707
+msgid "List"
+msgstr "Liste"
+
+#: ../src/ui/dialog/swatches.cpp:727
+msgctxt "Swatches"
+msgid "Size"
+msgstr "Größe"
+
+#: ../src/ui/dialog/swatches.cpp:731
+msgctxt "Swatches height"
+msgid "Tiny"
+msgstr "Winzig"
+
+#: ../src/ui/dialog/swatches.cpp:732
+msgctxt "Swatches height"
+msgid "Small"
+msgstr "Klein"
+
+#: ../src/ui/dialog/swatches.cpp:733
+msgctxt "Swatches height"
+msgid "Medium"
+msgstr "Mittel"
+
+#: ../src/ui/dialog/swatches.cpp:734
+msgctxt "Swatches height"
+msgid "Large"
+msgstr "Groß"
+
+#: ../src/ui/dialog/swatches.cpp:735
+msgctxt "Swatches height"
+msgid "Huge"
+msgstr "Groß"
+
+#: ../src/ui/dialog/swatches.cpp:757
+msgctxt "Swatches"
+msgid "Width"
+msgstr "Breite"
+
+# (swatches)
+#: ../src/ui/dialog/swatches.cpp:761
+msgctxt "Swatches width"
+msgid "Narrower"
+msgstr "Schmaler"
+
+#: ../src/ui/dialog/swatches.cpp:762
+msgctxt "Swatches width"
+msgid "Narrow"
+msgstr "Schmal"
+
+#: ../src/ui/dialog/swatches.cpp:763
+msgctxt "Swatches width"
+msgid "Medium"
+msgstr "Mittel"
+
+#: ../src/ui/dialog/swatches.cpp:764
+msgctxt "Swatches width"
+msgid "Wide"
+msgstr "Breit"
+
+#: ../src/ui/dialog/swatches.cpp:765
+msgctxt "Swatches width"
+msgid "Wider"
+msgstr "Breiter"
+
+#: ../src/ui/dialog/swatches.cpp:795
+msgctxt "Swatches"
+msgid "Border"
+msgstr "Rand"
+
+# CHECK
+#: ../src/ui/dialog/swatches.cpp:799
+msgctxt "Swatches border"
+msgid "None"
+msgstr "Keine"
+
+#: ../src/ui/dialog/swatches.cpp:800
+msgctxt "Swatches border"
+msgid "Solid"
+msgstr "Fest"
+
+#: ../src/ui/dialog/swatches.cpp:801
+msgctxt "Swatches border"
+msgid "Wide"
+msgstr "Breit"
+
+#. TRANSLATORS: "Wrap" indicates how colour swatches are displayed
+#: ../src/ui/dialog/swatches.cpp:832
+msgctxt "Swatches"
+msgid "Wrap"
+msgstr "Umbrechen"
+
+#: ../src/ui/dialog/symbols.cpp:75
+#, fuzzy
+msgid "Current document"
+msgstr "Aktuelles Dokument"
+
+#: ../src/ui/dialog/symbols.cpp:76
+#, fuzzy
+msgid "All symbol sets"
+msgstr "Symbolsatz:"
+
 #. ******************* Symbol Sets ************************
-#: ../src/ui/dialog/symbols.cpp:124
+#: ../src/ui/dialog/symbols.cpp:134
 msgid "Symbol set: "
 msgstr "Symbolsatz:"
 
-#. Fill in later
-#: ../src/ui/dialog/symbols.cpp:127 ../src/ui/dialog/symbols.cpp:128
-msgid "Current Document"
-msgstr "Aktuelles Dokument"
+#. *******************    Search    ************************
+#. Search
+#: ../src/ui/dialog/symbols.cpp:163
+msgid "Return to start search."
+msgstr ""
 
-#: ../src/ui/dialog/symbols.cpp:182
+#: ../src/ui/dialog/symbols.cpp:279
 msgid "Add Symbol from the current document."
 msgstr "Symbol vom aktuellen Dokument hinzufügen."
 
-#: ../src/ui/dialog/symbols.cpp:193
+#: ../src/ui/dialog/symbols.cpp:290
 msgid "Remove Symbol from the current document."
 msgstr "Symbol vom aktuellen Dokument entfernen."
 
-#: ../src/ui/dialog/symbols.cpp:210
+#: ../src/ui/dialog/symbols.cpp:307
 msgid "Display more icons in row."
 msgstr "Mehr Symbole in einer Reihe anzeigen."
 
-#: ../src/ui/dialog/symbols.cpp:221
+#: ../src/ui/dialog/symbols.cpp:318
 msgid "Display fewer icons in row."
 msgstr "Weniger Symbole in einer Reihe anzeigen."
 
-#: ../src/ui/dialog/symbols.cpp:233
+#: ../src/ui/dialog/symbols.cpp:330
 msgid "Toggle 'fit' symbols in icon space."
 msgstr "\"Einpassen\" der Symbole im Symbolbereich."
 
-#: ../src/ui/dialog/symbols.cpp:247
+#: ../src/ui/dialog/symbols.cpp:344
 msgid "Make symbols smaller by zooming out."
 msgstr "Symbole durch Herauszoomen verkleinern."
 
-#: ../src/ui/dialog/symbols.cpp:259
+#: ../src/ui/dialog/symbols.cpp:356
 msgid "Make symbols bigger by zooming in."
 msgstr "Symbole durch Hineinzoomen vergrößern."
 
-#: ../src/ui/dialog/symbols.cpp:602
+#. We are not in search all docs
+#: ../src/ui/dialog/symbols.cpp:457 ../src/ui/dialog/symbols.cpp:1053
+#, fuzzy
+msgid "Searching..."
+msgstr "Suchen in"
+
+#: ../src/ui/dialog/symbols.cpp:458 ../src/ui/dialog/symbols.cpp:1060
+#: ../src/ui/dialog/symbols.cpp:1124
+msgid "Loading all symbols..."
+msgstr ""
+
+#: ../src/ui/dialog/symbols.cpp:459
+#, fuzzy
+msgid "Searching...."
+msgstr "Suche Clipart..."
+
+#: ../src/ui/dialog/symbols.cpp:478 ../src/ui/dialog/symbols.cpp:485
+#, fuzzy
+msgid "Search in all symbol sets..."
+msgstr "In allen Ebenen suchen"
+
+#: ../src/ui/dialog/symbols.cpp:479
+msgid "First search can be slow."
+msgstr ""
+
+#: ../src/ui/dialog/symbols.cpp:481 ../src/ui/dialog/symbols.cpp:489
+#: ../src/ui/dialog/symbols.cpp:495
+#, fuzzy
+msgid "No results found"
+msgstr "Keine Objekte gefunden"
+
+#: ../src/ui/dialog/symbols.cpp:482
+msgid "Try a different search term."
+msgstr ""
+
+#: ../src/ui/dialog/symbols.cpp:490 ../src/ui/dialog/symbols.cpp:496
+msgid ""
+"Try a different search term,\n"
+"or switch to a different symbol set."
+msgstr ""
+
+#: ../src/ui/dialog/symbols.cpp:492
+#, fuzzy
+msgid "No symbols found"
+msgstr "Keine Objekte gefunden"
+
+#: ../src/ui/dialog/symbols.cpp:493
+msgid ""
+"No symbols in current document.\n"
+"Choose a different symbol set\n"
+"or add a new symbol."
+msgstr ""
+
+#: ../src/ui/dialog/symbols.cpp:816 ../src/ui/dialog/symbols.cpp:836
 msgid "Unnamed Symbols"
 msgstr "Unbenannte Symbole"
 
+#: ../src/ui/dialog/symbols.cpp:955
+#, fuzzy
+msgid "notitle_"
+msgstr "Titel"
+
+#: ../src/ui/dialog/symbols.cpp:1227
+msgid "Symbol without title "
+msgstr ""
+
 #: ../src/ui/dialog/tags.cpp:256 ../src/ui/dialog/tags.cpp:554
-#: ../src/ui/dialog/tags.cpp:668 ../src/ui/dialog/tags.cpp:931
+#: ../src/ui/dialog/tags.cpp:672 ../src/ui/dialog/tags.cpp:935
 msgid "Remove from selection set"
 msgstr "Aus Auswahlgruppe entfernen"
 
@@ -23141,19 +23515,19 @@ msgstr "Aus Auswahlgruppe entfernen"
 msgid "Items"
 msgstr "Objekte"
 
-#: ../src/ui/dialog/tags.cpp:651 ../src/ui/dialog/tags.cpp:929
+#: ../src/ui/dialog/tags.cpp:655 ../src/ui/dialog/tags.cpp:933
 msgid "Add selection to set"
 msgstr "Auswahl zu Gruppe hinzufügen"
 
-#: ../src/ui/dialog/tags.cpp:809
+#: ../src/ui/dialog/tags.cpp:813
 msgid "Moved sets"
 msgstr "Auswahlgruppe bewegen"
 
-#: ../src/ui/dialog/tags.cpp:985
+#: ../src/ui/dialog/tags.cpp:989
 msgid "Add a new selection set"
 msgstr "Neue Auswahlgruppe hinzufügen"
 
-#: ../src/ui/dialog/tags.cpp:994
+#: ../src/ui/dialog/tags.cpp:998
 msgid "Remove Item/Set"
 msgstr "Element/Gruppe entfernen"
 
@@ -23186,27 +23560,27 @@ msgid "AaBbCcIiPpQq12369$€¢?.;/()"
 msgstr "AaBbCcIiPpQqÜü12369$€ß?.;/()"
 
 #. Align buttons
-#: ../src/ui/dialog/text-edit.cpp:87 ../src/widgets/text-toolbar.cpp:1813
-#: ../src/widgets/text-toolbar.cpp:1814
+#: ../src/ui/dialog/text-edit.cpp:87 ../src/widgets/text-toolbar.cpp:2115
+#: ../src/widgets/text-toolbar.cpp:2116
 msgid "Align left"
 msgstr "Linksbündig ausrichten"
 
-#: ../src/ui/dialog/text-edit.cpp:88 ../src/widgets/text-toolbar.cpp:1819
-#: ../src/widgets/text-toolbar.cpp:1820
+#: ../src/ui/dialog/text-edit.cpp:88 ../src/widgets/text-toolbar.cpp:2121
+#: ../src/widgets/text-toolbar.cpp:2122
 msgid "Align center"
 msgstr "Zentriert ausrichten"
 
-#: ../src/ui/dialog/text-edit.cpp:89 ../src/widgets/text-toolbar.cpp:1825
-#: ../src/widgets/text-toolbar.cpp:1826
+#: ../src/ui/dialog/text-edit.cpp:89 ../src/widgets/text-toolbar.cpp:2127
+#: ../src/widgets/text-toolbar.cpp:2128
 msgid "Align right"
 msgstr "Rechtsbündig ausrichten"
 
-#: ../src/ui/dialog/text-edit.cpp:90 ../src/widgets/text-toolbar.cpp:1832
+#: ../src/ui/dialog/text-edit.cpp:90 ../src/widgets/text-toolbar.cpp:2134
 msgid "Justify (only flowed text)"
 msgstr "Ausrichten - Nur Fließtext"
 
 #. Direction buttons
-#: ../src/ui/dialog/text-edit.cpp:97 ../src/widgets/text-toolbar.cpp:1863
+#: ../src/ui/dialog/text-edit.cpp:97 ../src/widgets/text-toolbar.cpp:2165
 msgid "Horizontal text"
 msgstr "Horizontaler Text"
 
@@ -23218,8 +23592,8 @@ msgstr "Vertikaler Text"
 msgid "Text path offset"
 msgstr "Text-Pfad-Versatz"
 
-#: ../src/ui/dialog/text-edit.cpp:550 ../src/ui/dialog/text-edit.cpp:637
-#: ../src/ui/tools/text-tool.cpp:1493
+#: ../src/ui/dialog/text-edit.cpp:552 ../src/ui/dialog/text-edit.cpp:639
+#: ../src/ui/tools/text-tool.cpp:1489
 msgid "Set text style"
 msgstr "Textstil setzen"
 
@@ -23758,69 +24132,69 @@ msgstr "Knoten löschen"
 msgid "Change attribute"
 msgstr "Attribut ändern"
 
-#: ../src/ui/interface.cpp:767
+#: ../src/ui/interface.cpp:729
 msgctxt "Interface setup"
 msgid "Default"
 msgstr "Standard"
 
-#: ../src/ui/interface.cpp:767
+#: ../src/ui/interface.cpp:729
 msgid "Default interface setup"
 msgstr "Standardschnittstellen-Einrichtung"
 
-#: ../src/ui/interface.cpp:768
+#: ../src/ui/interface.cpp:730
 msgctxt "Interface setup"
 msgid "Custom"
 msgstr "Benutzerdefiniert"
 
-#: ../src/ui/interface.cpp:768
+#: ../src/ui/interface.cpp:730
 msgid "Setup for custom task"
 msgstr "Einrichtung für benutzerdefinierte Aufgabe"
 
-#: ../src/ui/interface.cpp:769
+#: ../src/ui/interface.cpp:731
 msgctxt "Interface setup"
 msgid "Wide"
 msgstr "Breit"
 
-#: ../src/ui/interface.cpp:769
+#: ../src/ui/interface.cpp:731
 msgid "Setup for widescreen work"
 msgstr "Einrichtung für die Breitbild-Arbeit"
 
-#: ../src/ui/interface.cpp:888
+#: ../src/ui/interface.cpp:849
 #, c-format
 msgid "Verb \"%s\" Unknown"
 msgstr "Verb \"%s\" unbekannt"
 
-#: ../src/ui/interface.cpp:923
+#: ../src/ui/interface.cpp:884
 msgid "Open _Recent"
 msgstr "Zuletzt _geöffnete Dateien"
 
 # !!! correct?
-#: ../src/ui/interface.cpp:1031 ../src/ui/interface.cpp:1117
-#: ../src/ui/interface.cpp:1220 ../src/ui/widget/selected-style.cpp:531
+#: ../src/ui/interface.cpp:992 ../src/ui/interface.cpp:1078
+#: ../src/ui/interface.cpp:1181 ../src/ui/widget/selected-style.cpp:528
 msgid "Drop color"
 msgstr "Farbe ablegen"
 
-#: ../src/ui/interface.cpp:1070 ../src/ui/interface.cpp:1180
+#: ../src/ui/interface.cpp:1031 ../src/ui/interface.cpp:1141
 msgid "Drop color on gradient"
 msgstr "Keine Zwischenfarben im Farbverlauf"
 
-#: ../src/ui/interface.cpp:1233
+#: ../src/ui/interface.cpp:1194
 msgid "Could not parse SVG data"
 msgstr "SVG-Daten konnten nicht analysiert werden"
 
-#: ../src/ui/interface.cpp:1272
+#: ../src/ui/interface.cpp:1233
 msgid "Drop SVG"
 msgstr "SVG ablegen"
 
-#: ../src/ui/interface.cpp:1285
+#: ../src/ui/interface.cpp:1246
 msgid "Drop Symbol"
 msgstr "Symbol ablegen"
 
-#: ../src/ui/interface.cpp:1308
+#: ../src/ui/interface.cpp:1269
 msgid "Drop bitmap image"
 msgstr "Bitmap-Bild ablegen"
 
-#: ../src/ui/interface.cpp:1400
+#: ../src/ui/interface.cpp:1362
 #, c-format
 msgid ""
 "<span weight=\"bold\" size=\"larger\">A file named \"%s\" already exists. Do "
@@ -23834,12 +24208,12 @@ msgstr ""
 "Die Datei existiert bereits in „%s“. Sie zu ersetzen wird ihren Inhalt "
 "überschreiben."
 
-#: ../src/ui/interface.cpp:1407 ../share/extensions/web-set-att.inx.h:21
+#: ../src/ui/interface.cpp:1369 ../share/extensions/web-set-att.inx.h:21
 #: ../share/extensions/web-transmit-att.inx.h:19
 msgid "Replace"
 msgstr "Ersetzen"
 
-#: ../src/ui/object-edit.cpp:479
+#: ../src/ui/shape-editor-knotholders.cpp:527
 msgid ""
 "Adjust the <b>horizontal rounding</b> radius; with <b>Ctrl</b> to make the "
 "vertical radius the same"
@@ -23847,7 +24221,7 @@ msgstr ""
 "Radius der <b>horizontalen Rundung</b> anpassen; <b>Strg</b> setzt vertikale "
 "und horizontale Rundung gleich"
 
-#: ../src/ui/object-edit.cpp:484
+#: ../src/ui/shape-editor-knotholders.cpp:532
 msgid ""
 "Adjust the <b>vertical rounding</b> radius; with <b>Ctrl</b> to make the "
 "horizontal radius the same"
@@ -23855,7 +24229,8 @@ msgstr ""
 "Radius der <b>vertikalen Rundung</b> anpassen; <b>Strg</b> setzt vertikale "
 "und horizontale Rundung gleich"
 
-#: ../src/ui/object-edit.cpp:489 ../src/ui/object-edit.cpp:494
+#: ../src/ui/shape-editor-knotholders.cpp:537
+#: ../src/ui/shape-editor-knotholders.cpp:542
 msgid ""
 "Adjust the <b>width and height</b> of the rectangle; with <b>Ctrl</b> to "
 "lock ratio or stretch in one dimension only"
@@ -23863,13 +24238,15 @@ msgstr ""
 "<b>Höhe/Breite</b> des Rechtecks anpassen; <b>Strg</b> um Seitenverhältnis "
 "bei zu behalten oder nur in eine Richtung zu strecken"
 
-#: ../src/ui/object-edit.cpp:499
+#: ../src/ui/shape-editor-knotholders.cpp:547
 #, fuzzy
 msgid "Drag to move the rectangle"
 msgstr "Rechteck entfernen"
 
-#: ../src/ui/object-edit.cpp:746 ../src/ui/object-edit.cpp:750
-#: ../src/ui/object-edit.cpp:754 ../src/ui/object-edit.cpp:758
+#: ../src/ui/shape-editor-knotholders.cpp:794
+#: ../src/ui/shape-editor-knotholders.cpp:798
+#: ../src/ui/shape-editor-knotholders.cpp:802
+#: ../src/ui/shape-editor-knotholders.cpp:806
 msgid ""
 "Resize box in X/Y direction; with <b>Shift</b> along the Z axis; with "
 "<b>Ctrl</b> to constrain to the directions of edges or diagonals"
@@ -23877,8 +24254,10 @@ msgstr ""
 "Größe der Box in X/Y-Richtung ändern; mit <b>Umschalt</b> entlang der Z-"
 "Achse; Mit <b>Strg</b> auf Richtung der Seiten oder Diagonalen beschränkt"
 
-#: ../src/ui/object-edit.cpp:762 ../src/ui/object-edit.cpp:766
-#: ../src/ui/object-edit.cpp:770 ../src/ui/object-edit.cpp:774
+#: ../src/ui/shape-editor-knotholders.cpp:810
+#: ../src/ui/shape-editor-knotholders.cpp:814
+#: ../src/ui/shape-editor-knotholders.cpp:818
+#: ../src/ui/shape-editor-knotholders.cpp:822
 msgid ""
 "Resize box along the Z axis; with <b>Shift</b> in X/Y direction; with "
 "<b>Ctrl</b> to constrain to the directions of edges or diagonals"
@@ -23886,20 +24265,20 @@ msgstr ""
 "Größe der Box entlang der Z-Achse ändern; mit <b>Umschalt</b> in X/Y-"
 "Richtung; Mit <b>Strg</b> auf Richtung der Seiten und Diagonalen beschränkt"
 
-#: ../src/ui/object-edit.cpp:778
+#: ../src/ui/shape-editor-knotholders.cpp:826
 msgid "Move the box in perspective"
 msgstr "Bewegen der Box in der Perspektive"
 
-#: ../src/ui/object-edit.cpp:1065
+#: ../src/ui/shape-editor-knotholders.cpp:1113
 msgid "Adjust ellipse <b>width</b>, with <b>Ctrl</b> to make circle"
 msgstr ""
 "<b>Höhe/Breite</b> der Ellipse anpassen; <b>Strg</b> erzeugt einen Kreis"
 
-#: ../src/ui/object-edit.cpp:1069
+#: ../src/ui/shape-editor-knotholders.cpp:1117
 msgid "Adjust ellipse <b>height</b>, with <b>Ctrl</b> to make circle"
 msgstr "<b>Höhe</b> der Ellipse anpassen; <b>Strg</b> erzeugt einen Kreis"
 
-#: ../src/ui/object-edit.cpp:1073
+#: ../src/ui/shape-editor-knotholders.cpp:1121
 #, fuzzy
 msgid ""
 "Position the <b>start point</b> of the arc or segment; with <b>Shift</b> to "
@@ -23910,7 +24289,7 @@ msgstr ""
 "den Winkel ein; ziehen <b>innerhalb</b> der Ellipse erzeugt einen Kreisbogen "
 "- <b>außerhalb</b> ein Kreissegment"
 
-#: ../src/ui/object-edit.cpp:1079
+#: ../src/ui/shape-editor-knotholders.cpp:1127
 #, fuzzy
 msgid ""
 "Position the <b>end point</b> of the arc or segment; with <b>Shift</b> to "
@@ -23921,12 +24300,12 @@ msgstr ""
 "ein; Ziehen <b>innerhalb</b> der Ellipse erzeugt einen Kreisbogen - "
 "<b>außerhalb</b> ein Kreissegment"
 
-#: ../src/ui/object-edit.cpp:1085
+#: ../src/ui/shape-editor-knotholders.cpp:1133
 #, fuzzy
 msgid "Drag to move the ellipse"
 msgstr "Ellipse erzeugen"
 
-#: ../src/ui/object-edit.cpp:1259
+#: ../src/ui/shape-editor-knotholders.cpp:1307
 msgid ""
 "Adjust the <b>tip radius</b> of the star or polygon; with <b>Shift</b> to "
 "round; with <b>Alt</b> to randomize"
@@ -23934,7 +24313,7 @@ msgstr ""
 "<b>Spitzen</b> des Sterns oder Polygons anpassen; <b>Umschalt</b> rundet ab; "
 "<b>Alt</b> verändert nach Zufall"
 
-#: ../src/ui/object-edit.cpp:1267
+#: ../src/ui/shape-editor-knotholders.cpp:1315
 msgid ""
 "Adjust the <b>base radius</b> of the star; with <b>Ctrl</b> to keep star "
 "rays radial (no skew); with <b>Shift</b> to round; with <b>Alt</b> to "
@@ -23944,17 +24323,17 @@ msgstr ""
 "Ausrichtung der Spitzen; <b>Umschalt</b> rundet; <b>Alt</b> verändert "
 "zufällig"
 
-#: ../src/ui/object-edit.cpp:1274
+#: ../src/ui/shape-editor-knotholders.cpp:1322
 #, fuzzy
 msgid "Drag to move the star"
 msgstr "Ziehen, um die Knoten neu zu sortieren"
 
-#: ../src/ui/object-edit.cpp:1510
+#: ../src/ui/shape-editor-knotholders.cpp:1558
 #, fuzzy
 msgid "Drag to move the spiral"
 msgstr "Spirale erstellen"
 
-#: ../src/ui/object-edit.cpp:1514
+#: ../src/ui/shape-editor-knotholders.cpp:1562
 msgid ""
 "Roll/unroll the spiral from <b>inside</b>; with <b>Ctrl</b> to snap angle; "
 "with <b>Alt</b> to converge/diverge"
@@ -23962,7 +24341,7 @@ msgstr ""
 "Spirale von <b>innen</b> einrollen/ausrollen; Winkel mit <b>Strg</b> "
 "einrasten; <b>Alt</b> konvergiert/divergiert"
 
-#: ../src/ui/object-edit.cpp:1518
+#: ../src/ui/shape-editor-knotholders.cpp:1566
 msgid ""
 "Roll/unroll the spiral from <b>outside</b>; with <b>Ctrl</b> to snap angle; "
 "with <b>Shift</b> to scale/rotate; with <b>Alt</b> to lock radius"
@@ -23970,11 +24349,11 @@ msgstr ""
 "Spirale von <b>außen</b> ausrollen/einrollen; Winkel mit <b>Strg</b> "
 "einrasten; <b>Umschalt</b> skaliert/rotiert; mit <b>Alt</b> Radius sperren"
 
-#: ../src/ui/object-edit.cpp:1568
+#: ../src/ui/shape-editor-knotholders.cpp:1616
 msgid "Adjust the <b>offset distance</b>"
 msgstr "<b>Versatz-Abstand</b> anpassen"
 
-#: ../src/ui/object-edit.cpp:1605
+#: ../src/ui/shape-editor-knotholders.cpp:1653
 msgid "Drag to resize the <b>flowed text frame</b>"
 msgstr "Ziehen, um die Größe des <b>Fließtext-Rahmens</b> zu ändern"
 
@@ -24026,96 +24405,96 @@ msgstr ""
 "<b>Bézier-Segment</b>: Ziehen, um das Segment zu formen, Doppelklick zum "
 "Einfügen eines Knotens oder Klicken zum Auswählen (mehr: Umschalt, Strg+Alt)"
 
-#: ../src/ui/tool/multi-path-manipulator.cpp:313
+#: ../src/ui/tool/multi-path-manipulator.cpp:312
 msgid "Retract handles"
 msgstr "Anfasser zurückziehen"
 
-#: ../src/ui/tool/multi-path-manipulator.cpp:313 ../src/ui/tool/node.cpp:292
+#: ../src/ui/tool/multi-path-manipulator.cpp:312 ../src/ui/tool/node.cpp:292
 msgid "Change node type"
 msgstr "Knotentyp ändern"
 
-#: ../src/ui/tool/multi-path-manipulator.cpp:321
+#: ../src/ui/tool/multi-path-manipulator.cpp:320
 msgid "Straighten segments"
 msgstr "Segmente begradigen"
 
-#: ../src/ui/tool/multi-path-manipulator.cpp:323
+#: ../src/ui/tool/multi-path-manipulator.cpp:322
 msgid "Make segments curves"
 msgstr "Die gewählten Abschnitte in Kurven umwandeln"
 
-#: ../src/ui/tool/multi-path-manipulator.cpp:331
-#: ../src/ui/tool/multi-path-manipulator.cpp:345
+#: ../src/ui/tool/multi-path-manipulator.cpp:330
+#: ../src/ui/tool/multi-path-manipulator.cpp:344
 msgid "Add nodes"
 msgstr "Mehrere Knoten hinzufügen"
 
-#: ../src/ui/tool/multi-path-manipulator.cpp:337
+#: ../src/ui/tool/multi-path-manipulator.cpp:336
 msgid "Add extremum nodes"
 msgstr "Extremwert-Knoten hinzufügen"
 
-#: ../src/ui/tool/multi-path-manipulator.cpp:352
+#: ../src/ui/tool/multi-path-manipulator.cpp:351
 msgid "Duplicate nodes"
 msgstr "Knoten duplizieren"
 
-#: ../src/ui/tool/multi-path-manipulator.cpp:415
+#: ../src/ui/tool/multi-path-manipulator.cpp:414
 #: ../src/widgets/node-toolbar.cpp:406
 msgid "Join nodes"
 msgstr "Knoten verbinden"
 
-#: ../src/ui/tool/multi-path-manipulator.cpp:422
+#: ../src/ui/tool/multi-path-manipulator.cpp:421
 #: ../src/widgets/node-toolbar.cpp:417
 msgid "Break nodes"
 msgstr "Knoten unterbrechen"
 
-#: ../src/ui/tool/multi-path-manipulator.cpp:429
+#: ../src/ui/tool/multi-path-manipulator.cpp:428
 msgid "Delete nodes"
 msgstr "Knoten löschen"
 
-#: ../src/ui/tool/multi-path-manipulator.cpp:775
+#: ../src/ui/tool/multi-path-manipulator.cpp:774
 msgid "Move nodes"
 msgstr "Knoten verschieben"
 
-#: ../src/ui/tool/multi-path-manipulator.cpp:778
+#: ../src/ui/tool/multi-path-manipulator.cpp:777
 msgid "Move nodes horizontally"
 msgstr "Knoten horizontal verschieben"
 
-#: ../src/ui/tool/multi-path-manipulator.cpp:782
+#: ../src/ui/tool/multi-path-manipulator.cpp:781
 msgid "Move nodes vertically"
 msgstr "Knoten vertikal verschieben"
 
-#: ../src/ui/tool/multi-path-manipulator.cpp:786
-#: ../src/ui/tool/multi-path-manipulator.cpp:789
+#: ../src/ui/tool/multi-path-manipulator.cpp:785
+#: ../src/ui/tool/multi-path-manipulator.cpp:788
 msgid "Rotate nodes"
 msgstr "Knoten rotieren"
 
-#: ../src/ui/tool/multi-path-manipulator.cpp:793
-#: ../src/ui/tool/multi-path-manipulator.cpp:799
+#: ../src/ui/tool/multi-path-manipulator.cpp:792
+#: ../src/ui/tool/multi-path-manipulator.cpp:798
 msgid "Scale nodes uniformly"
 msgstr "Knoten skalieren"
 
-#: ../src/ui/tool/multi-path-manipulator.cpp:796
+#: ../src/ui/tool/multi-path-manipulator.cpp:795
 msgid "Scale nodes"
 msgstr "Knoten skalieren"
 
-#: ../src/ui/tool/multi-path-manipulator.cpp:803
+#: ../src/ui/tool/multi-path-manipulator.cpp:802
 msgid "Scale nodes horizontally"
 msgstr "Knoten horizontal skalieren"
 
-#: ../src/ui/tool/multi-path-manipulator.cpp:807
+#: ../src/ui/tool/multi-path-manipulator.cpp:806
 msgid "Scale nodes vertically"
 msgstr "Knoten vertikal skalieren"
 
-#: ../src/ui/tool/multi-path-manipulator.cpp:811
+#: ../src/ui/tool/multi-path-manipulator.cpp:810
 msgid "Skew nodes horizontally"
 msgstr "Knoten horizontal krümmen"
 
-#: ../src/ui/tool/multi-path-manipulator.cpp:815
+#: ../src/ui/tool/multi-path-manipulator.cpp:814
 msgid "Skew nodes vertically"
 msgstr "Knoten vertikal krümmen"
 
-#: ../src/ui/tool/multi-path-manipulator.cpp:819
+#: ../src/ui/tool/multi-path-manipulator.cpp:818
 msgid "Flip nodes horizontally"
 msgstr "Knoten Horizontal umkehren"
 
-#: ../src/ui/tool/multi-path-manipulator.cpp:822
+#: ../src/ui/tool/multi-path-manipulator.cpp:821
 msgid "Flip nodes vertically"
 msgstr "Knoten Vertikal umkehren"
 
@@ -24237,43 +24616,43 @@ msgctxt "Path handle tip"
 msgid "Move handle by %s, %s; angle %.2f°, length %s"
 msgstr "Anfasser verschieben um %s, %s; Winkel %.2f°, Länge %s"
 
-#: ../src/ui/tool/node.cpp:1414
+#: ../src/ui/tool/node.cpp:1411
 msgctxt "Path node tip"
 msgid "<b>Shift</b>: drag out a handle, click to toggle selection"
 msgstr ""
 "<b>Umschalt</b>: Anfasser nach außen ziehen, Klicken um Auswahl umzuschalten"
 
-#: ../src/ui/tool/node.cpp:1416
+#: ../src/ui/tool/node.cpp:1413
 msgctxt "Path node tip"
 msgid "<b>Shift</b>: click to toggle selection"
 msgstr "<b>Umschalt</b>: Klick um Auswahl umzuschalten"
 
-#: ../src/ui/tool/node.cpp:1421
+#: ../src/ui/tool/node.cpp:1418
 msgctxt "Path node tip"
 msgid "<b>Ctrl+Alt</b>: move along handle lines, click to delete node"
 msgstr ""
 "<b>Strg+Alt</b>: Entlang der Anfasser-Linien verschieben. Klicken, um Knoten "
 "zu löschen"
 
-#: ../src/ui/tool/node.cpp:1424
+#: ../src/ui/tool/node.cpp:1421
 msgctxt "Path node tip"
 msgid "<b>Ctrl</b>: move along axes, click to change node type"
 msgstr ""
 "<b>Strg</b>: Verschieben entlang der Achsen. Klicken, um Knotentyp zu "
 "verändern"
 
-#: ../src/ui/tool/node.cpp:1428
+#: ../src/ui/tool/node.cpp:1425
 msgctxt "Path node tip"
 msgid "<b>Alt</b>: sculpt nodes"
 msgstr "<b>Alt</b>: Knoten formen"
 
-#: ../src/ui/tool/node.cpp:1437
+#: ../src/ui/tool/node.cpp:1434
 #, c-format
 msgctxt "Path node tip"
 msgid "<b>%s</b>: drag to shape the path (more: Shift, Ctrl, Alt)"
 msgstr "<b>%s</b>: Ziehen, um den Pfad zu formen (mehr: Umschalt, Strg, Alt)"
 
-#: ../src/ui/tool/node.cpp:1440
+#: ../src/ui/tool/node.cpp:1437
 #, c-format
 msgctxt "Path node tip"
 msgid ""
@@ -24283,7 +24662,7 @@ msgstr ""
 "<b>BSpline Knoten</b>: Ziehen, um den Pfad zu formen (mehr: Umschalt, Strg, "
 "Alt). %g "
 
-#: ../src/ui/tool/node.cpp:1443
+#: ../src/ui/tool/node.cpp:1440
 #, c-format
 msgctxt "Path node tip"
 msgid ""
@@ -24293,7 +24672,7 @@ msgstr ""
 "<b>%s</b>:Ziehen, um den Pfad zu formen, Klicken um Skalieren/Rotieren der "
 "Anfasser umzuschalten (mehr: Umschalt, Strg, Alt)"
 
-#: ../src/ui/tool/node.cpp:1447
+#: ../src/ui/tool/node.cpp:1444
 #, c-format
 msgctxt "Path node tip"
 msgid ""
@@ -24303,7 +24682,7 @@ msgstr ""
 "<b>%s</b>: Ziehen, um den Pfad zu formen, Klicken, um nur diesen Knoten "
 "auszuwählen (mehr: Umschalt, Strg, Alt)"
 
-#: ../src/ui/tool/node.cpp:1450
+#: ../src/ui/tool/node.cpp:1447
 #, c-format
 msgctxt "Path node tip"
 msgid ""
@@ -24313,17 +24692,17 @@ msgstr ""
 "<b>B-Spline Knoten</b>: Ziehen, um den Pfad zu formen, Klicken, um nur "
 "diesen Knoten auszuwählen (mehr: Umschalt, Strg, Alt). Exponent %g"
 
-#: ../src/ui/tool/node.cpp:1463
+#: ../src/ui/tool/node.cpp:1460
 #, c-format
 msgctxt "Path node tip"
 msgid "Move node by %s, %s"
 msgstr "Knoten verschieben um %s, %s"
 
-#: ../src/ui/tool/node.cpp:1474
+#: ../src/ui/tool/node.cpp:1469
 msgid "Symmetric node"
 msgstr "symmetrischer Knoten"
 
-#: ../src/ui/tool/node.cpp:1475
+#: ../src/ui/tool/node.cpp:1470
 msgid "Auto-smooth node"
 msgstr "Knoten automatisch glätten"
 
@@ -24568,7 +24947,7 @@ msgstr ""
 "Führungspfad. <b>Pfeiltasten</b> verändern Breite (links/rechts) und Winkel "
 "(hoch/runter)."
 
-#: ../src/ui/tools-switch.cpp:107 ../src/ui/tools/text-tool.cpp:1629
+#: ../src/ui/tools-switch.cpp:107 ../src/ui/tools/text-tool.cpp:1625
 msgid ""
 "<b>Click</b> to select or create text, <b>drag</b> to create flowed text; "
 "then type."
@@ -24666,7 +25045,7 @@ msgstr ""
 "<b>Ellipse</b>: %s &#215; %s; <b>Strg</b> drücken für ganzzahliges "
 "Verhältnis der Radien; <b>Umschalt</b> zeichnet um Startpunkt"
 
-#: ../src/ui/tools/arc-tool.cpp:427
+#: ../src/ui/tools/arc-tool.cpp:424
 msgid "Create ellipse"
 msgstr "Ellipse erzeugen"
 
@@ -24685,71 +25064,71 @@ msgstr "<b>3D Box</b>; <b>Umschalt</b> um in Z-Richtung zu vergrößern"
 msgid "Create 3D box"
 msgstr "3D-Quader erzeugen"
 
-#: ../src/ui/tools/calligraphic-tool.cpp:517
+#: ../src/ui/tools/calligraphic-tool.cpp:516
 msgid ""
 "<b>Guide path selected</b>; start drawing along the guide with <b>Ctrl</b>"
 msgstr ""
 "<b>Führungspfad ausgewählt</b>; starte Zeichnen entlang der Führung mit "
 "<b>Strg</b>"
 
-#: ../src/ui/tools/calligraphic-tool.cpp:519
+#: ../src/ui/tools/calligraphic-tool.cpp:518
 msgid "<b>Select a guide path</b> to track with <b>Ctrl</b>"
 msgstr "<b>Führungspfad auswählen</b> mit <b>Strg</b>"
 
-#: ../src/ui/tools/calligraphic-tool.cpp:654
+#: ../src/ui/tools/calligraphic-tool.cpp:653
 msgid "Tracking: <b>connection to guide path lost!</b>"
 msgstr "Verfolgen: <b>Verbindung zum Führungspfad verloren!</b>"
 
-#: ../src/ui/tools/calligraphic-tool.cpp:654
+#: ../src/ui/tools/calligraphic-tool.cpp:653
 msgid "<b>Tracking</b> a guide path"
 msgstr "<b>Verfolge</b> einen Führungspfad"
 
-#: ../src/ui/tools/calligraphic-tool.cpp:657
+#: ../src/ui/tools/calligraphic-tool.cpp:656
 msgid "<b>Drawing</b> a calligraphic stroke"
 msgstr "<b>Zeichne</b> einen kalligrafischen Strich"
 
-#: ../src/ui/tools/calligraphic-tool.cpp:960
+#: ../src/ui/tools/calligraphic-tool.cpp:958
 msgid "Draw calligraphic stroke"
 msgstr "Kalligrafischen Strich zeichnen"
 
-#: ../src/ui/tools/connector-tool.cpp:482
+#: ../src/ui/tools/connector-tool.cpp:489
 msgid "Creating new connector"
 msgstr "Einen neuen Objektverbinder erzeugen"
 
-#: ../src/ui/tools/connector-tool.cpp:723
+#: ../src/ui/tools/connector-tool.cpp:730
 msgid "Connector endpoint drag cancelled."
 msgstr "Ziehen von Verbinder-Endpunkten abgebrochen."
 
-#: ../src/ui/tools/connector-tool.cpp:766
+#: ../src/ui/tools/connector-tool.cpp:770
 msgid "Reroute connector"
 msgstr "Objektverbinder neu verlegen"
 
-#: ../src/ui/tools/connector-tool.cpp:919
+#: ../src/ui/tools/connector-tool.cpp:926
 msgid "Create connector"
 msgstr "Objektverbinder erzeugen"
 
 # !!!
-#: ../src/ui/tools/connector-tool.cpp:936
+#: ../src/ui/tools/connector-tool.cpp:945
 msgid "Finishing connector"
 msgstr "Beende Objektverbinder"
 
-#: ../src/ui/tools/connector-tool.cpp:1173
+#: ../src/ui/tools/connector-tool.cpp:1174
 msgid "<b>Connector endpoint</b>: drag to reroute or connect to new shapes"
 msgstr ""
 "<b>Objektverbinder-Endpunkt</b>: ziehen, um neu zu verlegen oder mit neuen "
 "Formen zu verbinden"
 
-#: ../src/ui/tools/connector-tool.cpp:1316
+#: ../src/ui/tools/connector-tool.cpp:1310
 msgid "Select <b>at least one non-connector object</b>."
 msgstr "<b>Mindestens ein Objekt</b> auswählen, das kein Objektverbinder ist."
 
-#: ../src/ui/tools/connector-tool.cpp:1321
-#: ../src/widgets/connector-toolbar.cpp:307
+#: ../src/ui/tools/connector-tool.cpp:1315
+#: ../src/widgets/connector-toolbar.cpp:310
 msgid "Make connectors avoid selected objects"
 msgstr "Objektverbinder weichen den ausgewählten Objekten aus"
 
-#: ../src/ui/tools/connector-tool.cpp:1322
-#: ../src/widgets/connector-toolbar.cpp:317
+#: ../src/ui/tools/connector-tool.cpp:1316
+#: ../src/widgets/connector-toolbar.cpp:320
 msgid "Make connectors ignore selected objects"
 msgstr "Objektverbinder ignorieren die ausgewählten Objekte"
 
@@ -24779,11 +25158,11 @@ msgstr " unter Mauszeiger"
 msgid "<b>Release mouse</b> to set color."
 msgstr "<b>Maustaste loslassen</b>, um die Farbe zu übernehmen."
 
-#: ../src/ui/tools/eraser-tool.cpp:431
+#: ../src/ui/tools/eraser-tool.cpp:430
 msgid "<b>Drawing</b> an eraser stroke"
 msgstr "<b>Zeichne</b> einen Löschstrich"
 
-#: ../src/ui/tools/eraser-tool.cpp:862
+#: ../src/ui/tools/eraser-tool.cpp:860
 msgid "Draw eraser stroke"
 msgstr "Radierer-Pfad zeichnen"
 
@@ -24864,24 +25243,24 @@ msgstr ""
 "durch Berührung"
 
 #. We hit green anchor, closing Green-Blue-Red
-#: ../src/ui/tools/freehand-base.cpp:660 ../src/ui/tools/freehand-base.cpp:742
+#: ../src/ui/tools/freehand-base.cpp:758 ../src/ui/tools/freehand-base.cpp:825
 msgid "Path is closed."
 msgstr "Pfad ist geschlossen."
 
 #. We hit bot start and end of single curve, closing paths
-#: ../src/ui/tools/freehand-base.cpp:675
+#: ../src/ui/tools/freehand-base.cpp:773
 msgid "Closing path."
 msgstr "Pfad schließen"
 
-#: ../src/ui/tools/freehand-base.cpp:818
+#: ../src/ui/tools/freehand-base.cpp:907
 msgid "Draw path"
 msgstr "Pfad zeichnen"
 
-#: ../src/ui/tools/freehand-base.cpp:975
+#: ../src/ui/tools/freehand-base.cpp:1063
 msgid "Creating single dot"
 msgstr "Erzeuge einzelnen Punkt"
 
-#: ../src/ui/tools/freehand-base.cpp:976
+#: ../src/ui/tools/freehand-base.cpp:1064
 msgid "Create single dot"
 msgstr "Einen einzelnen Punkt erzeugen"
 
@@ -24941,34 +25320,34 @@ msgstr[1] ""
 "Von %d Verlaufs-Anfassern <b>keiner</b> ausgewählt bei %d ausgewählten "
 "Objekten"
 
-#: ../src/ui/tools/gradient-tool.cpp:432
+#: ../src/ui/tools/gradient-tool.cpp:425
 msgid "Simplify gradient"
 msgstr "Farbverlauf vereinfachen"
 
-#: ../src/ui/tools/gradient-tool.cpp:509
+#: ../src/ui/tools/gradient-tool.cpp:498
 msgid "Create default gradient"
 msgstr "Standard-Farbverlauf erzeugen"
 
-#: ../src/ui/tools/gradient-tool.cpp:568 ../src/ui/tools/mesh-tool.cpp:731
+#: ../src/ui/tools/gradient-tool.cpp:557 ../src/ui/tools/mesh-tool.cpp:667
 msgid "<b>Draw around</b> handles to select them"
 msgstr "<b>Zeichne um</b> Anfasser um diese auszuwählen"
 
-#: ../src/ui/tools/gradient-tool.cpp:689
+#: ../src/ui/tools/gradient-tool.cpp:678
 msgid "<b>Ctrl</b>: snap gradient angle"
 msgstr "<b>Strg</b>: Winkel des Farbverlaufs einrasten"
 
-#: ../src/ui/tools/gradient-tool.cpp:690
+#: ../src/ui/tools/gradient-tool.cpp:679
 msgid "<b>Shift</b>: draw gradient around the starting point"
 msgstr "<b>Umschalt</b>: Farbverlauf ausgehend vom Mittelpunkt zeichnen"
 
-#: ../src/ui/tools/gradient-tool.cpp:955 ../src/ui/tools/mesh-tool.cpp:1195
+#: ../src/ui/tools/gradient-tool.cpp:944 ../src/ui/tools/mesh-tool.cpp:1128
 #, c-format
 msgid "<b>Gradient</b> for %d object; with <b>Ctrl</b> to snap angle"
 msgid_plural "<b>Gradient</b> for %d objects; with <b>Ctrl</b> to snap angle"
 msgstr[0] "<b>Farbverlauf</b> für %d Objekte; mit <b>Strg</b> Winkel einrasten"
 msgstr[1] "<b>Farbverlauf</b> für %d Objekte; mit <b>Strg</b> Winkel einrasten"
 
-#: ../src/ui/tools/gradient-tool.cpp:959 ../src/ui/tools/mesh-tool.cpp:1199
+#: ../src/ui/tools/gradient-tool.cpp:948 ../src/ui/tools/mesh-tool.cpp:1132
 msgid "Select <b>objects</b> on which to create gradient."
 msgstr "<b>Objekte</b> auswählen, für die ein Farbverlauf erzeugt werden soll."
 
@@ -24986,38 +25365,48 @@ msgid "Measure end, <b>Shift+Click</b> for position dialog"
 msgstr "Zweiter Messpunkt, <b>Umschalt+Klick</b> für Positionsdialog"
 
 # Is this meant to be translatable?
-#: ../src/ui/tools/measure-tool.cpp:740 ../share/extensions/measure.inx.h:2
+#: ../src/ui/tools/measure-tool.cpp:746 ../share/extensions/measure.inx.h:2
 msgid "Measure"
 msgstr "Maßstab"
 
-#: ../src/ui/tools/measure-tool.cpp:745
+#: ../src/ui/tools/measure-tool.cpp:751
 msgid "Base"
 msgstr "Basis"
 
-#: ../src/ui/tools/measure-tool.cpp:754
+#: ../src/ui/tools/measure-tool.cpp:760
 msgid "Add guides from measure tool"
 msgstr "Hilflinien aus Messwerkzeug hinzufügen"
 
-#: ../src/ui/tools/measure-tool.cpp:774
+#: ../src/ui/tools/measure-tool.cpp:780
 msgid "Keep last measure on the canvas, for reference"
 msgstr "Letzte Messung als Referenz auf der Leinwand behalten"
 
-#: ../src/ui/tools/measure-tool.cpp:794
+#: ../src/ui/tools/measure-tool.cpp:800
 msgid "Convert measure to items"
 msgstr "Maßstab in Objekte umwandeln"
 
-#: ../src/ui/tools/measure-tool.cpp:832
+#: ../src/ui/tools/measure-tool.cpp:838
 msgid "Add global measure line"
 msgstr "Maßlinie erstellen"
 
+#: ../src/ui/tools/measure-tool.cpp:1197
+#, fuzzy
+msgid "Selected"
+msgstr "Auswählen"
+
+#: ../src/ui/tools/measure-tool.cpp:1199
+#, fuzzy
+msgid "Not selected"
+msgstr "Nichts ausgewählt"
+
 # Entry in edit history, but what is "Stored" (where) and can it actually be undone?
 # - According to Jabier, it's the grey phantom measure you get (temporarily) when using the corresponding button - used to compare two measures.
-#: ../src/ui/tools/measure-tool.cpp:1195
+#: ../src/ui/tools/measure-tool.cpp:1210
 #, fuzzy
 msgid "Shift to measure into group"
 msgstr "Phantombild des aktuellen Maßstabs erstellt"
 
-#: ../src/ui/tools/measure-tool.cpp:1385 ../src/ui/tools/measure-tool.cpp:1387
+#: ../src/ui/tools/measure-tool.cpp:1403 ../src/ui/tools/measure-tool.cpp:1405
 #, c-format
 msgid "Crossing %lu"
 msgstr "Schnittpunkt %lu"
@@ -25047,44 +25436,44 @@ msgstr[0] ""
 msgstr[1] ""
 "Von %d Gitter-Anfassern <b>keiner</b> ausgewählt bei %d ausgewählten Objekten"
 
-#: ../src/ui/tools/mesh-tool.cpp:359
+#: ../src/ui/tools/mesh-tool.cpp:297
 msgid "Split mesh row/column"
 msgstr "Teile Gitter Reihe/Spalte"
 
-#: ../src/ui/tools/mesh-tool.cpp:452
+#: ../src/ui/tools/mesh-tool.cpp:390
 msgid "Toggled mesh path type."
 msgstr "Verlaufsgittertyp ändern"
 
-#: ../src/ui/tools/mesh-tool.cpp:457
+#: ../src/ui/tools/mesh-tool.cpp:395
 msgid "Approximated arc for mesh side."
 msgstr "Angenäherter Kreisbogen für Gitterseite"
 
-#: ../src/ui/tools/mesh-tool.cpp:462
+#: ../src/ui/tools/mesh-tool.cpp:400
 msgid "Toggled mesh tensors."
 msgstr "Gittertensoren umschalten"
 
-#: ../src/ui/tools/mesh-tool.cpp:467
+#: ../src/ui/tools/mesh-tool.cpp:405
 msgid "Smoothed mesh corner color."
 msgstr "Farbe einer Gitterecke glätten"
 
-#: ../src/ui/tools/mesh-tool.cpp:472
+#: ../src/ui/tools/mesh-tool.cpp:410
 msgid "Picked mesh corner color."
 msgstr "Farbe für Gitterecke wählen"
 
-#: ../src/ui/tools/mesh-tool.cpp:477
+#: ../src/ui/tools/mesh-tool.cpp:415
 #, fuzzy
 msgid "Inserted new row or column."
 msgstr "Hinzugefügte Patchreihe oder Spalte"
 
-#: ../src/ui/tools/mesh-tool.cpp:548
+#: ../src/ui/tools/mesh-tool.cpp:486
 msgid "Fit mesh inside bounding box."
 msgstr "Verlaufsgitter in Objektrahmen einpassen."
 
-#: ../src/ui/tools/mesh-tool.cpp:1189
+#: ../src/ui/tools/mesh-tool.cpp:1122
 msgid "Create mesh"
 msgstr "Verlaufsgitter erstellen"
 
-#: ../src/ui/tools/node-tool.cpp:643
+#: ../src/ui/tools/node-tool.cpp:647
 msgctxt "Node tool tip"
 msgid ""
 "<b>Shift</b>: drag to add nodes to the selection, click to toggle object "
@@ -25093,19 +25482,19 @@ msgstr ""
 "<b>Umschalt</b>: Ziehen, um Knoten zur Auswahl hinzuzufügen. Klicken, um die "
 "Auswahl umzuschalten."
 
-#: ../src/ui/tools/node-tool.cpp:647
+#: ../src/ui/tools/node-tool.cpp:651
 msgctxt "Node tool tip"
 msgid "<b>Shift</b>: drag to add nodes to the selection"
 msgstr "<b>Umschalt</b>: Ziehen, um Knoten zur Auswahl hinzuzufügen"
 
-#: ../src/ui/tools/node-tool.cpp:676
+#: ../src/ui/tools/node-tool.cpp:680
 #, c-format
 msgid "<b>%u of %u</b> node selected."
 msgid_plural "<b>%u of %u</b> nodes selected."
 msgstr[0] "<b>%u von %u</b> Knoten ausgewählt."
 msgstr[1] "<b>%u von %u</b> Knoten ausgewählt."
 
-#: ../src/ui/tools/node-tool.cpp:683
+#: ../src/ui/tools/node-tool.cpp:687
 #, c-format
 msgctxt "Node tool tip"
 msgid "%s Drag to select nodes, click to edit only this object (more: Shift)"
@@ -25113,57 +25502,58 @@ msgstr ""
 "%s Ziehen, um Knoten auszuwählen. Klicken, um nur dieses Objekt zu "
 "bearbeiten (mehr: Umschalt)"
 
-#: ../src/ui/tools/node-tool.cpp:689
+#: ../src/ui/tools/node-tool.cpp:693
 #, c-format
 msgctxt "Node tool tip"
 msgid "%s Drag to select nodes, click clear the selection"
 msgstr "%s Ziehen, um Knoten auszuwählen. Klicken, um Auswahl zu löschen"
 
-#: ../src/ui/tools/node-tool.cpp:698
+#: ../src/ui/tools/node-tool.cpp:702
 msgctxt "Node tool tip"
 msgid "Drag to select nodes, click to edit only this object"
 msgstr ""
 "Ziehen, um Knoten auszuwählen. Klicken, um nur dieses Objekt zu bearbeiten."
 
-#: ../src/ui/tools/node-tool.cpp:701
+#: ../src/ui/tools/node-tool.cpp:705
 msgctxt "Node tool tip"
 msgid "Drag to select nodes, click to clear the selection"
 msgstr "Ziehen, um Knoten auszuwählen. Klicken, um Auswahl zu löschen"
 
-#: ../src/ui/tools/node-tool.cpp:706
+#: ../src/ui/tools/node-tool.cpp:710
 msgctxt "Node tool tip"
 msgid "Drag to select objects to edit, click to edit this object (more: Shift)"
 msgstr ""
 "Ziehen um Objekte zum Bearbeiten auszuwählen und Klicken, um das Objekt zu "
 "bearbeiten (mehr: Umschalt)"
 
-#: ../src/ui/tools/node-tool.cpp:709
+#: ../src/ui/tools/node-tool.cpp:713
 msgctxt "Node tool tip"
 msgid "Drag to select objects to edit"
 msgstr "Ziehen, um Objekte zum Bearbeiten auszuwählen"
 
-#: ../src/ui/tools/pen-tool.cpp:211 ../src/ui/tools/pencil-tool.cpp:450
+#: ../src/ui/tools/pen-tool.cpp:214 ../src/ui/tools/pencil-tool.cpp:531
 msgid "Drawing cancelled"
 msgstr "Zeichnen abgebrochen"
 
 # !!! make singular and plural forms
-#: ../src/ui/tools/pen-tool.cpp:451 ../src/ui/tools/pencil-tool.cpp:191
+#: ../src/ui/tools/pen-tool.cpp:460 ../src/ui/tools/pencil-tool.cpp:223
 msgid "Continuing selected path"
 msgstr "Gewählten Pfad verlängern"
 
-#: ../src/ui/tools/pen-tool.cpp:461 ../src/ui/tools/pencil-tool.cpp:199
+#: ../src/ui/tools/pen-tool.cpp:470 ../src/ui/tools/pencil-tool.cpp:231
+#: ../src/ui/tools/pencil-tool.cpp:237
 msgid "Creating new path"
 msgstr "Erzeuge neuen Pfad"
 
-#: ../src/ui/tools/pen-tool.cpp:463 ../src/ui/tools/pencil-tool.cpp:202
+#: ../src/ui/tools/pen-tool.cpp:472 ../src/ui/tools/pencil-tool.cpp:240
 msgid "Appending to selected path"
 msgstr "Zu ausgewähltem Pfad hinzufügen"
 
-#: ../src/ui/tools/pen-tool.cpp:628
+#: ../src/ui/tools/pen-tool.cpp:637
 msgid "<b>Click</b> or <b>click and drag</b> to close and finish the path."
 msgstr "<b>Klick</b> oder <b>Klick und Ziehen</b>, um den Pfad abzuschließen."
 
-#: ../src/ui/tools/pen-tool.cpp:630
+#: ../src/ui/tools/pen-tool.cpp:639
 msgid ""
 "<b>Click</b> or <b>click and drag</b> to close and finish the path. Shift"
 "+Click make a cusp node"
@@ -25171,14 +25561,14 @@ msgstr ""
 "<b>Klick</b> oder <b>Klick und Ziehen</b>, um den Pfad abzuschließen. "
 "Umschalt+Klick um spitzen Knoten zu erzeugen"
 
-#: ../src/ui/tools/pen-tool.cpp:642
+#: ../src/ui/tools/pen-tool.cpp:651
 msgid ""
 "<b>Click</b> or <b>click and drag</b> to continue the path from this point."
 msgstr ""
 "<b>Klick</b> oder <b>Klick und Ziehen</b>, um den Pfad von diesem Punkt aus "
 "fortzusetzen."
 
-#: ../src/ui/tools/pen-tool.cpp:644
+#: ../src/ui/tools/pen-tool.cpp:653
 msgid ""
 "<b>Click</b> or <b>click and drag</b> to continue the path from this point. "
 "Shift+Click make a cusp node"
@@ -25186,7 +25576,27 @@ msgstr ""
 "<b>Klick</b> oder <b>Klick und Ziehen</b>, um den Pfad von diesem Punkt aus "
 "fortzusetzen. Umschalt+Klick um spitzen Knoten zu erzeugen"
 
-#: ../src/ui/tools/pen-tool.cpp:1779
+#: ../src/ui/tools/pen-tool.cpp:1799
+#, fuzzy, c-format
+msgid ""
+"<b>Curve segment</b>: angle %3.2f&#176;; with <b>Shift+Click</b> cusp node,"
+"<b>ALT</b> move previous, <b>Enter</b> or <b>Shift+Enter</b> to finish"
+msgstr ""
+"<b>Kurvensegment</b>: Winkel %3.2f&#176;, Abstand %s; <b>Umschalt+Klick</b> "
+"erzeugt spitzen Winkel; <b>Eingabe</b> oder<b>Umschalt+Eingabe</b> schließen "
+"den Pfad ab"
+
+#: ../src/ui/tools/pen-tool.cpp:1800
+#, fuzzy, c-format
+msgid ""
+"<b>Line segment</b>: angle %3.2f&#176;; with <b>Shift+Click</b> cusp node,"
+"<b>ALT</b> move previous, <b>Enter</b> or <b>Shift+Enter</b> to finish"
+msgstr ""
+"<b>Liniensegment</b>: Winkel %3.2f&#176;, Abstand %s; <b>Umschalt+Klick</b> "
+"erzeugt spitzen Winkel; <b>Eingabe</b> oder <b>Umschalt+Eingabe</b> "
+"schließen den Pfad ab"
+
+#: ../src/ui/tools/pen-tool.cpp:1804
 #, c-format
 msgid ""
 "<b>Curve segment</b>: angle %3.2f&#176;, distance %s; with <b>Ctrl</b> to "
@@ -25195,7 +25605,7 @@ msgstr ""
 "<b>Kurvensegment</b>: Winkel %3.2f&#176;, Abstand %s; <b>Strg</b> rastet den "
 "Winkel ein; <b>Eingabe</b> oder <b>Umschalt+Eingabe</b> schließen den Pfad ab"
 
-#: ../src/ui/tools/pen-tool.cpp:1780
+#: ../src/ui/tools/pen-tool.cpp:1805
 #, c-format
 msgid ""
 "<b>Line segment</b>: angle %3.2f&#176;, distance %s; with <b>Ctrl</b> to "
@@ -25204,27 +25614,7 @@ msgstr ""
 "<b>Liniensegment</b>: Winkel %3.2f&#176;, Abstand %s; <b>Strg</b> rastet den "
 "Winkel ein; <b>Eingabe</b> oder <b>Umschalt+Eingabe</b> schließen den Pfad ab"
 
-#: ../src/ui/tools/pen-tool.cpp:1783
-#, c-format
-msgid ""
-"<b>Curve segment</b>: angle %3.2f&#176;, distance %s; with <b>Shift+Click</"
-"b> make a cusp node, <b>Enter</b> or <b>Shift+Enter</b> to finish the path"
-msgstr ""
-"<b>Kurvensegment</b>: Winkel %3.2f&#176;, Abstand %s; <b>Umschalt+Klick</b> "
-"erzeugt spitzen Winkel; <b>Eingabe</b> oder<b>Umschalt+Eingabe</b> schließen "
-"den Pfad ab"
-
-#: ../src/ui/tools/pen-tool.cpp:1784
-#, c-format
-msgid ""
-"<b>Line segment</b>: angle %3.2f&#176;, distance %s; with <b>Shift+Click</b> "
-"make a cusp node, <b>Enter</b> or <b>Shift+Enter</b> to finish the path"
-msgstr ""
-"<b>Liniensegment</b>: Winkel %3.2f&#176;, Abstand %s; <b>Umschalt+Klick</b> "
-"erzeugt spitzen Winkel; <b>Eingabe</b> oder <b>Umschalt+Eingabe</b> "
-"schließen den Pfad ab"
-
-#: ../src/ui/tools/pen-tool.cpp:1801
+#: ../src/ui/tools/pen-tool.cpp:1823
 #, c-format
 msgid ""
 "<b>Curve handle</b>: angle %3.2f&#176;, length %s; with <b>Ctrl</b> to snap "
@@ -25233,7 +25623,7 @@ msgstr ""
 "<b>Kurvenanfasser</b>: Winkel %3.2f°; Länge %s; Winkel mit <b>Strg</b> "
 "einrasten"
 
-#: ../src/ui/tools/pen-tool.cpp:1825
+#: ../src/ui/tools/pen-tool.cpp:1847
 #, c-format
 msgid ""
 "<b>Curve handle, symmetric</b>: angle %3.2f&#176;, length %s; with <b>Ctrl</"
@@ -25242,7 +25632,7 @@ msgstr ""
 "<b>Symmetrischer Kurvenanfasser</b>: Winkel %3.2f&#176;, Länge %s; <b>Strg</"
 "b> rastet den Winkel ein; <b>Umschalt</b> bewegt nur diesen Anfasser"
 
-#: ../src/ui/tools/pen-tool.cpp:1826
+#: ../src/ui/tools/pen-tool.cpp:1848
 #, c-format
 msgid ""
 "<b>Curve handle</b>: angle %3.2f&#176;, length %s; with <b>Ctrl</b> to snap "
@@ -25252,29 +25642,28 @@ msgstr ""
 "Winkel ein; <b>Umschalt</b> bewegt nur diesen Anfasser"
 
 # not sure here -cm-
-#: ../src/ui/tools/pen-tool.cpp:1960
+#: ../src/ui/tools/pen-tool.cpp:1990
 msgid "Drawing finished"
 msgstr "Zeichnen beendet"
 
-#: ../src/ui/tools/pencil-tool.cpp:303
+#: ../src/ui/tools/pencil-tool.cpp:356
 msgid "<b>Release</b> here to close and finish the path."
 msgstr "Hier <b>loslassen</b>, um den Pfad zu schließen und beenden."
 
-#: ../src/ui/tools/pencil-tool.cpp:309
+#: ../src/ui/tools/pencil-tool.cpp:364
 msgid "Drawing a freehand path"
 msgstr "Freihandlinien zeichnen"
 
-#: ../src/ui/tools/pencil-tool.cpp:314
+#: ../src/ui/tools/pencil-tool.cpp:370
 msgid "<b>Drag</b> to continue the path from this point."
 msgstr "<b>Ziehen</b>, um den Pfad von diesem Punkt aus fortzusetzen."
 
 # !!!
-#. Write curves to object
-#: ../src/ui/tools/pencil-tool.cpp:397
+#: ../src/ui/tools/pencil-tool.cpp:472
 msgid "Finishing freehand"
 msgstr "Fertig mit Freihandlinien"
 
-#: ../src/ui/tools/pencil-tool.cpp:499
+#: ../src/ui/tools/pencil-tool.cpp:580
 msgid ""
 "<b>Sketch mode</b>: holding <b>Alt</b> interpolates between sketched paths. "
 "Release <b>Alt</b> to finalize."
@@ -25283,7 +25672,7 @@ msgstr ""
 "Pfaden. Zum Beenden <b>Alt</b> loslassen."
 
 # !!!
-#: ../src/ui/tools/pencil-tool.cpp:526
+#: ../src/ui/tools/pencil-tool.cpp:607
 msgid "Finishing freehand sketch"
 msgstr "Fertig mit Freihandlinien"
 
@@ -25295,7 +25684,7 @@ msgstr ""
 "<b>Strg</b>: Quadrat oder Rechteck mit ganzzahligem Kanten-Längenverhältnis, "
 "abgerundete Kanten mit einheitlichen Radien"
 
-#: ../src/ui/tools/rect-tool.cpp:424
+#: ../src/ui/tools/rect-tool.cpp:425
 #, c-format
 msgid ""
 "<b>Rectangle</b>: %s &#215; %s (constrained to ratio %d:%d); with <b>Shift</"
@@ -25304,7 +25693,7 @@ msgstr ""
 "<b>Rechteck</b>: %s × %s (beschränkt auf Seitenverhältnis %d:%d); "
 "<b>Umschalt</b> - Rechteck vom Zentrum aus zeichnen"
 
-#: ../src/ui/tools/rect-tool.cpp:427
+#: ../src/ui/tools/rect-tool.cpp:430
 #, c-format
 msgid ""
 "<b>Rectangle</b>: %s &#215; %s (constrained to golden ratio 1.618 : 1); with "
@@ -25313,7 +25702,7 @@ msgstr ""
 "<b>Rechteck</b>: %s × %s (beschränkt auf Goldenen Schnitt 1,618 : 1); "
 "<b>Umschalt</b> - Rechteck vom Zentrum aus zeichnen"
 
-#: ../src/ui/tools/rect-tool.cpp:429
+#: ../src/ui/tools/rect-tool.cpp:434
 #, c-format
 msgid ""
 "<b>Rectangle</b>: %s &#215; %s (constrained to golden ratio 1 : 1.618); with "
@@ -25322,7 +25711,7 @@ msgstr ""
 "<b>Rechteck</b>: %s × %s (beschränkt auf Goldenen Schnitt 1 : 1,618); "
 "<b>Umschalt</b> - Rechteck vom Zentrum aus zeichnen"
 
-#: ../src/ui/tools/rect-tool.cpp:433
+#: ../src/ui/tools/rect-tool.cpp:440
 #, c-format
 msgid ""
 "<b>Rectangle</b>: %s &#215; %s; with <b>Ctrl</b> to make square or integer-"
@@ -25331,7 +25720,7 @@ msgstr ""
 "<b>Rechteck</b>: %s × %s; <b>Strg</b> erzeugt Quadrat oder ganzzahliges "
 "Höhen/Breitenverhältnis; <b>Umschalt</b> - Rechteck vom Zentrum aus zeichnen"
 
-#: ../src/ui/tools/rect-tool.cpp:456
+#: ../src/ui/tools/rect-tool.cpp:461
 msgid "Create rectangle"
 msgstr "Rechteck erzeugen"
 
@@ -25359,7 +25748,7 @@ msgstr "Verschieben abgebrochen."
 msgid "Selection canceled."
 msgstr "Auswahl abgebrochen."
 
-#: ../src/ui/tools/select-tool.cpp:637
+#: ../src/ui/tools/select-tool.cpp:639
 msgid ""
 "<b>Draw over</b> objects to select them; release <b>Alt</b> to switch to "
 "rubberband selection"
@@ -25367,7 +25756,7 @@ msgstr ""
 "<b>Zeichnen über</b> Objekten wählt sie aus; <b>Alt</b> loslassen, um mit "
 "Gummiband auszuwählen"
 
-#: ../src/ui/tools/select-tool.cpp:639
+#: ../src/ui/tools/select-tool.cpp:641
 msgid ""
 "<b>Drag around</b> objects to select them; press <b>Alt</b> to switch to "
 "touch selection"
@@ -25375,19 +25764,19 @@ msgstr ""
 "<b>Ziehen um</b> Objekte wählt sie aus; <b>Alt</b> drücken, um durch "
 "Berührung auszuwählen"
 
-#: ../src/ui/tools/select-tool.cpp:880
+#: ../src/ui/tools/select-tool.cpp:882
 msgid "<b>Ctrl</b>: click to select in groups; drag to move hor/vert"
 msgstr ""
 "<b>Strg</b>: Klick um in Gruppierung auszuwählen; Ziehen um horizontal/"
 "vertikal bewegen"
 
-#: ../src/ui/tools/select-tool.cpp:881
+#: ../src/ui/tools/select-tool.cpp:883
 msgid "<b>Shift</b>: click to toggle select; drag for rubberband selection"
 msgstr ""
 "<b>Umschalt</b>: Klick um Auswahl aktivieren/deaktivieren, Ziehen für "
 "Gummiband-Auswahl"
 
-#: ../src/ui/tools/select-tool.cpp:882
+#: ../src/ui/tools/select-tool.cpp:884
 msgid ""
 "<b>Alt</b>: click to select under; scroll mouse-wheel to cycle-select; drag "
 "to move selected or select by touch"
@@ -25395,7 +25784,7 @@ msgstr ""
 "<b>Alt</b>: Klick um verdeckte Objekte auswählen; Ziehen um gewähltes Objekt "
 "zu verschieben oder durch Berühren auszuwählen"
 
-#: ../src/ui/tools/select-tool.cpp:1060
+#: ../src/ui/tools/select-tool.cpp:1062
 msgid "Selected object is not a group. Cannot enter."
 msgstr "Ausgewähltes Objekt ist keine Gruppe - kann diese nicht betreten."
 
@@ -25414,7 +25803,7 @@ msgid ""
 msgstr ""
 "<b>Spirale</b>: Radius %s, Winkel %5g&#176;; Winkel mit <b>Strg</b> einrasten"
 
-#: ../src/ui/tools/spiral-tool.cpp:398
+#: ../src/ui/tools/spiral-tool.cpp:397
 msgid "Create spiral"
 msgstr "Spirale erstellen"
 
@@ -25460,11 +25849,11 @@ msgstr ""
 msgid "<b>Nothing selected!</b> Select objects to spray."
 msgstr "<b>Nichts ausgewählt!</b> Wähle Objekte zum Sprühen aus."
 
-#: ../src/ui/tools/spray-tool.cpp:1360 ../src/widgets/spray-toolbar.cpp:360
+#: ../src/ui/tools/spray-tool.cpp:1360 ../src/widgets/spray-toolbar.cpp:362
 msgid "Spray with copies"
 msgstr "Sprühen mit Kopien"
 
-#: ../src/ui/tools/spray-tool.cpp:1364 ../src/widgets/spray-toolbar.cpp:367
+#: ../src/ui/tools/spray-tool.cpp:1364 ../src/widgets/spray-toolbar.cpp:368
 msgid "Spray with clones"
 msgstr "Sprühen mit Klonen"
 
@@ -25489,7 +25878,7 @@ msgid "<b>Star</b>: radius %s, angle %5g&#176;; with <b>Ctrl</b> to snap angle"
 msgstr ""
 "<b>Stern</b>: Radius %s, Winkel %5g&#176;; Winkel mit <b>Strg</b> einrasten"
 
-#: ../src/ui/tools/star-tool.cpp:424
+#: ../src/ui/tools/star-tool.cpp:422
 msgid "Create star"
 msgstr "Stern erstellen"
 
@@ -25523,7 +25912,7 @@ msgstr "Unicode-Zeichen einfügen"
 msgid "Unicode (<b>Enter</b> to finish): %s: %s"
 msgstr "Unicode (<b>Eingabe</b> zum Abschliessen): %s: %s"
 
-#: ../src/ui/tools/text-tool.cpp:499 ../src/ui/tools/text-tool.cpp:802
+#: ../src/ui/tools/text-tool.cpp:499 ../src/ui/tools/text-tool.cpp:798
 msgid "Unicode (<b>Enter</b> to finish): "
 msgstr "Unicode (<b>Eingabe</b> zum Abschliessen): "
 
@@ -25532,19 +25921,19 @@ msgstr "Unicode (<b>Eingabe</b> zum Abschliessen): "
 msgid "<b>Flowed text frame</b>: %s &#215; %s"
 msgstr "<b>Fließtext-Rahmen</b>: %s × %s"
 
-#: ../src/ui/tools/text-tool.cpp:638
+#: ../src/ui/tools/text-tool.cpp:634
 msgid "Type text; <b>Enter</b> to start new line."
 msgstr "Text schreiben; <b>Eingabe</b>, um eine neue Zeile zu beginnen."
 
-#: ../src/ui/tools/text-tool.cpp:649
+#: ../src/ui/tools/text-tool.cpp:645
 msgid "Flowed text is created."
 msgstr "Fließtext wird erzeugt."
 
-#: ../src/ui/tools/text-tool.cpp:650
+#: ../src/ui/tools/text-tool.cpp:646
 msgid "Create flowed text"
 msgstr "Fließtext erstellen"
 
-#: ../src/ui/tools/text-tool.cpp:652
+#: ../src/ui/tools/text-tool.cpp:648
 msgid ""
 "The frame is <b>too small</b> for the current font size. Flowed text not "
 "created."
@@ -25552,75 +25941,75 @@ msgstr ""
 "Der Rahmen ist <b>zu klein</b> für die aktuelle Schriftgröße. Der Fließtext "
 "wurde nicht erzeugt."
 
-#: ../src/ui/tools/text-tool.cpp:788
+#: ../src/ui/tools/text-tool.cpp:784
 msgid "No-break space"
 msgstr "Untrennbares Leerzeichen"
 
-#: ../src/ui/tools/text-tool.cpp:789
+#: ../src/ui/tools/text-tool.cpp:785
 msgid "Insert no-break space"
 msgstr "Untrennbares Leerzeichen einfügen"
 
-#: ../src/ui/tools/text-tool.cpp:825
+#: ../src/ui/tools/text-tool.cpp:821
 msgid "Make bold"
 msgstr "Fett"
 
-#: ../src/ui/tools/text-tool.cpp:842
+#: ../src/ui/tools/text-tool.cpp:838
 msgid "Make italic"
 msgstr "Kursiv"
 
-#: ../src/ui/tools/text-tool.cpp:880
+#: ../src/ui/tools/text-tool.cpp:876
 msgid "New line"
 msgstr "Neue Zeile"
 
-#: ../src/ui/tools/text-tool.cpp:921
+#: ../src/ui/tools/text-tool.cpp:917
 msgid "Backspace"
 msgstr "Rückschritt"
 
-#: ../src/ui/tools/text-tool.cpp:975
+#: ../src/ui/tools/text-tool.cpp:971
 msgid "Kern to the left"
 msgstr "Unterschneidung nach links"
 
-#: ../src/ui/tools/text-tool.cpp:999
+#: ../src/ui/tools/text-tool.cpp:995
 msgid "Kern to the right"
 msgstr "Unterschneidung nach rechts"
 
-#: ../src/ui/tools/text-tool.cpp:1023
+#: ../src/ui/tools/text-tool.cpp:1019
 msgid "Kern up"
 msgstr "Unterschneidung nach oben"
 
-#: ../src/ui/tools/text-tool.cpp:1047
+#: ../src/ui/tools/text-tool.cpp:1043
 msgid "Kern down"
 msgstr "Unterschneidung nach unten"
 
-#: ../src/ui/tools/text-tool.cpp:1122
+#: ../src/ui/tools/text-tool.cpp:1118
 msgid "Rotate counterclockwise"
 msgstr "Entgegen Uhrzeigersinn drehen"
 
-#: ../src/ui/tools/text-tool.cpp:1142
+#: ../src/ui/tools/text-tool.cpp:1138
 msgid "Rotate clockwise"
 msgstr "Im Uhrzeigersinn drehen"
 
-#: ../src/ui/tools/text-tool.cpp:1158
+#: ../src/ui/tools/text-tool.cpp:1154
 msgid "Contract line spacing"
 msgstr "Zeilenabstand vermindern"
 
-#: ../src/ui/tools/text-tool.cpp:1164
+#: ../src/ui/tools/text-tool.cpp:1160
 msgid "Contract letter spacing"
 msgstr "Zeichenabstand vermindern"
 
-#: ../src/ui/tools/text-tool.cpp:1181
+#: ../src/ui/tools/text-tool.cpp:1177
 msgid "Expand line spacing"
 msgstr "Zeilenabstand vergrößern"
 
-#: ../src/ui/tools/text-tool.cpp:1187
+#: ../src/ui/tools/text-tool.cpp:1183
 msgid "Expand letter spacing"
 msgstr "Zeichenabstand vergrößern"
 
-#: ../src/ui/tools/text-tool.cpp:1317
+#: ../src/ui/tools/text-tool.cpp:1313
 msgid "Paste text"
 msgstr "Text einfügen"
 
-#: ../src/ui/tools/text-tool.cpp:1619
+#: ../src/ui/tools/text-tool.cpp:1615
 #, c-format
 msgid ""
 "Type or edit flowed text (%d character%s); <b>Enter</b> to start new "
@@ -25635,7 +26024,7 @@ msgstr[1] ""
 "Fließtext schreiben (%d Zeichen%s); <b>Eingabe</b>, um einen neuen Absatz zu "
 "beginnen."
 
-#: ../src/ui/tools/text-tool.cpp:1621
+#: ../src/ui/tools/text-tool.cpp:1617
 #, c-format
 msgid "Type or edit text (%d character%s); <b>Enter</b> to start new line."
 msgid_plural ""
@@ -25647,11 +26036,11 @@ msgstr[1] ""
 "Text eintippen oder bearbeiten (%d Zeichen%s); <b>Eingabe</b>, um eine neue "
 "Zeile zu beginnen."
 
-#: ../src/ui/tools/text-tool.cpp:1731
+#: ../src/ui/tools/text-tool.cpp:1727
 msgid "Type text"
 msgstr "Text eingeben"
 
-#: ../src/ui/tools/tool-base.cpp:713
+#: ../src/ui/tools/tool-base.cpp:717
 msgid "<b>Space+mouse move</b> to pan canvas"
 msgstr "<b>Leertaste+Maus ziehen</b>, um die Arbeitsfläche zu verschieben"
 
@@ -25737,59 +26126,59 @@ msgstr ""
 "%s. Ziehen oder Klicken, um die <b>Unschärfe zu erhöhen</b>; mit Umschalt "
 "<b>verringern</b>."
 
-#: ../src/ui/tools/tweak-tool.cpp:1200
+#: ../src/ui/tools/tweak-tool.cpp:1197
 msgid "<b>Nothing selected!</b> Select objects to tweak."
 msgstr "<b>Nichts ausgewählt!</b> Wähle Objekte zum Justieren aus."
 
-#: ../src/ui/tools/tweak-tool.cpp:1234
+#: ../src/ui/tools/tweak-tool.cpp:1231
 msgid "Move tweak"
 msgstr "Optimieren durch Verschieben"
 
-#: ../src/ui/tools/tweak-tool.cpp:1238
+#: ../src/ui/tools/tweak-tool.cpp:1235
 msgid "Move in/out tweak"
 msgstr "Optimieren durch Zusammen-/Auseinanderbewegen"
 
-#: ../src/ui/tools/tweak-tool.cpp:1242
+#: ../src/ui/tools/tweak-tool.cpp:1239
 msgid "Move jitter tweak"
 msgstr "Optimieren durch Bewegungsversatz"
 
-#: ../src/ui/tools/tweak-tool.cpp:1246
+#: ../src/ui/tools/tweak-tool.cpp:1243
 msgid "Scale tweak"
 msgstr "Optimieren durch Skalieren"
 
-#: ../src/ui/tools/tweak-tool.cpp:1250
+#: ../src/ui/tools/tweak-tool.cpp:1247
 msgid "Rotate tweak"
 msgstr "Optimieren durch Rotieren"
 
-#: ../src/ui/tools/tweak-tool.cpp:1254
+#: ../src/ui/tools/tweak-tool.cpp:1251
 msgid "Duplicate/delete tweak"
 msgstr "Optimieren durch Duplizieren-/Löschen"
 
-#: ../src/ui/tools/tweak-tool.cpp:1258
+#: ../src/ui/tools/tweak-tool.cpp:1255
 msgid "Push path tweak"
 msgstr "Optimieren durch Verschieben von Pfaden"
 
-#: ../src/ui/tools/tweak-tool.cpp:1262
+#: ../src/ui/tools/tweak-tool.cpp:1259
 msgid "Shrink/grow path tweak"
 msgstr "Optimieren durch Schrumpfen/Vergößern von Pfaden"
 
-#: ../src/ui/tools/tweak-tool.cpp:1266
+#: ../src/ui/tools/tweak-tool.cpp:1263
 msgid "Attract/repel path tweak"
 msgstr "Optimieren durch Anziehen/Abstoßen von Pfaden"
 
-#: ../src/ui/tools/tweak-tool.cpp:1270
+#: ../src/ui/tools/tweak-tool.cpp:1267
 msgid "Roughen path tweak"
 msgstr "Optimieren der Pfadrauheit"
 
-#: ../src/ui/tools/tweak-tool.cpp:1274
+#: ../src/ui/tools/tweak-tool.cpp:1271
 msgid "Color paint tweak"
 msgstr "Optimieren der Farbe"
 
-#: ../src/ui/tools/tweak-tool.cpp:1278
+#: ../src/ui/tools/tweak-tool.cpp:1275
 msgid "Color jitter tweak"
 msgstr "Optimieren durch Farbrauschen"
 
-#: ../src/ui/tools/tweak-tool.cpp:1282
+#: ../src/ui/tools/tweak-tool.cpp:1279
 msgid "Blur tweak"
 msgstr "Optimieren durch Unschärfe"
 
@@ -25798,18 +26187,18 @@ msgid "Hexadecimal RGBA value of the color"
 msgstr "Hexadezimaler RGBA-Wert der Farbe"
 
 #: ../src/ui/widget/color-icc-selector.cpp:154
-#: ../src/ui/widget/color-scales.cpp:355
+#: ../src/ui/widget/color-scales.cpp:366
 msgid "_R:"
 msgstr "_R:"
 
 #. TYPE_RGB_16
 #: ../src/ui/widget/color-icc-selector.cpp:155
-#: ../src/ui/widget/color-scales.cpp:358
+#: ../src/ui/widget/color-scales.cpp:369
 msgid "_G:"
 msgstr "_G:"
 
 #: ../src/ui/widget/color-icc-selector.cpp:156
-#: ../src/ui/widget/color-scales.cpp:361
+#: ../src/ui/widget/color-scales.cpp:372
 msgid "_B:"
 msgstr "_B:"
 
@@ -25821,26 +26210,26 @@ msgstr "Grau"
 #. TYPE_GRAY_16
 #: ../src/ui/widget/color-icc-selector.cpp:160
 #: ../src/ui/widget/color-icc-selector.cpp:164
-#: ../src/ui/widget/color-scales.cpp:381
+#: ../src/ui/widget/color-scales.cpp:393 ../src/ui/widget/color-scales.cpp:429
 msgid "_H:"
 msgstr "_H:"
 
 #. TYPE_HSV_16
 #: ../src/ui/widget/color-icc-selector.cpp:161
 #: ../src/ui/widget/color-icc-selector.cpp:166
-#: ../src/ui/widget/color-scales.cpp:384
+#: ../src/ui/widget/color-scales.cpp:398 ../src/ui/widget/color-scales.cpp:434
 msgid "_S:"
 msgstr "_S:"
 
 #. TYPE_HLS_16
 #: ../src/ui/widget/color-icc-selector.cpp:165
-#: ../src/ui/widget/color-scales.cpp:387
+#: ../src/ui/widget/color-scales.cpp:402
 msgid "_L:"
 msgstr "_L:"
 
 #: ../src/ui/widget/color-icc-selector.cpp:168
 #: ../src/ui/widget/color-icc-selector.cpp:173
-#: ../src/ui/widget/color-scales.cpp:409
+#: ../src/ui/widget/color-scales.cpp:464
 msgid "_C:"
 msgstr "_C:"
 
@@ -25848,18 +26237,18 @@ msgstr "_C:"
 #. TYPE_CMY_16
 #: ../src/ui/widget/color-icc-selector.cpp:169
 #: ../src/ui/widget/color-icc-selector.cpp:174
-#: ../src/ui/widget/color-scales.cpp:412
+#: ../src/ui/widget/color-scales.cpp:467
 msgid "_M:"
 msgstr "_M:"
 
 #: ../src/ui/widget/color-icc-selector.cpp:170
 #: ../src/ui/widget/color-icc-selector.cpp:175
-#: ../src/ui/widget/color-scales.cpp:415
+#: ../src/ui/widget/color-scales.cpp:470
 msgid "_Y:"
 msgstr "Y:"
 
 #: ../src/ui/widget/color-icc-selector.cpp:171
-#: ../src/ui/widget/color-scales.cpp:418
+#: ../src/ui/widget/color-scales.cpp:473
 msgid "_K:"
 msgstr "_K:"
 
@@ -25879,40 +26268,41 @@ msgstr "Legt RGB-Ausweichwert für Entsprechung des icc-color()-Parameters fest"
 
 #. Label
 #: ../src/ui/widget/color-icc-selector.cpp:469
-#: ../src/ui/widget/color-scales.cpp:364 ../src/ui/widget/color-scales.cpp:390
-#: ../src/ui/widget/color-scales.cpp:421
-#: ../src/ui/widget/color-wheel-selector.cpp:64
+#: ../src/ui/widget/color-scales.cpp:375 ../src/ui/widget/color-scales.cpp:406
+#: ../src/ui/widget/color-scales.cpp:442 ../src/ui/widget/color-scales.cpp:476
+#: ../src/ui/widget/color-wheel-selector.cpp:66
 msgid "_A:"
 msgstr "_A:"
 
 #: ../src/ui/widget/color-icc-selector.cpp:481
 #: ../src/ui/widget/color-icc-selector.cpp:492
-#: ../src/ui/widget/color-scales.cpp:365 ../src/ui/widget/color-scales.cpp:366
-#: ../src/ui/widget/color-scales.cpp:391 ../src/ui/widget/color-scales.cpp:392
-#: ../src/ui/widget/color-scales.cpp:422 ../src/ui/widget/color-scales.cpp:423
-#: ../src/ui/widget/color-wheel-selector.cpp:87
-#: ../src/ui/widget/color-wheel-selector.cpp:109
+#: ../src/ui/widget/color-scales.cpp:376 ../src/ui/widget/color-scales.cpp:377
+#: ../src/ui/widget/color-scales.cpp:407 ../src/ui/widget/color-scales.cpp:408
+#: ../src/ui/widget/color-scales.cpp:443 ../src/ui/widget/color-scales.cpp:444
+#: ../src/ui/widget/color-scales.cpp:477 ../src/ui/widget/color-scales.cpp:478
+#: ../src/ui/widget/color-wheel-selector.cpp:89
+#: ../src/ui/widget/color-wheel-selector.cpp:111
 msgid "Alpha (opacity)"
 msgstr "Alpha (Deckkraft)"
 
-#: ../src/ui/widget/color-notebook.cpp:155
+#: ../src/ui/widget/color-notebook.cpp:160
 msgid "Color Managed"
 msgstr "Farb-Management"
 
-#: ../src/ui/widget/color-notebook.cpp:162
+#: ../src/ui/widget/color-notebook.cpp:167
 msgid "Out of gamut!"
 msgstr "Farbbereich überschritten!"
 
-#: ../src/ui/widget/color-notebook.cpp:169
+#: ../src/ui/widget/color-notebook.cpp:174
 msgid "Too much ink!"
 msgstr "Zu viel Farbe!"
 
-#: ../src/ui/widget/color-notebook.cpp:180 ../src/verbs.cpp:2927
+#: ../src/ui/widget/color-notebook.cpp:185 ../src/verbs.cpp:2961
 msgid "Pick colors from image"
 msgstr "Farben aus dem Bild übernehmen"
 
 #. Create RGBA entry and color preview
-#: ../src/ui/widget/color-notebook.cpp:185
+#: ../src/ui/widget/color-notebook.cpp:190
 msgid "RGBA_:"
 msgstr "RGBA_:"
 
@@ -25928,13 +26318,30 @@ msgstr "HSL"
 msgid "CMYK"
 msgstr "CMYK"
 
-#: ../src/ui/widget/filter-effect-chooser.cpp:22
-msgid "_Blur:"
-msgstr "Unschärfe:"
+#: ../src/ui/widget/color-scales.cpp:43
+#, fuzzy
+msgid "HSV"
+msgstr "HSL"
+
+#: ../src/ui/widget/color-scales.cpp:438
+#, fuzzy
+msgid "_V:"
+msgstr "V:"
+
+#: ../src/ui/widget/color-scales.cpp:439 ../src/ui/widget/color-scales.cpp:440
+#: ../src/widgets/sp-xmlview-attr-list.cpp:55
+msgid "Value"
+msgstr "Wert"
 
 #: ../src/ui/widget/filter-effect-chooser.cpp:25
 msgid "Blur (%)"
 msgstr "Unschärfe (%)"
+
+#: ../src/ui/widget/filter-effect-chooser.cpp:26
+#: ../src/ui/widget/selected-style.cpp:1066
+#: ../src/ui/widget/selected-style.cpp:1067
+msgid "Opacity (%)"
+msgstr "Deckkraft (%)"
 
 #: ../src/ui/widget/font-variants.cpp:30
 msgctxt "Font variant"
@@ -26260,19 +26667,14 @@ msgstr "Andere"
 msgid "Document license updated"
 msgstr "Lizenz des Dokuments geändert"
 
-#: ../src/ui/widget/object-composite-settings.cpp:39
-#: ../src/ui/widget/selected-style.cpp:1057
-#: ../src/ui/widget/selected-style.cpp:1058
-msgid "Opacity (%)"
-msgstr "Deckkraft (%)"
-
-#: ../src/ui/widget/object-composite-settings.cpp:152
-msgid "Change blur"
+#: ../src/ui/widget/object-composite-settings.cpp:139
+#, fuzzy
+msgid "Change blur/blend filter"
 msgstr "Weichzeichner ändern"
 
-#: ../src/ui/widget/object-composite-settings.cpp:192
-#: ../src/ui/widget/selected-style.cpp:881
-#: ../src/ui/widget/selected-style.cpp:1175
+#: ../src/ui/widget/object-composite-settings.cpp:174
+#: ../src/ui/widget/selected-style.cpp:890
+#: ../src/ui/widget/selected-style.cpp:1184
 msgid "Change opacity"
 msgstr "Deckkraft ändern"
 
@@ -26289,50 +26691,60 @@ msgid "Height of paper"
 msgstr "Höhe des Papiers"
 
 #: ../src/ui/widget/page-sizer.cpp:222
+#, fuzzy
+msgid "Loc_k margins"
+msgstr "Layout-Ränder"
+
+#: ../src/ui/widget/page-sizer.cpp:222
+#, fuzzy
+msgid "Lock margins"
+msgstr "Layout-Ränder"
+
+#: ../src/ui/widget/page-sizer.cpp:224
 msgid "T_op margin:"
 msgstr "Oberer Rand:"
 
-#: ../src/ui/widget/page-sizer.cpp:222
+#: ../src/ui/widget/page-sizer.cpp:224
 msgid "Top margin"
 msgstr "Oberer Rand"
 
-#: ../src/ui/widget/page-sizer.cpp:223
+#: ../src/ui/widget/page-sizer.cpp:225
 msgid "L_eft:"
 msgstr "Links:"
 
-#: ../src/ui/widget/page-sizer.cpp:223
+#: ../src/ui/widget/page-sizer.cpp:225
 msgid "Left margin"
 msgstr "Linker Rand"
 
-#: ../src/ui/widget/page-sizer.cpp:224
+#: ../src/ui/widget/page-sizer.cpp:226
 msgid "Ri_ght:"
 msgstr "Rechts:"
 
-#: ../src/ui/widget/page-sizer.cpp:224
+#: ../src/ui/widget/page-sizer.cpp:226
 msgid "Right margin"
 msgstr "Rechter Rand"
 
-#: ../src/ui/widget/page-sizer.cpp:225
+#: ../src/ui/widget/page-sizer.cpp:227
 msgid "Botto_m:"
 msgstr "Unten:"
 
-#: ../src/ui/widget/page-sizer.cpp:225
+#: ../src/ui/widget/page-sizer.cpp:227
 msgid "Bottom margin"
 msgstr "Unterer Rand"
 
-#: ../src/ui/widget/page-sizer.cpp:227
+#: ../src/ui/widget/page-sizer.cpp:229
 msgid "Scale _x:"
 msgstr "Skalierung _x:"
 
-#: ../src/ui/widget/page-sizer.cpp:227
+#: ../src/ui/widget/page-sizer.cpp:229
 msgid "Scale X"
 msgstr "X skalieren"
 
-#: ../src/ui/widget/page-sizer.cpp:228
+#: ../src/ui/widget/page-sizer.cpp:230
 msgid "Scale _y:"
 msgstr "Skalierung _y:"
 
-#: ../src/ui/widget/page-sizer.cpp:228
+#: ../src/ui/widget/page-sizer.cpp:230
 msgid ""
 "While SVG allows non-uniform scaling it is recommended to use only uniform "
 "scaling in Inkscape. To set a non-uniform scaling, set the 'viewBox' "
@@ -26343,20 +26755,20 @@ msgstr ""
 "Skalierungsfaktoren festzulegen kann das 'viewBox' Attribut direkt "
 "bearbeitet werden."
 
-#: ../src/ui/widget/page-sizer.cpp:306
+#: ../src/ui/widget/page-sizer.cpp:307
 msgid "Orientation:"
 msgstr "Ausrichtung"
 
-#: ../src/ui/widget/page-sizer.cpp:309
+#: ../src/ui/widget/page-sizer.cpp:310
 msgid "_Landscape"
 msgstr "_Querformat"
 
-#: ../src/ui/widget/page-sizer.cpp:314
+#: ../src/ui/widget/page-sizer.cpp:315
 msgid "_Portrait"
 msgstr "_Hochformat"
 
 #. ## Set up custom size frame
-#: ../src/ui/widget/page-sizer.cpp:333
+#: ../src/ui/widget/page-sizer.cpp:334
 msgid "Custom size"
 msgstr "Benutzerdefiniert"
 
@@ -26364,12 +26776,12 @@ msgstr "Benutzerdefiniert"
 msgid "Resi_ze page to content..."
 msgstr "Ändern der Seitengröße auf Inhalt..."
 
-#: ../src/ui/widget/page-sizer.cpp:403
+#: ../src/ui/widget/page-sizer.cpp:417
 #, fuzzy
 msgid "_Resize page to drawing or selection (Ctrl+Shift+R)"
 msgstr "Seiteng_röße auf Zeichnungs-/Auswahlgröße"
 
-#: ../src/ui/widget/page-sizer.cpp:404
+#: ../src/ui/widget/page-sizer.cpp:418
 msgid ""
 "Resize the page to fit the current selection, or the entire drawing if there "
 "is no selection"
@@ -26377,123 +26789,31 @@ msgstr ""
 "Seitengröße so verändern, daß die aktuelle Auswahl, oder, falls nichts "
 "ausgewählt ist,  die gesamte Zeichnung, hineinpasst."
 
-#: ../src/ui/widget/page-sizer.cpp:424
+#: ../src/ui/widget/page-sizer.cpp:438
 msgid "_Viewbox..."
 msgstr "_Viewbox..."
 
-#: ../src/ui/widget/page-sizer.cpp:520
+#: ../src/ui/widget/page-sizer.cpp:538
 msgid "Set page size"
 msgstr "Seitengröße setzen"
 
-#: ../src/ui/widget/page-sizer.cpp:766
+#: ../src/ui/widget/page-sizer.cpp:784
 msgid "User units per "
 msgstr "SVG-Benutzereinheiten pro "
 
-#: ../src/ui/widget/page-sizer.cpp:862
+#: ../src/ui/widget/page-sizer.cpp:880
 msgid "Set page scale"
 msgstr "Seitenskalierung festlegen"
 
-#: ../src/ui/widget/page-sizer.cpp:888
+#: ../src/ui/widget/page-sizer.cpp:906
 msgid "Set 'viewBox'"
 msgstr "'viewBox' festlegen"
 
-#: ../src/ui/widget/panel.cpp:111
-msgid "List"
-msgstr "Liste"
-
-#: ../src/ui/widget/panel.cpp:134
-msgctxt "Swatches"
-msgid "Size"
-msgstr "Größe"
-
-#: ../src/ui/widget/panel.cpp:138
-msgctxt "Swatches height"
-msgid "Tiny"
-msgstr "Winzig"
-
-#: ../src/ui/widget/panel.cpp:139
-msgctxt "Swatches height"
-msgid "Small"
-msgstr "Klein"
-
-#: ../src/ui/widget/panel.cpp:140
-msgctxt "Swatches height"
-msgid "Medium"
-msgstr "Mittel"
-
-#: ../src/ui/widget/panel.cpp:141
-msgctxt "Swatches height"
-msgid "Large"
-msgstr "Groß"
-
-#: ../src/ui/widget/panel.cpp:142
-msgctxt "Swatches height"
-msgid "Huge"
-msgstr "Groß"
-
-#: ../src/ui/widget/panel.cpp:164
-msgctxt "Swatches"
-msgid "Width"
-msgstr "Breite"
-
-# (swatches)
-#: ../src/ui/widget/panel.cpp:168
-msgctxt "Swatches width"
-msgid "Narrower"
-msgstr "Schmaler"
-
-#: ../src/ui/widget/panel.cpp:169
-msgctxt "Swatches width"
-msgid "Narrow"
-msgstr "Schmal"
-
-#: ../src/ui/widget/panel.cpp:170
-msgctxt "Swatches width"
-msgid "Medium"
-msgstr "Mittel"
-
-#: ../src/ui/widget/panel.cpp:171
-msgctxt "Swatches width"
-msgid "Wide"
-msgstr "Breit"
-
-#: ../src/ui/widget/panel.cpp:172
-msgctxt "Swatches width"
-msgid "Wider"
-msgstr "Breiter"
-
-#: ../src/ui/widget/panel.cpp:202
-msgctxt "Swatches"
-msgid "Border"
-msgstr "Rand"
-
-# CHECK
-#: ../src/ui/widget/panel.cpp:206
-msgctxt "Swatches border"
-msgid "None"
-msgstr "Keine"
-
-#: ../src/ui/widget/panel.cpp:207
-msgctxt "Swatches border"
-msgid "Solid"
-msgstr "Fest"
-
-#: ../src/ui/widget/panel.cpp:208
-msgctxt "Swatches border"
-msgid "Wide"
-msgstr "Breit"
-
-#. TRANSLATORS: "Wrap" indicates how colour swatches are displayed
-#: ../src/ui/widget/panel.cpp:239
-msgctxt "Swatches"
-msgid "Wrap"
-msgstr "Umbrechen"
-
-#: ../src/ui/widget/preferences-widget.cpp:709
+#: ../src/ui/widget/preferences-widget.cpp:711
 msgid "_Browse..."
 msgstr "_Durchsuchen..."
 
-#: ../src/ui/widget/preferences-widget.cpp:795
+#: ../src/ui/widget/preferences-widget.cpp:797
 msgid "Select a bitmap editor"
 msgstr "Bitmap-Editor wählen:"
 
@@ -26545,305 +26865,304 @@ msgstr ""
 "größer und die Qualität hängt vom Zoomfaktor ab, die Zeichnung wird jedoch "
 "identisch zur angezeigten ausgegeben."
 
-#: ../src/ui/widget/selected-style.cpp:122
+#: ../src/ui/widget/selected-style.cpp:121
 #: ../src/ui/widget/style-swatch.cpp:115
 msgid "Fill:"
 msgstr "Füllung:"
 
-#: ../src/ui/widget/selected-style.cpp:124
+#: ../src/ui/widget/selected-style.cpp:123
 msgid "O:"
 msgstr "O:"
 
-#: ../src/ui/widget/selected-style.cpp:183
+#: ../src/ui/widget/selected-style.cpp:181
 msgid "N/A"
 msgstr "N/V"
 
-#: ../src/ui/widget/selected-style.cpp:186
-#: ../src/ui/widget/selected-style.cpp:1050
-#: ../src/ui/widget/selected-style.cpp:1051
-#: ../src/widgets/gradient-toolbar.cpp:163
+#: ../src/ui/widget/selected-style.cpp:184
+#: ../src/ui/widget/selected-style.cpp:1059
+#: ../src/ui/widget/selected-style.cpp:1060
 msgid "Nothing selected"
 msgstr "Nichts ausgewählt"
 
 # !!!
-#: ../src/ui/widget/selected-style.cpp:189
+#: ../src/ui/widget/selected-style.cpp:187
 msgctxt "Fill"
 msgid "<i>None</i>"
 msgstr "<i>Keine</i>"
 
 # !!!
-#: ../src/ui/widget/selected-style.cpp:191
+#: ../src/ui/widget/selected-style.cpp:189
 msgctxt "Stroke"
 msgid "<i>None</i>"
 msgstr "<i>Keine</i>"
 
-#: ../src/ui/widget/selected-style.cpp:195
+#: ../src/ui/widget/selected-style.cpp:193
 #: ../src/ui/widget/style-swatch.cpp:316
 msgctxt "Fill and stroke"
 msgid "No fill"
 msgstr "Keine Füllung"
 
-#: ../src/ui/widget/selected-style.cpp:195
+#: ../src/ui/widget/selected-style.cpp:193
 #: ../src/ui/widget/style-swatch.cpp:316
 msgctxt "Fill and stroke"
 msgid "No stroke"
 msgstr "Keine Kontur"
 
-#: ../src/ui/widget/selected-style.cpp:197
-#: ../src/ui/widget/style-swatch.cpp:295 ../src/widgets/paint-selector.cpp:219
+#: ../src/ui/widget/selected-style.cpp:195
+#: ../src/ui/widget/style-swatch.cpp:295 ../src/widgets/paint-selector.cpp:221
 msgid "Pattern"
 msgstr "Muster"
 
-#: ../src/ui/widget/selected-style.cpp:200
+#: ../src/ui/widget/selected-style.cpp:198
 #: ../src/ui/widget/style-swatch.cpp:297
 msgid "Pattern fill"
 msgstr "Füllmuster"
 
-#: ../src/ui/widget/selected-style.cpp:200
+#: ../src/ui/widget/selected-style.cpp:198
 #: ../src/ui/widget/style-swatch.cpp:297
 msgid "Pattern stroke"
 msgstr "Kontur mit Muster"
 
 # Short for 'Linear Gradient' in indicator field bottom left.
-#: ../src/ui/widget/selected-style.cpp:202
+#: ../src/ui/widget/selected-style.cpp:200
 msgid "<b>L</b>"
 msgstr "<b>L</b>"
 
-#: ../src/ui/widget/selected-style.cpp:205
+#: ../src/ui/widget/selected-style.cpp:203
 #: ../src/ui/widget/style-swatch.cpp:289
 msgid "Linear gradient fill"
 msgstr "Füllung mit linearem Farbverlauf"
 
-#: ../src/ui/widget/selected-style.cpp:205
+#: ../src/ui/widget/selected-style.cpp:203
 #: ../src/ui/widget/style-swatch.cpp:289
 msgid "Linear gradient stroke"
 msgstr "Kontur mit linearem Farbverlauf"
 
 # Short for 'Radial gradient' in indicator field bottom left.
-#: ../src/ui/widget/selected-style.cpp:212
+#: ../src/ui/widget/selected-style.cpp:210
 msgid "<b>R</b>"
 msgstr "<b>R</b>"
 
-#: ../src/ui/widget/selected-style.cpp:215
+#: ../src/ui/widget/selected-style.cpp:213
 #: ../src/ui/widget/style-swatch.cpp:293
 msgid "Radial gradient fill"
 msgstr "Füllung mit radialem Farbverlauf"
 
-#: ../src/ui/widget/selected-style.cpp:215
+#: ../src/ui/widget/selected-style.cpp:213
 #: ../src/ui/widget/style-swatch.cpp:293
 msgid "Radial gradient stroke"
 msgstr "Kontur mit radialem Farbverlauf"
 
 # Short for 'Mesh gradient' in indicator field bottom left
-#: ../src/ui/widget/selected-style.cpp:223
+#: ../src/ui/widget/selected-style.cpp:221
 msgid "<b>M</b>"
 msgstr "<b>G</b>"
 
 # Leider inkonsistent mit Mesh gradient stroke. Vielleicht gibt's noch was besseres?
-#: ../src/ui/widget/selected-style.cpp:226
+#: ../src/ui/widget/selected-style.cpp:224
 msgid "Mesh gradient fill"
 msgstr "Verlaufsgitterfüllung"
 
-#: ../src/ui/widget/selected-style.cpp:226
+#: ../src/ui/widget/selected-style.cpp:224
 msgid "Mesh gradient stroke"
 msgstr "Kontur mit Verlaufsgitter"
 
-#: ../src/ui/widget/selected-style.cpp:234
+#: ../src/ui/widget/selected-style.cpp:232
 msgid "Different"
 msgstr "Unterschiedlich"
 
-#: ../src/ui/widget/selected-style.cpp:237
+#: ../src/ui/widget/selected-style.cpp:235
 msgid "Different fills"
 msgstr "Unterschiedliche Füllungen"
 
-#: ../src/ui/widget/selected-style.cpp:237
+#: ../src/ui/widget/selected-style.cpp:235
 msgid "Different strokes"
 msgstr "Unterschiedliche Konturen"
 
 # !!!
-#: ../src/ui/widget/selected-style.cpp:239
+#: ../src/ui/widget/selected-style.cpp:237
 #: ../src/ui/widget/style-swatch.cpp:319
 msgid "<b>Unset</b>"
 msgstr "<b>Ungesetzt</b>"
 
 #. TRANSLATORS COMMENT: unset is a verb here
-#: ../src/ui/widget/selected-style.cpp:242
-#: ../src/ui/widget/selected-style.cpp:300
-#: ../src/ui/widget/selected-style.cpp:562
+#: ../src/ui/widget/selected-style.cpp:240
+#: ../src/ui/widget/selected-style.cpp:298
+#: ../src/ui/widget/selected-style.cpp:559
 #: ../src/ui/widget/style-swatch.cpp:321 ../src/widgets/fill-style.cpp:811
 msgid "Unset fill"
 msgstr "Füllung aufheben"
 
-#: ../src/ui/widget/selected-style.cpp:242
-#: ../src/ui/widget/selected-style.cpp:300
-#: ../src/ui/widget/selected-style.cpp:578
+#: ../src/ui/widget/selected-style.cpp:240
+#: ../src/ui/widget/selected-style.cpp:298
+#: ../src/ui/widget/selected-style.cpp:575
 #: ../src/ui/widget/style-swatch.cpp:321 ../src/widgets/fill-style.cpp:811
 msgid "Unset stroke"
 msgstr "Kontur aufheben"
 
-#: ../src/ui/widget/selected-style.cpp:245
+#: ../src/ui/widget/selected-style.cpp:243
 msgid "Flat color fill"
 msgstr "Einfache Farbe der Füllung"
 
-#: ../src/ui/widget/selected-style.cpp:245
+#: ../src/ui/widget/selected-style.cpp:243
 msgid "Flat color stroke"
 msgstr "Einfache Farbe der Kontur"
 
 # !!!
 #. TRANSLATOR COMMENT: A means "Averaged"
-#: ../src/ui/widget/selected-style.cpp:248
+#: ../src/ui/widget/selected-style.cpp:246
 msgid "<b>a</b>"
 msgstr "<b>a</b>"
 
-#: ../src/ui/widget/selected-style.cpp:251
+#: ../src/ui/widget/selected-style.cpp:249
 msgid "Fill is averaged over selected objects"
 msgstr "Füllfarbe wird über ausgewählte Objekte gemittelt"
 
-#: ../src/ui/widget/selected-style.cpp:251
+#: ../src/ui/widget/selected-style.cpp:249
 msgid "Stroke is averaged over selected objects"
 msgstr "Konturfarbe wird über ausgewählte Objekte gemittelt"
 
 # !!!
 #. TRANSLATOR COMMENT: M means "Multiple"
-#: ../src/ui/widget/selected-style.cpp:254
+#: ../src/ui/widget/selected-style.cpp:252
 msgid "<b>m</b>"
 msgstr "<b>m</b>"
 
-#: ../src/ui/widget/selected-style.cpp:257
+#: ../src/ui/widget/selected-style.cpp:255
 msgid "Multiple selected objects have the same fill"
 msgstr "Mehrere ausgewählte Objekte haben die selbe Füllung"
 
-#: ../src/ui/widget/selected-style.cpp:257
+#: ../src/ui/widget/selected-style.cpp:255
 msgid "Multiple selected objects have the same stroke"
 msgstr "Mehrere ausgewählte Objekte haben die selbe Kontur"
 
-#: ../src/ui/widget/selected-style.cpp:259
+#: ../src/ui/widget/selected-style.cpp:257
 msgid "Edit fill..."
 msgstr "Füllung bearbeiten..."
 
-#: ../src/ui/widget/selected-style.cpp:259
+#: ../src/ui/widget/selected-style.cpp:257
 msgid "Edit stroke..."
 msgstr "Kontur bearbeiten..."
 
-#: ../src/ui/widget/selected-style.cpp:263
+#: ../src/ui/widget/selected-style.cpp:261
 msgid "Last set color"
 msgstr "Zuletzt gesetzte Farbe"
 
-#: ../src/ui/widget/selected-style.cpp:267
+#: ../src/ui/widget/selected-style.cpp:265
 msgid "Last selected color"
 msgstr "Zuletzt gewählte Farbe"
 
-#: ../src/ui/widget/selected-style.cpp:283
+#: ../src/ui/widget/selected-style.cpp:281
 msgid "Copy color"
 msgstr "Farbe kopieren"
 
-#: ../src/ui/widget/selected-style.cpp:287
+#: ../src/ui/widget/selected-style.cpp:285
 msgid "Paste color"
 msgstr "Farbe einfügen"
 
-#: ../src/ui/widget/selected-style.cpp:291 ../src/verbs.cpp:2688
+#: ../src/ui/widget/selected-style.cpp:289 ../src/verbs.cpp:2718
 msgid "Swap fill and stroke"
 msgstr "Füllung und Linie vertauschen"
 
-#: ../src/ui/widget/selected-style.cpp:295
-#: ../src/ui/widget/selected-style.cpp:587
-#: ../src/ui/widget/selected-style.cpp:596
+#: ../src/ui/widget/selected-style.cpp:293
+#: ../src/ui/widget/selected-style.cpp:584
+#: ../src/ui/widget/selected-style.cpp:593
 msgid "Make fill opaque"
 msgstr "Füllung undurchsichtig machen"
 
-#: ../src/ui/widget/selected-style.cpp:295
+#: ../src/ui/widget/selected-style.cpp:293
 msgid "Make stroke opaque"
 msgstr "Kontur undurchsichtig machen"
 
-#: ../src/ui/widget/selected-style.cpp:304
-#: ../src/ui/widget/selected-style.cpp:544 ../src/widgets/fill-style.cpp:510
+#: ../src/ui/widget/selected-style.cpp:302
+#: ../src/ui/widget/selected-style.cpp:541 ../src/widgets/fill-style.cpp:510
 msgid "Remove fill"
 msgstr "Füllung entfernen"
 
-#: ../src/ui/widget/selected-style.cpp:304
-#: ../src/ui/widget/selected-style.cpp:553 ../src/widgets/fill-style.cpp:510
+#: ../src/ui/widget/selected-style.cpp:302
+#: ../src/ui/widget/selected-style.cpp:550 ../src/widgets/fill-style.cpp:510
 msgid "Remove stroke"
 msgstr "Kontur entfernen"
 
-#: ../src/ui/widget/selected-style.cpp:608
+#: ../src/ui/widget/selected-style.cpp:605
 msgid "Apply last set color to fill"
 msgstr "Zuletzt gesetzte Farbe auf Füllung anwenden"
 
-#: ../src/ui/widget/selected-style.cpp:620
+#: ../src/ui/widget/selected-style.cpp:617
 msgid "Apply last set color to stroke"
 msgstr "Zuletzt gesetzte Farbe auf Kontur anwenden"
 
-#: ../src/ui/widget/selected-style.cpp:631
+#: ../src/ui/widget/selected-style.cpp:628
 msgid "Apply last selected color to fill"
 msgstr "Zuletzt gewählte Farbe auf Füllung anwenden"
 
-#: ../src/ui/widget/selected-style.cpp:642
+#: ../src/ui/widget/selected-style.cpp:639
 msgid "Apply last selected color to stroke"
 msgstr "Zuletzt gewählte Farbe auf Kontur anwenden"
 
-#: ../src/ui/widget/selected-style.cpp:668
+#: ../src/ui/widget/selected-style.cpp:665
 msgid "Invert fill"
 msgstr "Füllung invertieren"
 
-#: ../src/ui/widget/selected-style.cpp:692
+#: ../src/ui/widget/selected-style.cpp:689
 msgid "Invert stroke"
 msgstr "Kontur invertieren"
 
-#: ../src/ui/widget/selected-style.cpp:704
+#: ../src/ui/widget/selected-style.cpp:701
 msgid "White fill"
 msgstr "Weiße Füllung"
 
-#: ../src/ui/widget/selected-style.cpp:716
+#: ../src/ui/widget/selected-style.cpp:713
 msgid "White stroke"
 msgstr "Weiße Kontur"
 
-#: ../src/ui/widget/selected-style.cpp:728
+#: ../src/ui/widget/selected-style.cpp:725
 msgid "Black fill"
 msgstr "Schwarze Füllung"
 
-#: ../src/ui/widget/selected-style.cpp:740
+#: ../src/ui/widget/selected-style.cpp:737
 msgid "Black stroke"
 msgstr "Schwarze Kontur"
 
-#: ../src/ui/widget/selected-style.cpp:783
+#: ../src/ui/widget/selected-style.cpp:780
 msgid "Paste fill"
 msgstr "Füllmuster einfügen"
 
-#: ../src/ui/widget/selected-style.cpp:801
+#: ../src/ui/widget/selected-style.cpp:798
 msgid "Paste stroke"
 msgstr "Kontur einfügen"
 
-#: ../src/ui/widget/selected-style.cpp:908
+#: ../src/ui/widget/selected-style.cpp:917
 msgid "Change stroke width"
 msgstr "Breite der Kontur ändern"
 
-#: ../src/ui/widget/selected-style.cpp:1011
+#: ../src/ui/widget/selected-style.cpp:1020
 msgid ", drag to adjust"
 msgstr ", Ziehen stellt ein"
 
-#: ../src/ui/widget/selected-style.cpp:1092
+#: ../src/ui/widget/selected-style.cpp:1101
 #, c-format
 msgid "Stroke width: %.5g%s%s"
 msgstr "Breite der Kontur: %.5g%s%s"
 
 # !!! not the best translation
-#: ../src/ui/widget/selected-style.cpp:1096
+#: ../src/ui/widget/selected-style.cpp:1105
 msgid " (averaged)"
 msgstr " (gemittelt)"
 
-#: ../src/ui/widget/selected-style.cpp:1122
+#: ../src/ui/widget/selected-style.cpp:1131
 msgid "0 (transparent)"
 msgstr "0 (durchsichtig)"
 
-#: ../src/ui/widget/selected-style.cpp:1146
+#: ../src/ui/widget/selected-style.cpp:1155
 msgid "100% (opaque)"
 msgstr "100% (undurchsichtig)"
 
-#: ../src/ui/widget/selected-style.cpp:1312
+#: ../src/ui/widget/selected-style.cpp:1321
 msgid "Adjust alpha"
 msgstr "Alpha anpassen"
 
-#: ../src/ui/widget/selected-style.cpp:1314
+#: ../src/ui/widget/selected-style.cpp:1323
 #, c-format
 msgid ""
 "Adjusting <b>alpha</b>: was %.3g, now <b>%.3g</b> (diff %.3g); with <b>Ctrl</"
@@ -26854,11 +27173,11 @@ msgstr ""
 "mit <b>Strg</b> wird Sättigung, mit <b>Umschalt</b> die Sättigung "
 "eingestellt, ohne Zusatztaste für Farbtom"
 
-#: ../src/ui/widget/selected-style.cpp:1318
+#: ../src/ui/widget/selected-style.cpp:1327
 msgid "Adjust saturation"
 msgstr "Sättigung anpassen"
 
-#: ../src/ui/widget/selected-style.cpp:1320
+#: ../src/ui/widget/selected-style.cpp:1329
 #, c-format
 msgid ""
 "Adjusting <b>saturation</b>: was %.3g, now <b>%.3g</b> (diff %.3g); with "
@@ -26869,11 +27188,11 @@ msgstr ""
 "mit <b>Strg</b> wird Helligkeit, mit <b>Alt</b> der Alphawert angepasst, "
 "ohne Zusatztaste für Farbton"
 
-#: ../src/ui/widget/selected-style.cpp:1324
+#: ../src/ui/widget/selected-style.cpp:1333
 msgid "Adjust lightness"
 msgstr "Helligkeit anpassen"
 
-#: ../src/ui/widget/selected-style.cpp:1326
+#: ../src/ui/widget/selected-style.cpp:1335
 #, c-format
 msgid ""
 "Adjusting <b>lightness</b>: was %.3g, now <b>%.3g</b> (diff %.3g); with "
@@ -26884,11 +27203,11 @@ msgstr ""
 "mit <b>Umschalt</b> wird Sättigung, mit <b>Alt</b> der Alphawert angepasst, "
 "ohne Zusatztaste für Farbwert."
 
-#: ../src/ui/widget/selected-style.cpp:1330
+#: ../src/ui/widget/selected-style.cpp:1339
 msgid "Adjust hue"
 msgstr "Farbton anpassen"
 
-#: ../src/ui/widget/selected-style.cpp:1332
+#: ../src/ui/widget/selected-style.cpp:1341
 #, c-format
 msgid ""
 "Adjusting <b>hue</b>: was %.3g, now <b>%.3g</b> (diff %.3g); with <b>Shift</"
@@ -26899,19 +27218,19 @@ msgstr ""
 "<b>Umschalt</b> wird Sättigung, mit <b>Alt</b> wird Alphawert und mit "
 "<b>Strg</b> Helligkeit angepasst"
 
-#: ../src/ui/widget/selected-style.cpp:1442
-#: ../src/ui/widget/selected-style.cpp:1456
+#: ../src/ui/widget/selected-style.cpp:1451
+#: ../src/ui/widget/selected-style.cpp:1465
 msgid "Adjust stroke width"
 msgstr "Breite der Konturlinie"
 
-#: ../src/ui/widget/selected-style.cpp:1443
+#: ../src/ui/widget/selected-style.cpp:1452
 #, c-format
 msgid "Adjusting <b>stroke width</b>: was %.3g, now <b>%.3g</b> (diff %.3g)"
 msgstr ""
 "<b>Strichbreite</b> eingestellt: vorher %.3g, jetzt <b>%.3g</b> (Diff. %.3g)"
 
 #. TRANSLATORS: "Link" means to _link_ two sliders together
-#: ../src/ui/widget/spin-scale.cpp:123 ../src/ui/widget/spin-slider.cpp:114
+#: ../src/ui/widget/spin-scale.cpp:121 ../src/ui/widget/spin-slider.cpp:115
 msgctxt "Sliders"
 msgid "Link"
 msgstr "Verknüpfung:"
@@ -27002,276 +27321,276 @@ msgstr[0] "<b>%d</b> Quader zugewiesen. "
 msgstr[1] ""
 "<b>%d</b> Quadern zugewiesen. <b>Umschalt+Ziehen</b> trennt die Quader."
 
-#: ../src/verbs.cpp:132
+#: ../src/verbs.cpp:135
 msgid "File"
 msgstr "_Datei"
 
-#: ../src/verbs.cpp:227 ../share/extensions/interp_att_g.inx.h:24
+#: ../src/verbs.cpp:230 ../share/extensions/interp_att_g.inx.h:27
 msgid "Tag"
 msgstr "Markierung"
 
-#: ../src/verbs.cpp:246
+#: ../src/verbs.cpp:249
 msgid "Context"
 msgstr "Kontext"
 
-#: ../src/verbs.cpp:265 ../src/verbs.cpp:2430
+#: ../src/verbs.cpp:268 ../src/verbs.cpp:2460
 #: ../share/extensions/jessyInk_view.inx.h:1
 #: ../share/extensions/polyhedron_3d.inx.h:26
 msgid "View"
 msgstr "Ansicht"
 
-#: ../src/verbs.cpp:285
+#: ../src/verbs.cpp:288
 msgid "Dialog"
 msgstr "Dialog"
 
-#: ../src/verbs.cpp:1323
+#: ../src/verbs.cpp:1345
 msgid "Switch to next layer"
 msgstr "Zur nächste Ebene wechseln"
 
-#: ../src/verbs.cpp:1324
+#: ../src/verbs.cpp:1346
 msgid "Switched to next layer."
 msgstr "Zur nächsten Ebene gewechselt."
 
-#: ../src/verbs.cpp:1326
+#: ../src/verbs.cpp:1348
 msgid "Cannot go past last layer."
 msgstr "Kann nicht hinter letzte Ebene wechseln."
 
-#: ../src/verbs.cpp:1335
+#: ../src/verbs.cpp:1357
 msgid "Switch to previous layer"
 msgstr "Zur vorherigen Ebene wechseln"
 
-#: ../src/verbs.cpp:1336
+#: ../src/verbs.cpp:1358
 msgid "Switched to previous layer."
 msgstr "Zur vorherigen Ebene gewechselt."
 
-#: ../src/verbs.cpp:1338
+#: ../src/verbs.cpp:1360
 msgid "Cannot go before first layer."
 msgstr "Kann nicht vor erste Ebene wechseln."
 
-#: ../src/verbs.cpp:1359 ../src/verbs.cpp:1426 ../src/verbs.cpp:1462
-#: ../src/verbs.cpp:1468 ../src/verbs.cpp:1492 ../src/verbs.cpp:1507
+#: ../src/verbs.cpp:1381 ../src/verbs.cpp:1448 ../src/verbs.cpp:1484
+#: ../src/verbs.cpp:1490 ../src/verbs.cpp:1514 ../src/verbs.cpp:1529
 msgid "No current layer."
 msgstr "Keine aktuelle Ebene."
 
-#: ../src/verbs.cpp:1388 ../src/verbs.cpp:1392
+#: ../src/verbs.cpp:1410 ../src/verbs.cpp:1414
 #, c-format
 msgid "Raised layer <b>%s</b>."
 msgstr "Ebene <b>%s</b> angehoben."
 
-#: ../src/verbs.cpp:1389
+#: ../src/verbs.cpp:1411
 msgid "Layer to top"
 msgstr "Ebene nach ganz oben"
 
-#: ../src/verbs.cpp:1393
+#: ../src/verbs.cpp:1415
 msgid "Raise layer"
 msgstr "Ebene anheben"
 
-#: ../src/verbs.cpp:1396 ../src/verbs.cpp:1400
+#: ../src/verbs.cpp:1418 ../src/verbs.cpp:1422
 #, c-format
 msgid "Lowered layer <b>%s</b>."
 msgstr "Ebene <b>%s</b> abgesenkt."
 
-#: ../src/verbs.cpp:1397
+#: ../src/verbs.cpp:1419
 msgid "Layer to bottom"
 msgstr "Ebene nach ganz unten"
 
-#: ../src/verbs.cpp:1401
+#: ../src/verbs.cpp:1423
 msgid "Lower layer"
 msgstr "Ebene absenken"
 
-#: ../src/verbs.cpp:1410
+#: ../src/verbs.cpp:1432
 msgid "Cannot move layer any further."
 msgstr "Kann Ebene nicht weiter verschieben."
 
-#: ../src/verbs.cpp:1421
+#: ../src/verbs.cpp:1443
 msgid "Duplicate layer"
 msgstr "Ebene duplizieren"
 
 #. TRANSLATORS: this means "The layer has been duplicated."
-#: ../src/verbs.cpp:1424
+#: ../src/verbs.cpp:1446
 msgid "Duplicated layer."
 msgstr "Duplizierte Ebene."
 
-#: ../src/verbs.cpp:1457
+#: ../src/verbs.cpp:1479
 msgid "Delete layer"
 msgstr "Ebene löschen"
 
 #. TRANSLATORS: this means "The layer has been deleted."
-#: ../src/verbs.cpp:1460
+#: ../src/verbs.cpp:1482
 msgid "Deleted layer."
 msgstr "Ebene wurde gelöscht."
 
-#: ../src/verbs.cpp:1477
+#: ../src/verbs.cpp:1499
 msgid "Show all layers"
 msgstr "Alle Ebenen zeigen"
 
-#: ../src/verbs.cpp:1482
+#: ../src/verbs.cpp:1504
 msgid "Hide all layers"
 msgstr "Alle Ebenen ausblenden"
 
-#: ../src/verbs.cpp:1487
+#: ../src/verbs.cpp:1509
 msgid "Lock all layers"
 msgstr "Alle Ebenen sperren"
 
-#: ../src/verbs.cpp:1501
+#: ../src/verbs.cpp:1523
 msgid "Unlock all layers"
 msgstr "Alle Ebenen entsperren"
 
-#: ../src/verbs.cpp:1585
+#: ../src/verbs.cpp:1607
 msgid "Flip horizontally"
 msgstr "Horizontal umkehren"
 
-#: ../src/verbs.cpp:1590
+#: ../src/verbs.cpp:1612
 msgid "Flip vertically"
 msgstr "Vertikal umkehren"
 
-#: ../src/verbs.cpp:1638
+#: ../src/verbs.cpp:1668
 #, c-format
 msgid "Set %d"
 msgstr "Gruppe %d"
 
-#: ../src/verbs.cpp:1647 ../src/verbs.cpp:2890
+#: ../src/verbs.cpp:1677 ../src/verbs.cpp:2924
 msgid "Create new selection set"
 msgstr "Neue Auswahlgruppe erzeugen"
 
 #. TRANSLATORS: If you have translated the tutorial-basic.en.svgz file to your language,
 #. then translate this string as "tutorial-basic.LANG.svgz" (where LANG is your language
 #. code); otherwise leave as "tutorial-basic.svg".
-#: ../src/verbs.cpp:2308
+#: ../src/verbs.cpp:2338
 msgid "tutorial-basic.svg"
 msgstr "tutorial-basic.de.svg"
 
 #. TRANSLATORS: See "tutorial-basic.svg" comment.
-#: ../src/verbs.cpp:2312
+#: ../src/verbs.cpp:2342
 msgid "tutorial-shapes.svg"
 msgstr "tutorial-shapes.de.svg"
 
 #. TRANSLATORS: See "tutorial-basic.svg" comment.
-#: ../src/verbs.cpp:2316
+#: ../src/verbs.cpp:2346
 msgid "tutorial-advanced.svg"
 msgstr "tutorial-advanced.de.svg"
 
 #. TRANSLATORS: See "tutorial-basic.svg" comment.
-#: ../src/verbs.cpp:2322
+#: ../src/verbs.cpp:2352
 msgid "tutorial-tracing.svg"
 msgstr "tutorial-tracing.de.svg"
 
-#: ../src/verbs.cpp:2327
+#: ../src/verbs.cpp:2357
 msgid "tutorial-tracing-pixelart.svg"
 msgstr "tutorial-tracing-pixelart.de.svg"
 
 #. TRANSLATORS: See "tutorial-basic.svg" comment.
-#: ../src/verbs.cpp:2331
+#: ../src/verbs.cpp:2361
 msgid "tutorial-calligraphy.svg"
 msgstr "tutorial-calligraphy.de.svg"
 
 #. TRANSLATORS: See "tutorial-basic.svg" comment.
-#: ../src/verbs.cpp:2335
+#: ../src/verbs.cpp:2365
 msgid "tutorial-interpolate.svg"
 msgstr "tutorial-interpolate.de.svg"
 
 #. TRANSLATORS: See "tutorial-basic.svg" comment.
-#: ../src/verbs.cpp:2339
+#: ../src/verbs.cpp:2369
 msgid "tutorial-elements.svg"
 msgstr "tutorial-elements.de.svg"
 
 #. TRANSLATORS: See "tutorial-basic.svg" comment.
-#: ../src/verbs.cpp:2343
+#: ../src/verbs.cpp:2373
 msgid "tutorial-tips.svg"
 msgstr "tutorial-tips.de.svg"
 
-#: ../src/verbs.cpp:2529 ../src/verbs.cpp:3194
+#: ../src/verbs.cpp:2559 ../src/verbs.cpp:3228
 msgid "Unlock all objects in the current layer"
 msgstr "Alle Objekte in der aktuellen Ebene entsperren"
 
-#: ../src/verbs.cpp:2533 ../src/verbs.cpp:3196
+#: ../src/verbs.cpp:2563 ../src/verbs.cpp:3230
 msgid "Unlock all objects in all layers"
 msgstr "Alle Objekte in allen Ebenen entsperren"
 
-#: ../src/verbs.cpp:2537 ../src/verbs.cpp:3198
+#: ../src/verbs.cpp:2567 ../src/verbs.cpp:3232
 msgid "Unhide all objects in the current layer"
 msgstr "Alle Objekte in der aktuellen Ebene einblenden"
 
-#: ../src/verbs.cpp:2541 ../src/verbs.cpp:3200
+#: ../src/verbs.cpp:2571 ../src/verbs.cpp:3234
 msgid "Unhide all objects in all layers"
 msgstr "Alle Objekte in allen Ebenen einblenden"
 
 # CHECK
-#: ../src/verbs.cpp:2556
+#: ../src/verbs.cpp:2586
 msgctxt "Verb"
 msgid "None"
 msgstr "Keine"
 
-#: ../src/verbs.cpp:2556
+#: ../src/verbs.cpp:2586
 msgid "Does nothing"
 msgstr "Hat keine Funktion"
 
-#: ../src/verbs.cpp:2559
+#: ../src/verbs.cpp:2589
 msgid "Create new document from the default template"
 msgstr "Ein neues Dokument mit der Standardvorlage anlegen"
 
-#: ../src/verbs.cpp:2561
+#: ../src/verbs.cpp:2591
 msgid "_Open..."
 msgstr "_Öffnen..."
 
-#: ../src/verbs.cpp:2562
+#: ../src/verbs.cpp:2592
 msgid "Open an existing document"
 msgstr "Ein bestehendes Dokument öffnen"
 
-#: ../src/verbs.cpp:2563
+#: ../src/verbs.cpp:2593
 msgid "Re_vert"
 msgstr "_Zurücksetzen"
 
-#: ../src/verbs.cpp:2564
+#: ../src/verbs.cpp:2594
 msgid "Revert to the last saved version of document (changes will be lost)"
 msgstr ""
 "Das Dokument auf die zuletzt gespeicherte Version zurücksetzen (Änderungen "
 "gehen verloren)"
 
-#: ../src/verbs.cpp:2565
+#: ../src/verbs.cpp:2595
 msgid "Save document"
 msgstr "Das Dokument speichern"
 
-#: ../src/verbs.cpp:2567
+#: ../src/verbs.cpp:2597
 msgid "Save _As..."
 msgstr "Speichern _unter..."
 
-#: ../src/verbs.cpp:2568
+#: ../src/verbs.cpp:2598
 msgid "Save document under a new name"
 msgstr "Dokument unter einem anderen Namen speichern"
 
-#: ../src/verbs.cpp:2569
+#: ../src/verbs.cpp:2599
 msgid "Save a Cop_y..."
 msgstr "_Kopie speichern..."
 
-#: ../src/verbs.cpp:2570
+#: ../src/verbs.cpp:2600
 msgid "Save a copy of the document under a new name"
 msgstr "Eine Kopie des Dokuments unter einem anderen Namen speichern"
 
-#: ../src/verbs.cpp:2571
+#: ../src/verbs.cpp:2601
 #, fuzzy
 msgid "Save template ..."
 msgstr "_Vorlagen..."
 
-#: ../src/verbs.cpp:2572
+#: ../src/verbs.cpp:2602
 #, fuzzy
 msgid "Save a copy of the document as template"
 msgstr "Eine Kopie des Dokuments unter einem anderen Namen speichern"
 
-#: ../src/verbs.cpp:2573
+#: ../src/verbs.cpp:2603
 msgid "_Print..."
 msgstr "_Drucken..."
 
-#: ../src/verbs.cpp:2573
+#: ../src/verbs.cpp:2603
 msgid "Print document"
 msgstr "Das Dokument drucken"
 
 #. TRANSLATORS: "Vacuum Defs" means "Clean up defs" (so as to remove unused definitions)
-#: ../src/verbs.cpp:2576
+#: ../src/verbs.cpp:2606
 msgid "Clean _up document"
 msgstr "Dok_ument säubern"
 
-#: ../src/verbs.cpp:2576
+#: ../src/verbs.cpp:2606
 msgid ""
 "Remove unused definitions (such as gradients or clipping paths) from the &lt;"
 "defs&gt; of the document"
@@ -27279,140 +27598,140 @@ msgstr ""
 "Unbenutzte Definitionen (z. B. Farbverläufe oder Ausschneidepfade) aus den "
 "&lt;defs&gt; des Dokuments entfernen"
 
-#: ../src/verbs.cpp:2578
+#: ../src/verbs.cpp:2608
 msgid "_Import..."
 msgstr "_Importieren..."
 
-#: ../src/verbs.cpp:2579
+#: ../src/verbs.cpp:2609
 msgid "Import a bitmap or SVG image into this document"
 msgstr "Ein Bitmap- oder SVG-Bild in dieses Dokument importieren"
 
 #. new FileVerb(SP_VERB_FILE_EXPORT, "FileExport", N_("_Export Bitmap..."), N_("Export this document or a selection as a bitmap image"), INKSCAPE_ICON("document-export")),
-#: ../src/verbs.cpp:2581
+#: ../src/verbs.cpp:2611
 msgid "Import Clip Art..."
 msgstr "Clip Art importieren..."
 
-#: ../src/verbs.cpp:2582
+#: ../src/verbs.cpp:2612
 msgid "Import clipart from Open Clip Art Library"
 msgstr "Import aus der Open Clip Art Library"
 
 #. new FileVerb(SP_VERB_FILE_EXPORT_TO_OCAL, "FileExportToOCAL", N_("Export To Open Clip Art Library"), N_("Export this document to Open Clip Art Library"), INKSCAPE_ICON_DOCUMENT_EXPORT_OCAL),
-#: ../src/verbs.cpp:2584
+#: ../src/verbs.cpp:2614
 msgid "N_ext Window"
 msgstr "Nä_chstes Fenster"
 
-#: ../src/verbs.cpp:2585
+#: ../src/verbs.cpp:2615
 msgid "Switch to the next document window"
 msgstr "Zum nächsten Dokumentenfenster umschalten"
 
-#: ../src/verbs.cpp:2586
+#: ../src/verbs.cpp:2616
 msgid "P_revious Window"
 msgstr "Vor_heriges Fenster"
 
-#: ../src/verbs.cpp:2587
+#: ../src/verbs.cpp:2617
 msgid "Switch to the previous document window"
 msgstr "Zum vorherigen Dokumentenfenster umschalten"
 
-#: ../src/verbs.cpp:2589
+#: ../src/verbs.cpp:2619
 msgid "Close this document window"
 msgstr "Dieses Dokumentenfenster schließen"
 
-#: ../src/verbs.cpp:2590
+#: ../src/verbs.cpp:2620
 msgid "_Quit"
 msgstr "_Beenden"
 
-#: ../src/verbs.cpp:2590
+#: ../src/verbs.cpp:2620
 msgid "Quit Inkscape"
 msgstr "Inkscape verlassen"
 
-#: ../src/verbs.cpp:2591
+#: ../src/verbs.cpp:2621
 msgid "New from _Template..."
 msgstr "Neu aus _Vorlage"
 
-#: ../src/verbs.cpp:2592
+#: ../src/verbs.cpp:2622
 msgid "Create new project from template"
 msgstr "Ein neues Dokument aus Vorlage anlegen"
 
-#: ../src/verbs.cpp:2595
+#: ../src/verbs.cpp:2625
 msgid "Undo last action"
 msgstr "Letzten Bearbeitungsschritt rückgängig machen"
 
 # !!! Abiword just says "Letzten Befehl wiederholen"
-#: ../src/verbs.cpp:2598
+#: ../src/verbs.cpp:2628
 msgid "Do again the last undone action"
 msgstr "Einen rückgängig gemachten Bearbeitungsschritt erneut durchführen"
 
-#: ../src/verbs.cpp:2599
+#: ../src/verbs.cpp:2629
 msgid "Cu_t"
 msgstr "A_usschneiden"
 
-#: ../src/verbs.cpp:2600
+#: ../src/verbs.cpp:2630
 msgid "Cut selection to clipboard"
 msgstr "Die gewählten Objekte in die Zwischenablage verschieben"
 
-#: ../src/verbs.cpp:2601
+#: ../src/verbs.cpp:2631
 msgid "_Copy"
 msgstr "_Kopieren"
 
-#: ../src/verbs.cpp:2602
+#: ../src/verbs.cpp:2632
 msgid "Copy selection to clipboard"
 msgstr "Die gewählten Objekte in die Zwischenablage kopieren"
 
-#: ../src/verbs.cpp:2603
+#: ../src/verbs.cpp:2633
 msgid "_Paste"
 msgstr "E_infügen"
 
-#: ../src/verbs.cpp:2604
+#: ../src/verbs.cpp:2634
 msgid "Paste objects from clipboard to mouse point, or paste text"
 msgstr ""
 "Objekte aus der Zwischenablage an der Mausposition einfügen, oder Text "
 "einfügen"
 
-#: ../src/verbs.cpp:2605
+#: ../src/verbs.cpp:2635
 msgid "Paste _Style"
 msgstr "Stil an_wenden"
 
-#: ../src/verbs.cpp:2606
+#: ../src/verbs.cpp:2636
 msgid "Apply the style of the copied object to selection"
 msgstr "Stil des kopierten Objekts auf Auswahl anwenden"
 
-#: ../src/verbs.cpp:2607 ../share/ui/menus.xml.h:3
+#: ../src/verbs.cpp:2637 ../share/ui/menus.xml.h:3
 msgid "Paste Si_ze"
 msgstr "_Größe einfügen"
 
-#: ../src/verbs.cpp:2608
+#: ../src/verbs.cpp:2638
 msgid "Scale selection to match the size of the copied object"
 msgstr "Auswahl auf Größe des kopierten Objekts skalieren"
 
-#: ../src/verbs.cpp:2609
+#: ../src/verbs.cpp:2639
 msgid "Paste _Width"
 msgstr "_Breite einfügen"
 
-#: ../src/verbs.cpp:2610
+#: ../src/verbs.cpp:2640
 msgid "Scale selection horizontally to match the width of the copied object"
 msgstr "Auswahl horizontal auf Breite des kopierten Objekts skalieren"
 
-#: ../src/verbs.cpp:2611
+#: ../src/verbs.cpp:2641
 msgid "Paste _Height"
 msgstr "_Höhe einfügen"
 
-#: ../src/verbs.cpp:2612
+#: ../src/verbs.cpp:2642
 msgid "Scale selection vertically to match the height of the copied object"
 msgstr "Auswahl vertikal auf Höhe des kopierten Objekts skalieren"
 
-#: ../src/verbs.cpp:2613
+#: ../src/verbs.cpp:2643
 msgid "Paste Size Separately"
 msgstr "Größe getrennt einfügen"
 
-#: ../src/verbs.cpp:2614
+#: ../src/verbs.cpp:2644
 msgid "Scale each selected object to match the size of the copied object"
 msgstr "Jedes ausgewählte Objekt auf Größe des kopierten Objekts skalieren"
 
-#: ../src/verbs.cpp:2615
+#: ../src/verbs.cpp:2645
 msgid "Paste Width Separately"
 msgstr "Breite getrennt einfügen"
 
-#: ../src/verbs.cpp:2616
+#: ../src/verbs.cpp:2646
 msgid ""
 "Scale each selected object horizontally to match the width of the copied "
 "object"
@@ -27420,11 +27739,11 @@ msgstr ""
 "Jedes ausgewählte Objekt horizontal auf Breite des kopierten Objekts "
 "skalieren"
 
-#: ../src/verbs.cpp:2617
+#: ../src/verbs.cpp:2647
 msgid "Paste Height Separately"
 msgstr "Höhe getrennt einfügen"
 
-#: ../src/verbs.cpp:2618
+#: ../src/verbs.cpp:2648
 msgid ""
 "Scale each selected object vertically to match the height of the copied "
 "object"
@@ -27432,65 +27751,65 @@ msgstr ""
 "Jedes ausgewählte Objekt vertikal auf Höhe des kopierten Objekts skalieren"
 
 # !!! translation is a bit clumsy...
-#: ../src/verbs.cpp:2619
+#: ../src/verbs.cpp:2649
 msgid "Paste _In Place"
 msgstr "An Ori_ginalposition einfügen"
 
-#: ../src/verbs.cpp:2620
+#: ../src/verbs.cpp:2650
 msgid "Paste objects from clipboard to the original location"
 msgstr "Objekte aus der Zwischenablage an ihrer Originalposition einfügen"
 
-#: ../src/verbs.cpp:2621
+#: ../src/verbs.cpp:2651
 msgid "Paste Path _Effect"
 msgstr "Pfad-_Effekt einfügen"
 
-#: ../src/verbs.cpp:2622
+#: ../src/verbs.cpp:2652
 msgid "Apply the path effect of the copied object to selection"
 msgstr "Pfadeffekt des kopierten Objekts auf Auswahl anwenden"
 
-#: ../src/verbs.cpp:2623
+#: ../src/verbs.cpp:2653
 msgid "Remove Path _Effect"
 msgstr "Pfadeffekt _entfernen"
 
-#: ../src/verbs.cpp:2624
+#: ../src/verbs.cpp:2654
 msgid "Remove any path effects from selected objects"
 msgstr "Effekt von Auswahl entfernen"
 
-#: ../src/verbs.cpp:2625
+#: ../src/verbs.cpp:2655
 msgid "_Remove Filters"
 msgstr "Filter entfernen"
 
-#: ../src/verbs.cpp:2626
+#: ../src/verbs.cpp:2656
 msgid "Remove any filters from selected objects"
 msgstr "Jeden Filter von Auswahl entfernen"
 
-#: ../src/verbs.cpp:2628
+#: ../src/verbs.cpp:2658
 msgid "Delete selection"
 msgstr "Auswahl löschen"
 
-#: ../src/verbs.cpp:2629
+#: ../src/verbs.cpp:2659
 msgid "Duplic_ate"
 msgstr "Dupli_zieren"
 
-#: ../src/verbs.cpp:2630
+#: ../src/verbs.cpp:2660
 msgid "Duplicate selected objects"
 msgstr "Gewählte Objekte duplizieren"
 
-#: ../src/verbs.cpp:2631
+#: ../src/verbs.cpp:2661
 msgid "Create Clo_ne"
 msgstr "_Klon erzeugen"
 
-#: ../src/verbs.cpp:2632
+#: ../src/verbs.cpp:2662
 msgid "Create a clone (a copy linked to the original) of selected object"
 msgstr ""
 "Einen Klon des gewählten Objekts erstellen (die Kopie ist mit dem Original "
 "verbunden)"
 
-#: ../src/verbs.cpp:2633
+#: ../src/verbs.cpp:2663
 msgid "Unlin_k Clone"
 msgstr "Klonverbindung auf_trennen"
 
-#: ../src/verbs.cpp:2634
+#: ../src/verbs.cpp:2664
 msgid ""
 "Cut the selected clones' links to the originals, turning them into "
 "standalone objects"
@@ -27498,36 +27817,36 @@ msgstr ""
 "Die Verbindung des Klons zu seinem Original auftrennen, so daß ein "
 "selbständiges Objekt entsteht"
 
-#: ../src/verbs.cpp:2635
+#: ../src/verbs.cpp:2665
 #, fuzzy
 msgid "Unlink Clones _recursively"
 msgstr "Klonverbindung auf_trennen"
 
-#: ../src/verbs.cpp:2636
+#: ../src/verbs.cpp:2666
 msgid "Unlink all clones in the selection, even if they are in groups."
 msgstr ""
 
-#: ../src/verbs.cpp:2637
+#: ../src/verbs.cpp:2667
 msgid "Relink to Copied"
 msgstr "Verbinden mit Kopie"
 
-#: ../src/verbs.cpp:2638
+#: ../src/verbs.cpp:2668
 msgid "Relink the selected clones to the object currently on the clipboard"
 msgstr "Verbindet die Ausgewählten Klone mit dem Objekt in der Zwischenablage"
 
-#: ../src/verbs.cpp:2639
+#: ../src/verbs.cpp:2669
 msgid "Select _Original"
 msgstr "_Original auswählen"
 
-#: ../src/verbs.cpp:2640
+#: ../src/verbs.cpp:2670
 msgid "Select the object to which the selected clone is linked"
 msgstr "Objekt auswählen, mit dem der Klon verbunden ist"
 
-#: ../src/verbs.cpp:2641
+#: ../src/verbs.cpp:2671
 msgid "Clone original path (LPE)"
 msgstr "Originalpfad klonen (LPE)"
 
-#: ../src/verbs.cpp:2642
+#: ../src/verbs.cpp:2672
 msgid ""
 "Creates a new path, applies the Clone original LPE, and refers it to the "
 "selected path"
@@ -27535,19 +27854,19 @@ msgstr ""
 "Erstellt einen neuen Pfad, verwendet die ursprünglichen Klone LPE und "
 "verweist auf den ausgewählten Pfad"
 
-#: ../src/verbs.cpp:2643
+#: ../src/verbs.cpp:2673
 msgid "Objects to _Marker"
 msgstr "Objekte zu Knoten_markierung"
 
-#: ../src/verbs.cpp:2644
+#: ../src/verbs.cpp:2674
 msgid "Convert selection to a line marker"
 msgstr "Auswahl in in eine Knotenmarkierung konvertieren"
 
-#: ../src/verbs.cpp:2645
+#: ../src/verbs.cpp:2675
 msgid "Objects to Gu_ides"
 msgstr "Objekte zu H_ilfslinien"
 
-#: ../src/verbs.cpp:2646
+#: ../src/verbs.cpp:2676
 msgid ""
 "Convert selected objects to a collection of guidelines aligned with their "
 "edges"
@@ -27555,95 +27874,95 @@ msgstr ""
 "Ausgewählte Objekte in eine Sammlung von Hilfslinien entlang ihrer Kanten "
 "umwandeln"
 
-#: ../src/verbs.cpp:2647
+#: ../src/verbs.cpp:2677
 msgid "Objects to Patter_n"
 msgstr "_Objekte in Füllmuster umwandeln"
 
-#: ../src/verbs.cpp:2648
+#: ../src/verbs.cpp:2678
 msgid "Convert selection to a rectangle with tiled pattern fill"
 msgstr "Die Auswahl in ein Rechteck mit gekacheltem Füllmuster umwandeln"
 
-#: ../src/verbs.cpp:2649
+#: ../src/verbs.cpp:2679
 msgid "Pattern to _Objects"
 msgstr "Füllmuster in Ob_jekte umwandeln"
 
-#: ../src/verbs.cpp:2650
+#: ../src/verbs.cpp:2680
 msgid "Extract objects from a tiled pattern fill"
 msgstr "Objekte aus einem gekacheltem Füllmuster extrahieren"
 
-#: ../src/verbs.cpp:2651
+#: ../src/verbs.cpp:2681
 msgid "Group to Symbol"
 msgstr "Gruppe zu Symbol"
 
-#: ../src/verbs.cpp:2652
+#: ../src/verbs.cpp:2682
 msgid "Convert group to a symbol"
 msgstr "Gruppe in Symbol konvertieren"
 
-#: ../src/verbs.cpp:2653
+#: ../src/verbs.cpp:2683
 msgid "Symbol to Group"
 msgstr "Symbol zu Gruppe"
 
-#: ../src/verbs.cpp:2654
+#: ../src/verbs.cpp:2684
 msgid "Extract group from a symbol"
 msgstr "Extrahiere Gruppe aus einem Symbol"
 
-#: ../src/verbs.cpp:2655
+#: ../src/verbs.cpp:2685
 msgid "Clea_r All"
 msgstr "Alles l_eeren"
 
-#: ../src/verbs.cpp:2656
+#: ../src/verbs.cpp:2686
 msgid "Delete all objects from document"
 msgstr "Alle Objekte aus dem Dokument löschen"
 
-#: ../src/verbs.cpp:2657
+#: ../src/verbs.cpp:2687
 msgid "Select Al_l"
 msgstr "_Alles auswählen"
 
-#: ../src/verbs.cpp:2658
+#: ../src/verbs.cpp:2688
 msgid "Select all objects or all nodes"
 msgstr "Alle Objekte oder alle Knoten im Dokument auswählen"
 
-#: ../src/verbs.cpp:2659
+#: ../src/verbs.cpp:2689
 msgid "Select All in All La_yers"
 msgstr "Alles in allen Ebenen auswählen"
 
-#: ../src/verbs.cpp:2660
+#: ../src/verbs.cpp:2690
 msgid "Select all objects in all visible and unlocked layers"
 msgstr "Alle Objekte in allen sichtbaren und entsperrten Ebenen auswählen"
 
-#: ../src/verbs.cpp:2661
+#: ../src/verbs.cpp:2691
 msgid "Fill _and Stroke"
 msgstr "Füllung und _Kontur"
 
-#: ../src/verbs.cpp:2662
+#: ../src/verbs.cpp:2692
 msgid ""
 "Select all objects with the same fill and stroke as the selected objects"
 msgstr ""
 "Alle Objekte mit der gleichen Füllung und Kontur der ausgewählten Objekte "
 "wählen"
 
-#: ../src/verbs.cpp:2663
+#: ../src/verbs.cpp:2693
 msgid "_Fill Color"
 msgstr "_Füllfarbe"
 
-#: ../src/verbs.cpp:2664
+#: ../src/verbs.cpp:2694
 msgid "Select all objects with the same fill as the selected objects"
 msgstr "Alle Objekte mit der gleichen Füllung der ausgewählten Objekte wählen"
 
-#: ../src/verbs.cpp:2665
+#: ../src/verbs.cpp:2695
 msgid "_Stroke Color"
 msgstr "Konturfarbe"
 
-#: ../src/verbs.cpp:2666
+#: ../src/verbs.cpp:2696
 msgid "Select all objects with the same stroke as the selected objects"
 msgstr ""
 "Wählen Sie alle Objekte mit der gleichen Kontur wie die ausgewählten Objekte"
 
-#: ../src/verbs.cpp:2667
+#: ../src/verbs.cpp:2697
 msgid "Stroke St_yle"
 msgstr "Konturstil"
 
-#: ../src/verbs.cpp:2668
+#: ../src/verbs.cpp:2698
 msgid ""
 "Select all objects with the same stroke style (width, dash, markers) as the "
 "selected objects"
@@ -27651,11 +27970,11 @@ msgstr ""
 "Wählen Sie alle Objekte mit dem gleichen Konturstil (Breite, Bindestrich, "
 "Marker) wie die ausgewählten Objekte"
 
-#: ../src/verbs.cpp:2669
+#: ../src/verbs.cpp:2699
 msgid "_Object Type"
 msgstr "_Objekttyp"
 
-#: ../src/verbs.cpp:2670
+#: ../src/verbs.cpp:2700
 msgid ""
 "Select all objects with the same object type (rect, arc, text, path, bitmap "
 "etc) as the selected objects"
@@ -27663,193 +27982,193 @@ msgstr ""
 "Wählen Sie alle Objekte mit dem gleichen Objekttyp (Rechteck, Bogen, Text, "
 "Pfad, Bitmap etc.) wie die ausgewählten Objekte"
 
-#: ../src/verbs.cpp:2671
+#: ../src/verbs.cpp:2701
 msgid "In_vert Selection"
 msgstr "Auswahl _umkehren"
 
-#: ../src/verbs.cpp:2672
+#: ../src/verbs.cpp:2702
 msgid "Invert selection (unselect what is selected and select everything else)"
 msgstr ""
 "Auswahl invertieren (alle ausgewählten Objekte deselektieren und alle "
 "anderen auswählen)"
 
-#: ../src/verbs.cpp:2673
+#: ../src/verbs.cpp:2703
 msgid "Invert in All Layers"
 msgstr "In allen Ebenen invertieren"
 
-#: ../src/verbs.cpp:2674
+#: ../src/verbs.cpp:2704
 msgid "Invert selection in all visible and unlocked layers"
 msgstr "Auswahl in allen sichtbaren und entsperrten Ebenen invertieren"
 
-#: ../src/verbs.cpp:2675
+#: ../src/verbs.cpp:2705
 msgid "Select Next"
 msgstr "Nächstes auswählen"
 
-#: ../src/verbs.cpp:2676
+#: ../src/verbs.cpp:2706
 msgid "Select next object or node"
 msgstr "Nächstes Objekt oder nächsten Knoten auswählen"
 
-#: ../src/verbs.cpp:2677
+#: ../src/verbs.cpp:2707
 msgid "Select Previous"
 msgstr "Vorheriges auswählen"
 
-#: ../src/verbs.cpp:2678
+#: ../src/verbs.cpp:2708
 msgid "Select previous object or node"
 msgstr "Vorheriges Objekt oder vorherigen Knoten auswählen"
 
-#: ../src/verbs.cpp:2679
+#: ../src/verbs.cpp:2709
 msgid "D_eselect"
 msgstr "Auswahl auf_heben"
 
-#: ../src/verbs.cpp:2680
+#: ../src/verbs.cpp:2710
 msgid "Deselect any selected objects or nodes"
 msgstr "Jede Auswahl von Objekten oder Knoten aufheben"
 
-#: ../src/verbs.cpp:2682
+#: ../src/verbs.cpp:2712
 msgid "Delete all the guides in the document"
 msgstr "Alle Hilfslinien aus dem Dokument löschen"
 
-#: ../src/verbs.cpp:2683
+#: ../src/verbs.cpp:2713
 msgid "Lock All Guides"
 msgstr "Alle Hilfslinien sperren"
 
-#: ../src/verbs.cpp:2683 ../src/widgets/desktop-widget.cpp:363
+#: ../src/verbs.cpp:2713 ../src/widgets/desktop-widget.cpp:377
 msgid "Toggle lock of all guides in the document"
 msgstr "Sperrt/Entsperrt alle Hilfslinien im Dokument"
 
-#: ../src/verbs.cpp:2684
+#: ../src/verbs.cpp:2714
 msgid "Create _Guides Around the Page"
 msgstr "Hilfslinien an Seitenrändern erstellen"
 
-#: ../src/verbs.cpp:2685
+#: ../src/verbs.cpp:2715
 msgid "Create four guides aligned with the page borders"
 msgstr "Erstellt vier Hilfslinien mit Ausrichtung an den Seitengrenzen"
 
-#: ../src/verbs.cpp:2686
+#: ../src/verbs.cpp:2716
 msgid "Next path effect parameter"
 msgstr "Nächster Pfadeffekt-Parameter"
 
-#: ../src/verbs.cpp:2687
+#: ../src/verbs.cpp:2717
 msgid "Show next editable path effect parameter"
 msgstr "Nächsten bearbeitbaren Pfadeffektparameter anzeigen"
 
 #. Selection
-#: ../src/verbs.cpp:2692
+#: ../src/verbs.cpp:2722
 msgid "Raise to _Top"
 msgstr "Nach ganz o_ben anheben"
 
-#: ../src/verbs.cpp:2693
+#: ../src/verbs.cpp:2723
 msgid "Raise selection to top"
 msgstr "Die gewählten Objekte nach ganz oben anheben"
 
-#: ../src/verbs.cpp:2694
+#: ../src/verbs.cpp:2724
 msgid "Lower to _Bottom"
 msgstr "Nach ganz u_nten absenken"
 
-#: ../src/verbs.cpp:2695
+#: ../src/verbs.cpp:2725
 msgid "Lower selection to bottom"
 msgstr "Die gewählten Objekte nach ganz unten absenken"
 
-#: ../src/verbs.cpp:2696
+#: ../src/verbs.cpp:2726
 msgid "_Raise"
 msgstr "_Anheben"
 
-#: ../src/verbs.cpp:2697
+#: ../src/verbs.cpp:2727
 msgid "Raise selection one step"
 msgstr "Die gewählten Objekte eine Stufe nach oben anheben"
 
-#: ../src/verbs.cpp:2698
+#: ../src/verbs.cpp:2728
 msgid "_Lower"
 msgstr "Ab_senken"
 
-#: ../src/verbs.cpp:2699
+#: ../src/verbs.cpp:2729
 msgid "Lower selection one step"
 msgstr "Die gewählten Objekte eine Stufe nach unten absenken"
 
-#: ../src/verbs.cpp:2702
+#: ../src/verbs.cpp:2732
 #, fuzzy
 msgid "_Stack up"
 msgstr "Abtastungen stapeln"
 
-#: ../src/verbs.cpp:2703
+#: ../src/verbs.cpp:2733
 #, fuzzy
 msgid "Stack selection one step up"
 msgstr "Die gewählten Objekte eine Stufe nach oben anheben"
 
-#: ../src/verbs.cpp:2704
+#: ../src/verbs.cpp:2734
 #, fuzzy
 msgid "_Stack down"
 msgstr "Übereinander"
 
-#: ../src/verbs.cpp:2705
+#: ../src/verbs.cpp:2735
 #, fuzzy
 msgid "Stack selection one step down"
 msgstr "Die gewählten Objekte eine Stufe nach oben anheben"
 
-#: ../src/verbs.cpp:2709
+#: ../src/verbs.cpp:2739
 msgid "Group selected objects"
 msgstr "Die gewählten Objekte gruppieren"
 
-#: ../src/verbs.cpp:2711
+#: ../src/verbs.cpp:2741
 msgid "Ungroup selected groups"
 msgstr "Gruppierung markierter Gruppen aufheben"
 
-#: ../src/verbs.cpp:2712
+#: ../src/verbs.cpp:2742
 msgid "_Pop selected objects out of group"
 msgstr "Gewählte Objekte aus Gruppe herauslösen"
 
-#: ../src/verbs.cpp:2713
+#: ../src/verbs.cpp:2743
 msgid "Pop selected objects out of group"
 msgstr "Gewählte Objekte aus Gruppe herauslösen"
 
-#: ../src/verbs.cpp:2715
+#: ../src/verbs.cpp:2745
 msgid "_Put on Path"
 msgstr "An _Pfad ausrichten"
 
-#: ../src/verbs.cpp:2717
+#: ../src/verbs.cpp:2747
 msgid "_Remove from Path"
 msgstr "Von Pfad _trennen"
 
-#: ../src/verbs.cpp:2719
+#: ../src/verbs.cpp:2749
 msgid "Remove Manual _Kerns"
 msgstr "Manuelle _Unterschneidungen entfernen"
 
 #. TRANSLATORS: "glyph": An image used in the visual representation of characters;
 #. roughly speaking, how a character looks. A font is a set of glyphs.
-#: ../src/verbs.cpp:2722
+#: ../src/verbs.cpp:2752
 msgid "Remove all manual kerns and glyph rotations from a text object"
 msgstr ""
 "Alle manuellen Unterschneidungen und Drehungen von einem Textobjekt entfernen"
 
-#: ../src/verbs.cpp:2724
+#: ../src/verbs.cpp:2754
 msgid "_Union"
 msgstr "_Vereinigung"
 
-#: ../src/verbs.cpp:2725
+#: ../src/verbs.cpp:2755
 msgid "Create union of selected paths"
 msgstr "Vereinigung der ausgewählten Pfade erzeugen"
 
-#: ../src/verbs.cpp:2726
+#: ../src/verbs.cpp:2756
 msgid "_Intersection"
 msgstr "Ü_berschneidung"
 
-#: ../src/verbs.cpp:2727
+#: ../src/verbs.cpp:2757
 msgid "Create intersection of selected paths"
 msgstr "Überschneidung der gewählten Pfade erzeugen"
 
-#: ../src/verbs.cpp:2728
+#: ../src/verbs.cpp:2758
 msgid "_Difference"
 msgstr "_Differenz"
 
-#: ../src/verbs.cpp:2729
+#: ../src/verbs.cpp:2759
 msgid "Create difference of selected paths (bottom minus top)"
 msgstr "Differenz der gewählten Pfade erzeugen (Unterer minus Oberer)"
 
-#: ../src/verbs.cpp:2730
+#: ../src/verbs.cpp:2760
 msgid "E_xclusion"
 msgstr "E_xklusiv-Oder (Ausschluss)"
 
-#: ../src/verbs.cpp:2731
+#: ../src/verbs.cpp:2761
 msgid ""
 "Create exclusive OR of selected paths (those parts that belong to only one "
 "path)"
@@ -27857,78 +28176,78 @@ msgstr ""
 "Exklusiv-ODER der ausgewählen Pfade erzeugen (die Teile, die nur zu einem "
 "Pfad gehören)"
 
-#: ../src/verbs.cpp:2732
+#: ../src/verbs.cpp:2762
 msgid "Di_vision"
 msgstr "Di_vision"
 
-#: ../src/verbs.cpp:2733
+#: ../src/verbs.cpp:2763
 msgid "Cut the bottom path into pieces"
 msgstr "Untenliegenden Pfad in Teile zerschneiden"
 
 #. TRANSLATORS: "to cut a path" is not the same as "to break a path apart" - see the
 #. Advanced tutorial for more info
-#: ../src/verbs.cpp:2736
+#: ../src/verbs.cpp:2766
 msgid "Cut _Path"
 msgstr "Pfad _zerschneiden"
 
-#: ../src/verbs.cpp:2737
+#: ../src/verbs.cpp:2767
 msgid "Cut the bottom path's stroke into pieces, removing fill"
 msgstr ""
 "Kontur des untenliegenden Pfads in Teile zerschneiden, Füllung wird entfernt"
 
-#: ../src/verbs.cpp:2738
+#: ../src/verbs.cpp:2768
 #, fuzzy
 msgid "_Grow"
 msgstr "_Gruppieren"
 
-#: ../src/verbs.cpp:2739
+#: ../src/verbs.cpp:2769
 #, fuzzy
 msgid "Make selected objects bigger"
 msgstr "Die gewählten Knoten in Ecken umwandeln"
 
-#: ../src/verbs.cpp:2740
+#: ../src/verbs.cpp:2770
 msgid "_Grow on screen"
 msgstr ""
 
-#: ../src/verbs.cpp:2741
+#: ../src/verbs.cpp:2771
 #, fuzzy
 msgid "Make selected objects bigger relative to screen"
 msgstr "Ausgewählte Objekte in einer Tabelle oder im Kreis anordnen"
 
-#: ../src/verbs.cpp:2742
+#: ../src/verbs.cpp:2772
 #, fuzzy
 msgid "_Double size"
 msgstr "Punktgröße:"
 
-#: ../src/verbs.cpp:2743
+#: ../src/verbs.cpp:2773
 #, fuzzy
 msgid "Double the size of selected objects"
 msgstr "Farben der gewählten Objekte verrauschen"
 
-#: ../src/verbs.cpp:2744
+#: ../src/verbs.cpp:2774
 msgid "_Shrink"
 msgstr ""
 
-#: ../src/verbs.cpp:2745
+#: ../src/verbs.cpp:2775
 #, fuzzy
 msgid "Make selected objects smaller"
 msgstr "Die gewählten Knoten symmetrisch machen"
 
-#: ../src/verbs.cpp:2746
+#: ../src/verbs.cpp:2776
 msgid "_Shrink on screen"
 msgstr ""
 
-#: ../src/verbs.cpp:2747
+#: ../src/verbs.cpp:2777
 #, fuzzy
 msgid "Make selected objects smaller relative to screen"
 msgstr "Ausgewählte Objekte in einer Tabelle oder im Kreis anordnen"
 
-#: ../src/verbs.cpp:2748
+#: ../src/verbs.cpp:2778
 #, fuzzy
 msgid "_Halve size"
 msgstr "Anfassergröße:"
 
-#: ../src/verbs.cpp:2749
+#: ../src/verbs.cpp:2779
 #, fuzzy
 msgid "Halve the size of selected objects"
 msgstr "Farben der gewählten Objekte verrauschen"
@@ -27936,370 +28255,370 @@ msgstr "Farben der gewählten Objekte verrauschen"
 #. TRANSLATORS: "outset": expand a shape by offsetting the object's path,
 #. i.e. by displacing it perpendicular to the path in each point.
 #. See also the Advanced Tutorial for explanation.
-#: ../src/verbs.cpp:2753
+#: ../src/verbs.cpp:2783
 msgid "Outs_et"
 msgstr "Er_weitern (vergrößern)"
 
-#: ../src/verbs.cpp:2754
+#: ../src/verbs.cpp:2784
 msgid "Outset selected paths"
 msgstr "Gewählte Pfade erweitern (vergrößern)"
 
-#: ../src/verbs.cpp:2756
+#: ../src/verbs.cpp:2786
 msgid "O_utset Path by 1 px"
 msgstr "Pfad um 1 px erweitern (vergrößern)"
 
-#: ../src/verbs.cpp:2757
+#: ../src/verbs.cpp:2787
 msgid "Outset selected paths by 1 px"
 msgstr "Gewählte Pfade um 1 px erweitern (vergrößern)"
 
-#: ../src/verbs.cpp:2759
+#: ../src/verbs.cpp:2789
 msgid "O_utset Path by 10 px"
 msgstr "Pfad um 10 px _erweitern (vergrößern)"
 
-#: ../src/verbs.cpp:2760
+#: ../src/verbs.cpp:2790
 msgid "Outset selected paths by 10 px"
 msgstr "Gewählte Pfade um 10 px erweitern (vergrößern)"
 
 #. TRANSLATORS: "inset": contract a shape by offsetting the object's path,
 #. i.e. by displacing it perpendicular to the path in each point.
 #. See also the Advanced Tutorial for explanation.
-#: ../src/verbs.cpp:2764
+#: ../src/verbs.cpp:2794
 msgid "I_nset"
 msgstr "Schrum_pfen"
 
 # !!! make singular and plural forms
-#: ../src/verbs.cpp:2765
+#: ../src/verbs.cpp:2795
 msgid "Inset selected paths"
 msgstr "Gewählte Pfade schrumpfen"
 
-#: ../src/verbs.cpp:2767
+#: ../src/verbs.cpp:2797
 msgid "I_nset Path by 1 px"
 msgstr "Pfad um _1 px schrumpfen"
 
-#: ../src/verbs.cpp:2768
+#: ../src/verbs.cpp:2798
 msgid "Inset selected paths by 1 px"
 msgstr "Gewählte Pfade um 1 px schrumpfen"
 
-#: ../src/verbs.cpp:2770
+#: ../src/verbs.cpp:2800
 msgid "I_nset Path by 10 px"
 msgstr "Pfad um 1_0 px schrumpfen"
 
-#: ../src/verbs.cpp:2771
+#: ../src/verbs.cpp:2801
 msgid "Inset selected paths by 10 px"
 msgstr "Gewählte Pfade um 10 px schrumpfen"
 
-#: ../src/verbs.cpp:2773
+#: ../src/verbs.cpp:2803
 msgid "D_ynamic Offset"
 msgstr "D_ynamischer Versatz"
 
-#: ../src/verbs.cpp:2773
+#: ../src/verbs.cpp:2803
 msgid "Create a dynamic offset object"
 msgstr "Ein Objekt mit dynamischem Versatz erstellen"
 
-#: ../src/verbs.cpp:2775
+#: ../src/verbs.cpp:2805
 msgid "_Linked Offset"
 msgstr "Ver_bundener Versatz"
 
-#: ../src/verbs.cpp:2776
+#: ../src/verbs.cpp:2806
 msgid "Create a dynamic offset object linked to the original path"
 msgstr ""
 "Dynamischen Versatz am Objekt erstellen. Verknüpfung zum originalen Pfad "
 "bleibt bestehen."
 
-#: ../src/verbs.cpp:2778
+#: ../src/verbs.cpp:2808
 msgid "_Stroke to Path"
 msgstr "_Kontur in Pfad umwandeln"
 
-#: ../src/verbs.cpp:2779
+#: ../src/verbs.cpp:2809
 msgid "Convert selected object's stroke to paths"
 msgstr "Die gewählten Konturen des Objekts in Pfade umwandeln"
 
-#: ../src/verbs.cpp:2780
+#: ../src/verbs.cpp:2810
 #, fuzzy
 msgid "_Stroke to Path Legacy"
 msgstr "_Kontur in Pfad umwandeln"
 
-#: ../src/verbs.cpp:2781
+#: ../src/verbs.cpp:2811
 #, fuzzy
 msgid "Convert selected object's stroke to paths legacy mode"
 msgstr "Die gewählten Konturen des Objekts in Pfade umwandeln"
 
-#: ../src/verbs.cpp:2782
+#: ../src/verbs.cpp:2812
 msgid "Si_mplify"
 msgstr "Ver_einfachen"
 
-#: ../src/verbs.cpp:2783
+#: ../src/verbs.cpp:2813
 msgid "Simplify selected paths (remove extra nodes)"
 msgstr "Ausgewählte Pfade vereinfachen (unnötige Punkte werden entfernt)"
 
-#: ../src/verbs.cpp:2784
+#: ../src/verbs.cpp:2814
 msgid "_Reverse"
 msgstr "_Richtung umkehren"
 
-#: ../src/verbs.cpp:2785
+#: ../src/verbs.cpp:2815
 msgid "Reverse the direction of selected paths (useful for flipping markers)"
 msgstr ""
 "Richtung der gewählten Pfade umkehren (nützlich, um Knotenmarkierungen "
 "umzukehren)"
 
-#: ../src/verbs.cpp:2790
+#: ../src/verbs.cpp:2820
 msgid "Create one or more paths from a bitmap by tracing it"
 msgstr ""
 "Erzeuge einen oder mehrere Pfade durch das Nachzeichnen einer Rastergrafik"
 
-#: ../src/verbs.cpp:2793
+#: ../src/verbs.cpp:2823
 msgid "Trace Pixel Art..."
 msgstr "Pixelkunst nachzeichnen..."
 
-#: ../src/verbs.cpp:2794
+#: ../src/verbs.cpp:2824
 msgid "Create paths using Kopf-Lischinski algorithm to vectorize pixel art"
 msgstr ""
 "Pfad durch Verwendung des Kopf-Lischinski-Algorithmus erstellen um Pixel-"
 "Effekt zu erzeugen."
 
-#: ../src/verbs.cpp:2795
+#: ../src/verbs.cpp:2825
 msgid "Make a _Bitmap Copy"
 msgstr "_Bitmap-Kopie erstellen"
 
-#: ../src/verbs.cpp:2796
+#: ../src/verbs.cpp:2826
 msgid "Export selection to a bitmap and insert it into document"
 msgstr "Auswahl als Bitmap exportieren und in das Dokument re-importieren"
 
 # !!! maybe use "verbinden"
-#: ../src/verbs.cpp:2797
+#: ../src/verbs.cpp:2827
 msgid "_Combine"
 msgstr "_Kombinieren"
 
-#: ../src/verbs.cpp:2798
+#: ../src/verbs.cpp:2828
 msgid "Combine several paths into one"
 msgstr "Mehrere Pfade zu einem kombinieren"
 
 #. TRANSLATORS: "to cut a path" is not the same as "to break a path apart" - see the
 #. Advanced tutorial for more info
-#: ../src/verbs.cpp:2801
+#: ../src/verbs.cpp:2831
 msgid "Break _Apart"
 msgstr "_Zerlegen"
 
-#: ../src/verbs.cpp:2802
+#: ../src/verbs.cpp:2832
 msgid "Break selected paths into subpaths"
 msgstr "Die markierten Pfade in Unterpfade zerlegen"
 
-#: ../src/verbs.cpp:2803
+#: ../src/verbs.cpp:2833
 msgid "_Arrange..."
 msgstr "_Anordnen..."
 
-#: ../src/verbs.cpp:2804
+#: ../src/verbs.cpp:2834
 msgid "Arrange selected objects in a table or circle"
 msgstr "Ausgewählte Objekte in einer Tabelle oder im Kreis anordnen"
 
 #. Layer
-#: ../src/verbs.cpp:2806
+#: ../src/verbs.cpp:2836
 msgid "_Add Layer..."
 msgstr "Ebene _hinzufügen..."
 
-#: ../src/verbs.cpp:2807
+#: ../src/verbs.cpp:2837
 msgid "Create a new layer"
 msgstr "Eine neue Ebene anlegen"
 
-#: ../src/verbs.cpp:2808
+#: ../src/verbs.cpp:2838
 msgid "Re_name Layer..."
 msgstr "Ebene umbe_nennen..."
 
-#: ../src/verbs.cpp:2809
+#: ../src/verbs.cpp:2839
 msgid "Rename the current layer"
 msgstr "Aktuelle Ebene umbenennen"
 
-#: ../src/verbs.cpp:2810
+#: ../src/verbs.cpp:2840
 msgid "Switch to Layer Abov_e"
 msgstr "Zur darü_berliegenden Ebene umschalten"
 
-#: ../src/verbs.cpp:2811
+#: ../src/verbs.cpp:2841
 msgid "Switch to the layer above the current"
 msgstr "Zur darüberliegenden Ebene im Dokument umschalten"
 
-#: ../src/verbs.cpp:2812
+#: ../src/verbs.cpp:2842
 msgid "Switch to Layer Belo_w"
 msgstr "Zur dar_unterliegenden Ebene umschalten"
 
-#: ../src/verbs.cpp:2813
+#: ../src/verbs.cpp:2843
 msgid "Switch to the layer below the current"
 msgstr "Zur darunterliegenden Ebene im Dokument umschalten"
 
-#: ../src/verbs.cpp:2814
+#: ../src/verbs.cpp:2844
 msgid "Move Selection to Layer Abo_ve"
 msgstr "Auswahl zur darüber_liegenden Ebene verschieben"
 
-#: ../src/verbs.cpp:2815
+#: ../src/verbs.cpp:2845
 msgid "Move selection to the layer above the current"
 msgstr "Die Auswahl auf die darüberliegende Ebene verschieben"
 
-#: ../src/verbs.cpp:2816
+#: ../src/verbs.cpp:2846
 msgid "Move Selection to Layer Bel_ow"
 msgstr "Auswahl zur darun_terliegenden Ebene verschieben"
 
-#: ../src/verbs.cpp:2817
+#: ../src/verbs.cpp:2847
 msgid "Move selection to the layer below the current"
 msgstr "Die Auswahl auf die darunterliegende Ebene verschieben"
 
-#: ../src/verbs.cpp:2818
+#: ../src/verbs.cpp:2848
 msgid "Move Selection to Layer..."
 msgstr "Auswahl zur anderer Ebene verschieben"
 
-#: ../src/verbs.cpp:2820
+#: ../src/verbs.cpp:2850
 msgid "Layer to _Top"
 msgstr "Ebene nach ganz _oben"
 
-#: ../src/verbs.cpp:2821
+#: ../src/verbs.cpp:2851
 msgid "Raise the current layer to the top"
 msgstr "Die aktuelle Ebene nach ganz oben anheben"
 
-#: ../src/verbs.cpp:2822
+#: ../src/verbs.cpp:2852
 msgid "Layer to _Bottom"
 msgstr "Ebene nach ganz _unten"
 
-#: ../src/verbs.cpp:2823
+#: ../src/verbs.cpp:2853
 msgid "Lower the current layer to the bottom"
 msgstr "Die aktuelle Ebene nach ganz unten absenken"
 
-#: ../src/verbs.cpp:2824
+#: ../src/verbs.cpp:2854
 msgid "_Raise Layer"
 msgstr "Ebene an_heben"
 
-#: ../src/verbs.cpp:2825
+#: ../src/verbs.cpp:2855
 msgid "Raise the current layer"
 msgstr "Die aktuelle Ebene anheben"
 
-#: ../src/verbs.cpp:2826
+#: ../src/verbs.cpp:2856
 msgid "_Lower Layer"
 msgstr "Ebene ab_senken"
 
-#: ../src/verbs.cpp:2827
+#: ../src/verbs.cpp:2857
 msgid "Lower the current layer"
 msgstr "Die aktuelle Ebene absenken"
 
-#: ../src/verbs.cpp:2828
+#: ../src/verbs.cpp:2858
 msgid "D_uplicate Current Layer"
 msgstr "Aktuelle Ebene duplizieren"
 
-#: ../src/verbs.cpp:2829
+#: ../src/verbs.cpp:2859
 msgid "Duplicate an existing layer"
 msgstr "Dupliziert eine vorhandene Ebene"
 
-#: ../src/verbs.cpp:2830
+#: ../src/verbs.cpp:2860
 msgid "_Delete Current Layer"
 msgstr "Aktuelle Ebene _löschen"
 
-#: ../src/verbs.cpp:2831
+#: ../src/verbs.cpp:2861
 msgid "Delete the current layer"
 msgstr "Die aktuelle Ebene löschen"
 
-#: ../src/verbs.cpp:2832
+#: ../src/verbs.cpp:2862
 msgid "_Show/hide other layers"
 msgstr "Andere Ebenen anzeigen oder ausblenden"
 
-#: ../src/verbs.cpp:2833
+#: ../src/verbs.cpp:2863
 msgid "Solo the current layer"
 msgstr "Aktuelle Ebene vereinzeln"
 
-#: ../src/verbs.cpp:2834
+#: ../src/verbs.cpp:2864
 msgid "_Show all layers"
 msgstr "Zeige alle Ebenen"
 
-#: ../src/verbs.cpp:2835
+#: ../src/verbs.cpp:2865
 msgid "Show all the layers"
 msgstr "Zeige all die Ebenen"
 
-#: ../src/verbs.cpp:2836
+#: ../src/verbs.cpp:2866
 msgid "_Hide all layers"
 msgstr "Alle Ebenen ausblenden"
 
-#: ../src/verbs.cpp:2837
+#: ../src/verbs.cpp:2867
 msgid "Hide all the layers"
 msgstr "All die Ebenen ausblenden"
 
-#: ../src/verbs.cpp:2838
+#: ../src/verbs.cpp:2868
 msgid "_Lock all layers"
 msgstr "A_lle Ebenen sperren"
 
-#: ../src/verbs.cpp:2839
+#: ../src/verbs.cpp:2869
 msgid "Lock all the layers"
 msgstr "Alle der Ebenen sperren"
 
-#: ../src/verbs.cpp:2840
+#: ../src/verbs.cpp:2870
 msgid "Lock/Unlock _other layers"
 msgstr "An_dere Ebenen sperren/entsperren"
 
-#: ../src/verbs.cpp:2841
+#: ../src/verbs.cpp:2871
 msgid "Lock all the other layers"
 msgstr "Alle der anderen Ebenen sperren"
 
-#: ../src/verbs.cpp:2842
+#: ../src/verbs.cpp:2872
 msgid "_Unlock all layers"
 msgstr "Alle Ebenen entsperren"
 
-#: ../src/verbs.cpp:2843
+#: ../src/verbs.cpp:2873
 msgid "Unlock all the layers"
 msgstr "Alle Ebenen entsperren"
 
-#: ../src/verbs.cpp:2844
+#: ../src/verbs.cpp:2874
 msgid "_Lock/Unlock Current Layer"
 msgstr "Aktuelle Ebene sperren/entsperren"
 
-#: ../src/verbs.cpp:2845
+#: ../src/verbs.cpp:2875
 msgid "Toggle lock on current layer"
 msgstr "Aktuelle Ebene sperren oder entsperren"
 
-#: ../src/verbs.cpp:2846
+#: ../src/verbs.cpp:2876
 msgid "_Show/hide Current Layer"
 msgstr "Aktuelle Ebene anzeigen oder au_sblenden"
 
-#: ../src/verbs.cpp:2847
+#: ../src/verbs.cpp:2877
 msgid "Toggle visibility of current layer"
 msgstr "Aktuelle Ebene sichtbar/unsichtbar"
 
 #. Object
-#: ../src/verbs.cpp:2850
+#: ../src/verbs.cpp:2880
 msgid "Rotate _90° CW"
 msgstr "Um _90° im Uhrzeigersinn drehen"
 
 #. This is shared between tooltips and statusbar, so they
 #. must use UTF-8, not HTML entities for special characters.
-#: ../src/verbs.cpp:2853
+#: ../src/verbs.cpp:2883
 msgid "Rotate selection 90° clockwise"
 msgstr "Auswahl um 90° im Uhrzeigersinn drehen"
 
-#: ../src/verbs.cpp:2854
+#: ../src/verbs.cpp:2884
 msgid "Rotate 9_0° CCW"
 msgstr "Um 9_0° gegen den Uhrzeigersinn drehen"
 
 #. This is shared between tooltips and statusbar, so they
 #. must use UTF-8, not HTML entities for special characters.
-#: ../src/verbs.cpp:2857
+#: ../src/verbs.cpp:2887
 msgid "Rotate selection 90° counter-clockwise"
 msgstr "Auswahl um 90° gegen den Uhrzeigersinn drehen"
 
-#: ../src/verbs.cpp:2858
+#: ../src/verbs.cpp:2888
 msgid "Remove _Transformations"
 msgstr "Transformationen _zurücksetzen"
 
-#: ../src/verbs.cpp:2859
+#: ../src/verbs.cpp:2889
 msgid "Remove transformations from object"
 msgstr "Transformationen des Objekts rückgängig machen"
 
-#: ../src/verbs.cpp:2860
+#: ../src/verbs.cpp:2890
 msgid "_Object to Path"
 msgstr "_Objekt in Pfad umwandeln"
 
-#: ../src/verbs.cpp:2861
+#: ../src/verbs.cpp:2891
 msgid "Convert selected object to path"
 msgstr "Gewähltes Objekt in Pfad umwandeln"
 
 # !!! Frame, not form?
-#: ../src/verbs.cpp:2862
+#: ../src/verbs.cpp:2892
 msgid "_Flow into Frame"
 msgstr "Umbruch an Form _anpassen"
 
-#: ../src/verbs.cpp:2863
+#: ../src/verbs.cpp:2893
 msgid ""
 "Put text into a frame (path or shape), creating a flowed text linked to the "
 "frame object"
@@ -28307,817 +28626,835 @@ msgstr ""
 "Text in einen Rahmen setzen (Pfad oder Form), so dass ein mit seinem Rahmen "
 "verbundener Fließtext erzeugt wird"
 
-#: ../src/verbs.cpp:2864
+#: ../src/verbs.cpp:2894
 msgid "_Unflow"
 msgstr "Fließtext _aufheben"
 
-#: ../src/verbs.cpp:2865
+#: ../src/verbs.cpp:2895
 msgid "Remove text from frame (creates a single-line text object)"
 msgstr "Text von der Form trennen (erzeugt einzeiliges Textobjekt)"
 
-#: ../src/verbs.cpp:2866
+#: ../src/verbs.cpp:2896
 msgid "_Convert to Text"
 msgstr "In normalen Text um_wandeln"
 
-#: ../src/verbs.cpp:2867
+#: ../src/verbs.cpp:2897
 msgid "Convert flowed text to regular text object (preserves appearance)"
 msgstr "Fließtext in gewöhnliches Textobjekt umwandeln (behält Aussehen bei)"
 
-#: ../src/verbs.cpp:2869
+#: ../src/verbs.cpp:2899
 msgid "Flip _Horizontal"
 msgstr "_Horizontal umkehren"
 
-#: ../src/verbs.cpp:2869
+#: ../src/verbs.cpp:2899
 msgid "Flip selected objects horizontally"
 msgstr "Ausgewählte Objekte horizontal umkehren"
 
-#: ../src/verbs.cpp:2872
+#: ../src/verbs.cpp:2902
 msgid "Flip _Vertical"
 msgstr "_Vertikal umkehren"
 
-#: ../src/verbs.cpp:2872
+#: ../src/verbs.cpp:2902
 msgid "Flip selected objects vertically"
 msgstr "Ausgewählte Objekte vertikal umkehren"
 
-#: ../src/verbs.cpp:2875
+#: ../src/verbs.cpp:2905
 msgid "Apply mask to selection (using the topmost object as mask)"
 msgstr "Maske auf Auswahl anwenden (oberstes Objekt als Maske verwenden)"
 
-#: ../src/verbs.cpp:2876 ../src/verbs.cpp:2884 ../share/ui/menus.xml.h:2
+#: ../src/verbs.cpp:2906 ../src/verbs.cpp:2914
+msgid "_Set Inverse (LPE)"
+msgstr ""
+
+#: ../src/verbs.cpp:2907
+#, fuzzy
+msgid "Apply inverse mask to selection (using the topmost object as mask)"
+msgstr "Maske auf Auswahl anwenden (oberstes Objekt als Maske verwenden)"
+
+#: ../src/verbs.cpp:2908 ../src/verbs.cpp:2918 ../share/ui/menus.xml.h:2
 msgid "_Edit"
 msgstr "_Bearbeiten"
 
-#: ../src/verbs.cpp:2877
+#: ../src/verbs.cpp:2909
 msgid "Edit mask"
 msgstr "Maske bearbeiten"
 
-#: ../src/verbs.cpp:2878 ../src/verbs.cpp:2886
+#: ../src/verbs.cpp:2910 ../src/verbs.cpp:2920
 msgid "_Release"
 msgstr "F_reigeben"
 
-#: ../src/verbs.cpp:2879
+#: ../src/verbs.cpp:2911
 msgid "Remove mask from selection"
 msgstr "Maske von Auswahl entfernen"
 
-#: ../src/verbs.cpp:2881
+#: ../src/verbs.cpp:2913
 msgid ""
 "Apply clipping path to selection (using the topmost object as clipping path)"
 msgstr ""
 "Ausschneidepfad auf Auswahl anwenden (oberstes Objekt als Ausschneidepfad "
 "verwenden)"
 
-#: ../src/verbs.cpp:2882
+#: ../src/verbs.cpp:2915
+#, fuzzy
+msgid ""
+"Apply inverse clipping path to selection (using the topmost object as "
+"clipping path)"
+msgstr ""
+"Ausschneidepfad auf Auswahl anwenden (oberstes Objekt als Ausschneidepfad "
+"verwenden)"
+
+#: ../src/verbs.cpp:2916
 msgid "Create Cl_ip Group"
 msgstr "Ausschne_idemaske erzeugen"
 
-#: ../src/verbs.cpp:2883
+#: ../src/verbs.cpp:2917
 msgid "Creates a clip group using the selected objects as a base"
 msgstr "Eine Ausschneidemaske auf Basis der gewählten Objekte erstellen"
 
-#: ../src/verbs.cpp:2885
+#: ../src/verbs.cpp:2919
 msgid "Edit clipping path"
 msgstr "Ausschneidepfad bearbeiten"
 
-#: ../src/verbs.cpp:2887
+#: ../src/verbs.cpp:2921
 msgid "Remove clipping path from selection"
 msgstr "Ausschneidepfad von Auswahl entfernen"
 
 #. Tools
-#: ../src/verbs.cpp:2892
+#: ../src/verbs.cpp:2926
 msgctxt "ContextVerb"
 msgid "Select"
 msgstr "Auswählen"
 
-#: ../src/verbs.cpp:2893
+#: ../src/verbs.cpp:2927
 msgid "Select and transform objects"
 msgstr "Objekte auswählen und verändern"
 
-#: ../src/verbs.cpp:2894
+#: ../src/verbs.cpp:2928
 msgctxt "ContextVerb"
 msgid "Node Edit"
 msgstr "Knoten bearbeiten"
 
-#: ../src/verbs.cpp:2895
+#: ../src/verbs.cpp:2929
 msgid "Edit paths by nodes"
 msgstr "Bearbeiten der Knoten oder der Anfasser eines Pfades"
 
-#: ../src/verbs.cpp:2896
+#: ../src/verbs.cpp:2930
 msgctxt "ContextVerb"
 msgid "Tweak"
 msgstr "Modellieren"
 
-#: ../src/verbs.cpp:2897
+#: ../src/verbs.cpp:2931
 msgid "Tweak objects by sculpting or painting"
 msgstr "Objekte optimieren durch Verformen oder Einfärben"
 
-#: ../src/verbs.cpp:2898
+#: ../src/verbs.cpp:2932
 msgctxt "ContextVerb"
 msgid "Spray"
 msgstr "Spray"
 
-#: ../src/verbs.cpp:2899
+#: ../src/verbs.cpp:2933
 msgid "Spray objects by sculpting or painting"
 msgstr "Objekte sprühen durch Verformen oder Einfärben"
 
-#: ../src/verbs.cpp:2900
+#: ../src/verbs.cpp:2934
 msgctxt "ContextVerb"
 msgid "Rectangle"
 msgstr "Rechteck"
 
-#: ../src/verbs.cpp:2901
+#: ../src/verbs.cpp:2935
 msgid "Create rectangles and squares"
 msgstr "Rechtecke und Quadrate erstellen"
 
-#: ../src/verbs.cpp:2902
+#: ../src/verbs.cpp:2936
 msgctxt "ContextVerb"
 msgid "3D Box"
 msgstr "3D-Box"
 
-#: ../src/verbs.cpp:2903
+#: ../src/verbs.cpp:2937
 msgid "Create 3D boxes"
 msgstr "3D-Boxen erzeugen"
 
-#: ../src/verbs.cpp:2904
+#: ../src/verbs.cpp:2938
 msgctxt "ContextVerb"
 msgid "Ellipse"
 msgstr "Ellipse"
 
-#: ../src/verbs.cpp:2905
+#: ../src/verbs.cpp:2939
 msgid "Create circles, ellipses, and arcs"
 msgstr "Kreise, Ellipsen und Bögen erstellen"
 
-#: ../src/verbs.cpp:2906
+#: ../src/verbs.cpp:2940
 msgctxt "ContextVerb"
 msgid "Star"
 msgstr "Stern"
 
-#: ../src/verbs.cpp:2907
+#: ../src/verbs.cpp:2941
 msgid "Create stars and polygons"
 msgstr "Sterne und Polygone erstellen"
 
-#: ../src/verbs.cpp:2908
+#: ../src/verbs.cpp:2942
 msgctxt "ContextVerb"
 msgid "Spiral"
 msgstr "Spirale"
 
-#: ../src/verbs.cpp:2909
+#: ../src/verbs.cpp:2943
 msgid "Create spirals"
 msgstr "Spiralen erstellen"
 
-#: ../src/verbs.cpp:2910
+#: ../src/verbs.cpp:2944
 msgctxt "ContextVerb"
 msgid "Pencil"
 msgstr "Malwerkzeug (Freihand)"
 
-#: ../src/verbs.cpp:2911
+#: ../src/verbs.cpp:2945
 msgid "Draw freehand lines"
 msgstr "Freihandlinien zeichnen"
 
-#: ../src/verbs.cpp:2912
+#: ../src/verbs.cpp:2946
 msgctxt "ContextVerb"
 msgid "Pen"
 msgstr "Füller (Linien und Bézierkurven)"
 
-#: ../src/verbs.cpp:2913
+#: ../src/verbs.cpp:2947
 msgid "Draw Bezier curves and straight lines"
 msgstr "Bézier-Kurven und gerade Linien zeichnen"
 
-#: ../src/verbs.cpp:2914
+#: ../src/verbs.cpp:2948
 msgctxt "ContextVerb"
 msgid "Calligraphy"
 msgstr "Kalligrafie"
 
-#: ../src/verbs.cpp:2915
+#: ../src/verbs.cpp:2949
 msgid "Draw calligraphic or brush strokes"
 msgstr "Kalligrafisch zeichnen"
 
-#: ../src/verbs.cpp:2917
+#: ../src/verbs.cpp:2951
 msgid "Create and edit text objects"
 msgstr "Textobjekte erstellen und bearbeiten"
 
-#: ../src/verbs.cpp:2918
+#: ../src/verbs.cpp:2952
 msgctxt "ContextVerb"
 msgid "Gradient"
 msgstr "Farbverlauf"
 
-#: ../src/verbs.cpp:2919
+#: ../src/verbs.cpp:2953
 msgid "Create and edit gradients"
 msgstr "Farbverläufe erstellen und bearbeiten"
 
-#: ../src/verbs.cpp:2920
+#: ../src/verbs.cpp:2954
 msgctxt "ContextVerb"
 msgid "Mesh"
 msgstr "Verlaufsgitter"
 
-#: ../src/verbs.cpp:2921
+#: ../src/verbs.cpp:2955
 msgid "Create and edit meshes"
 msgstr "Verlaufsgitter erstellen und bearbeiten"
 
-#: ../src/verbs.cpp:2922
+#: ../src/verbs.cpp:2956
 msgctxt "ContextVerb"
 msgid "Zoom"
 msgstr "Zoomfaktor"
 
-#: ../src/verbs.cpp:2923
+#: ../src/verbs.cpp:2957
 msgid "Zoom in or out"
 msgstr "Zoomfaktor vergrößern oder verringern"
 
-#: ../src/verbs.cpp:2925
+#: ../src/verbs.cpp:2959
 msgid "Measurement tool"
 msgstr "Messwerkzeug"
 
-#: ../src/verbs.cpp:2926
+#: ../src/verbs.cpp:2960
 msgctxt "ContextVerb"
 msgid "Dropper"
 msgstr "Farbpipette"
 
-#: ../src/verbs.cpp:2928
+#: ../src/verbs.cpp:2962
 msgctxt "ContextVerb"
 msgid "Connector"
 msgstr "Objektverbinder"
 
-#: ../src/verbs.cpp:2929
+#: ../src/verbs.cpp:2963
 msgid "Create diagram connectors"
 msgstr "Objektverbinder erzeugen"
 
-#: ../src/verbs.cpp:2932
+#: ../src/verbs.cpp:2966
 msgctxt "ContextVerb"
 msgid "Paint Bucket"
 msgstr "Farbeimer"
 
-#: ../src/verbs.cpp:2933
+#: ../src/verbs.cpp:2967
 msgid "Fill bounded areas"
 msgstr "Abgegrenzte Flächen füllen"
 
-#: ../src/verbs.cpp:2936
+#: ../src/verbs.cpp:2970
 msgctxt "ContextVerb"
 msgid "LPE Edit"
 msgstr "LPE bearbeiten"
 
-#: ../src/verbs.cpp:2937
+#: ../src/verbs.cpp:2971
 msgid "Edit Path Effect parameters"
 msgstr "Pfadeffekt-Parameter bearbeiten"
 
-#: ../src/verbs.cpp:2938
+#: ../src/verbs.cpp:2972
 msgctxt "ContextVerb"
 msgid "Eraser"
 msgstr "Radierer"
 
-#: ../src/verbs.cpp:2939
+#: ../src/verbs.cpp:2973
 msgid "Erase existing paths"
 msgstr "Vorhandene Pfade löschen"
 
-#: ../src/verbs.cpp:2940
+#: ../src/verbs.cpp:2974
 msgctxt "ContextVerb"
 msgid "LPE Tool"
 msgstr "LPE-Werkzeug"
 
-#: ../src/verbs.cpp:2941
+#: ../src/verbs.cpp:2975
 msgid "Do geometric constructions"
 msgstr "Geometrische Konstruktion durchführen"
 
 #. Tool prefs
-#: ../src/verbs.cpp:2943
+#: ../src/verbs.cpp:2977
 msgid "Selector Preferences"
 msgstr "Einstellungen für Auswahlwerkzeug"
 
-#: ../src/verbs.cpp:2944
+#: ../src/verbs.cpp:2978
 msgid "Open Preferences for the Selector tool"
 msgstr "Einstellungen für das Auswahlwerkzeug öffnen"
 
-#: ../src/verbs.cpp:2945
+#: ../src/verbs.cpp:2979
 msgid "Node Tool Preferences"
 msgstr "Einstellungen für Knotenwerkzeug"
 
-#: ../src/verbs.cpp:2946
+#: ../src/verbs.cpp:2980
 msgid "Open Preferences for the Node tool"
 msgstr "Einstellungen für das Knotenwerkzeug öffnen"
 
-#: ../src/verbs.cpp:2947
+#: ../src/verbs.cpp:2981
 msgid "Tweak Tool Preferences"
 msgstr "Einstellungen für Anpasswerkzeug"
 
-#: ../src/verbs.cpp:2948
+#: ../src/verbs.cpp:2982
 msgid "Open Preferences for the Tweak tool"
 msgstr "Eigenschaften für das Modifizier-Werkzeug öffnen"
 
-#: ../src/verbs.cpp:2949
+#: ../src/verbs.cpp:2983
 msgid "Spray Tool Preferences"
 msgstr "Einstellungen für Spraydose"
 
-#: ../src/verbs.cpp:2950
+#: ../src/verbs.cpp:2984
 msgid "Open Preferences for the Spray tool"
 msgstr "Eigenschaften für das Spray-Werkzeug öffnen"
 
-#: ../src/verbs.cpp:2951
+#: ../src/verbs.cpp:2985
 msgid "Rectangle Preferences"
 msgstr "Eigenschaften für Rechteckwerkzeug"
 
-#: ../src/verbs.cpp:2952
+#: ../src/verbs.cpp:2986
 msgid "Open Preferences for the Rectangle tool"
 msgstr "Einstellungen für das Rechteckwerkzeug öffnen"
 
-#: ../src/verbs.cpp:2953
+#: ../src/verbs.cpp:2987
 msgid "3D Box Preferences"
 msgstr "Einstellungen für 3D-Box"
 
-#: ../src/verbs.cpp:2954
+#: ../src/verbs.cpp:2988
 msgid "Open Preferences for the 3D Box tool"
 msgstr "Einstellungen für das 3D-Box-Werkzeug öffnen"
 
-#: ../src/verbs.cpp:2955
+#: ../src/verbs.cpp:2989
 msgid "Ellipse Preferences"
 msgstr "Einstellungen für Ellipsenwerkzeug"
 
-#: ../src/verbs.cpp:2956
+#: ../src/verbs.cpp:2990
 msgid "Open Preferences for the Ellipse tool"
 msgstr "Einstellungen für das Ellipsenwerkzeug öffnen"
 
-#: ../src/verbs.cpp:2957
+#: ../src/verbs.cpp:2991
 msgid "Star Preferences"
 msgstr "Einstellungen für Sternwerkzeug"
 
-#: ../src/verbs.cpp:2958
+#: ../src/verbs.cpp:2992
 msgid "Open Preferences for the Star tool"
 msgstr "Eigenschaften für das Sternwerkzeug öffnen"
 
-#: ../src/verbs.cpp:2959
+#: ../src/verbs.cpp:2993
 msgid "Spiral Preferences"
 msgstr "Einstellungen für Spiralenwerkzeug"
 
-#: ../src/verbs.cpp:2960
+#: ../src/verbs.cpp:2994
 msgid "Open Preferences for the Spiral tool"
 msgstr "Eigenschaften für das Spiralenwerkzeug öffnen"
 
-#: ../src/verbs.cpp:2961
+#: ../src/verbs.cpp:2995
 msgid "Pencil Preferences"
 msgstr "Einstellungen für Malwerkzeug"
 
-#: ../src/verbs.cpp:2962
+#: ../src/verbs.cpp:2996
 msgid "Open Preferences for the Pencil tool"
 msgstr "Eigenschaften für das Malwerkzeug öffnen"
 
-#: ../src/verbs.cpp:2963
+#: ../src/verbs.cpp:2997
 msgid "Pen Preferences"
 msgstr "Einstellungen für Zeichenwerkzeug"
 
-#: ../src/verbs.cpp:2964
+#: ../src/verbs.cpp:2998
 msgid "Open Preferences for the Pen tool"
 msgstr "Eigenschaften für das Zeichenwerkzeug öffnen"
 
-#: ../src/verbs.cpp:2965
+#: ../src/verbs.cpp:2999
 msgid "Calligraphic Preferences"
 msgstr "Einstellungen für Kalligrafiewerkzeug"
 
-#: ../src/verbs.cpp:2966
+#: ../src/verbs.cpp:3000
 msgid "Open Preferences for the Calligraphy tool"
 msgstr "Eigenschaften für das Kalligrafiewerkzeug öffnen"
 
-#: ../src/verbs.cpp:2967
+#: ../src/verbs.cpp:3001
 msgid "Text Preferences"
 msgstr "Einstellungen für Textwerkzeug"
 
-#: ../src/verbs.cpp:2968
+#: ../src/verbs.cpp:3002
 msgid "Open Preferences for the Text tool"
 msgstr "Eigenschaften für das Textwerkzeug öffnen"
 
-#: ../src/verbs.cpp:2969
+#: ../src/verbs.cpp:3003
 msgid "Gradient Preferences"
 msgstr "Einstellungen für Farbverläufe"
 
-#: ../src/verbs.cpp:2970
+#: ../src/verbs.cpp:3004
 msgid "Open Preferences for the Gradient tool"
 msgstr "Eigenschaften für Farbverläufe öffnen"
 
-#: ../src/verbs.cpp:2971
+#: ../src/verbs.cpp:3005
 msgid "Mesh Preferences"
 msgstr "Gitter-Einstellungen"
 
-#: ../src/verbs.cpp:2972
+#: ../src/verbs.cpp:3006
 msgid "Open Preferences for the Mesh tool"
 msgstr "Eigenschaften für das Gitterwerkzeug öffnen"
 
-#: ../src/verbs.cpp:2973
+#: ../src/verbs.cpp:3007
 msgid "Zoom Preferences"
 msgstr "Einstellungen für Zoomwerkzeug"
 
-#: ../src/verbs.cpp:2974
+#: ../src/verbs.cpp:3008
 msgid "Open Preferences for the Zoom tool"
 msgstr "Eigenschaften für das Zoomwerkzeug öffnen"
 
-#: ../src/verbs.cpp:2975
+#: ../src/verbs.cpp:3009
 msgid "Measure Preferences"
 msgstr "Messwerkzeug-Einstellungen"
 
-#: ../src/verbs.cpp:2976
+#: ../src/verbs.cpp:3010
 msgid "Open Preferences for the Measure tool"
 msgstr "Eigenschaften für das Messwerkzeug öffnen"
 
-#: ../src/verbs.cpp:2977
+#: ../src/verbs.cpp:3011
 msgid "Dropper Preferences"
 msgstr "Einstellungen für Farbpipette"
 
-#: ../src/verbs.cpp:2978
+#: ../src/verbs.cpp:3012
 msgid "Open Preferences for the Dropper tool"
 msgstr "Eigenschaften für die Farbpipette öffnen"
 
-#: ../src/verbs.cpp:2979
+#: ../src/verbs.cpp:3013
 msgid "Connector Preferences"
 msgstr "Einstellungen für Objektverbinder"
 
-#: ../src/verbs.cpp:2980
+#: ../src/verbs.cpp:3014
 msgid "Open Preferences for the Connector tool"
 msgstr "Eigenschaften für das Objektverbinder-Werkzeug öffnen"
 
-#: ../src/verbs.cpp:2983
+#: ../src/verbs.cpp:3017
 msgid "Paint Bucket Preferences"
 msgstr "Einstellungen für den Farbeimer"
 
-#: ../src/verbs.cpp:2984
+#: ../src/verbs.cpp:3018
 msgid "Open Preferences for the Paint Bucket tool"
 msgstr "Eigenschaften für das Farbeimer-Werkzeug öffnen"
 
-#: ../src/verbs.cpp:2987
+#: ../src/verbs.cpp:3021
 msgid "Eraser Preferences"
 msgstr "Einstellungen für das Löschwerkzeug"
 
-#: ../src/verbs.cpp:2988
+#: ../src/verbs.cpp:3022
 msgid "Open Preferences for the Eraser tool"
 msgstr "Eigenschaften für das Löschwerkzeug öffnen"
 
-#: ../src/verbs.cpp:2989
+#: ../src/verbs.cpp:3023
 msgid "LPE Tool Preferences"
 msgstr "LPE-Werkzeug-Einstellungen"
 
-#: ../src/verbs.cpp:2990
+#: ../src/verbs.cpp:3024
 msgid "Open Preferences for the LPETool tool"
 msgstr "Eigenschaften für LPE-Werkzeug öffnen"
 
 #. Zoom
-#: ../src/verbs.cpp:2993
+#: ../src/verbs.cpp:3027
 msgid "Zoom In"
 msgstr "Heranzoomen"
 
-#: ../src/verbs.cpp:2993
+#: ../src/verbs.cpp:3027
 msgid "Zoom in"
 msgstr "Ansicht vergrößern"
 
-#: ../src/verbs.cpp:2994
+#: ../src/verbs.cpp:3028
 msgid "Zoom Out"
 msgstr "Wegzoomen"
 
-#: ../src/verbs.cpp:2994
+#: ../src/verbs.cpp:3028
 msgid "Zoom out"
 msgstr "Ansicht verkleinern"
 
-#: ../src/verbs.cpp:2995
+#: ../src/verbs.cpp:3029
 msgid "Nex_t Zoom"
 msgstr "_Nächster Zoomfaktor"
 
-#: ../src/verbs.cpp:2995
+#: ../src/verbs.cpp:3029
 msgid "Next zoom (from the history of zooms)"
 msgstr "Den nächsten Zoomfaktor einstellen (aus der Liste bisheriger Faktoren)"
 
-#: ../src/verbs.cpp:2997
+#: ../src/verbs.cpp:3031
 msgid "Pre_vious Zoom"
 msgstr "_Vorheriger Zoomfaktor"
 
-#: ../src/verbs.cpp:2997
+#: ../src/verbs.cpp:3031
 msgid "Previous zoom (from the history of zooms)"
 msgstr ""
 "Den vorherigen Zoomfaktor einstellen (aus der Liste bisheriger Faktoren)"
 
-#: ../src/verbs.cpp:2999
+#: ../src/verbs.cpp:3033
 msgid "Zoom 1:_1"
 msgstr "Zoomfaktor 1:_1"
 
-#: ../src/verbs.cpp:2999
+#: ../src/verbs.cpp:3033
 msgid "Zoom to 1:1"
 msgstr "Den Zoomfaktor auf 1:1 setzen"
 
-#: ../src/verbs.cpp:3001
+#: ../src/verbs.cpp:3035
 msgid "Zoom 1:_2"
 msgstr "Zoomfaktor 1:_2"
 
-#: ../src/verbs.cpp:3001
+#: ../src/verbs.cpp:3035
 msgid "Zoom to 1:2"
 msgstr "Den Zoomfaktor auf 1:2 setzen"
 
-#: ../src/verbs.cpp:3003
+#: ../src/verbs.cpp:3037
 msgid "_Zoom 2:1"
 msgstr "_Zoomfaktor 2:1"
 
-#: ../src/verbs.cpp:3003
+#: ../src/verbs.cpp:3037
 msgid "Zoom to 2:1"
 msgstr "Den Zoomfaktor auf 2:1 setzen"
 
-#: ../src/verbs.cpp:3006
+#: ../src/verbs.cpp:3040
 msgid "Zoom to fit page in window"
 msgstr "Die Seite in das Fenster einpassen"
 
-#: ../src/verbs.cpp:3007
+#: ../src/verbs.cpp:3041
 msgid "Page _Width"
 msgstr "Seiten_breite"
 
-#: ../src/verbs.cpp:3008
+#: ../src/verbs.cpp:3042
 msgid "Zoom to fit page width in window"
 msgstr "Die Seitenbreite in das Fenster einpassen"
 
-#: ../src/verbs.cpp:3010
+#: ../src/verbs.cpp:3044
 msgid "Zoom to fit drawing in window"
 msgstr "Die Zeichnung in das Fenster einpassen"
 
-#: ../src/verbs.cpp:3012
+#: ../src/verbs.cpp:3046
 msgid "Zoom to fit selection in window"
 msgstr "Die Auswahl in das Fenster einpassen"
 
-#: ../src/verbs.cpp:3014
+#: ../src/verbs.cpp:3048
 #, fuzzy
 msgid "Rotate Clockwise"
 msgstr "Im Uhrzeigersinn drehen"
 
-#: ../src/verbs.cpp:3014
+#: ../src/verbs.cpp:3048
 #, fuzzy
 msgid "Rotate canvas clockwise"
 msgstr "Im Uhrzeigersinn drehen"
 
-#: ../src/verbs.cpp:3015
+#: ../src/verbs.cpp:3049
 #, fuzzy
 msgid "Rotate Counter-Clockwise"
 msgstr "Entgegen Uhrzeigersinn drehen"
 
-#: ../src/verbs.cpp:3015
+#: ../src/verbs.cpp:3049
 #, fuzzy
 msgid "Rotate canvas counter-clockwise"
 msgstr "Entgegen Uhrzeigersinn drehen"
 
-#: ../src/verbs.cpp:3016
+#: ../src/verbs.cpp:3050
 #, fuzzy
-msgid "Rotate Zero"
-msgstr "Drehmodus"
+msgid "Reset Rotation"
+msgstr "Drehung"
 
-#: ../src/verbs.cpp:3016
+#: ../src/verbs.cpp:3050
 msgid "Reset canvas rotation to zero"
 msgstr ""
 
-#: ../src/verbs.cpp:3018
+#: ../src/verbs.cpp:3052
 #, fuzzy
-msgid "Flip Horizontal"
-msgstr "_Horizontal umkehren"
+msgid "Flip Horizontally"
+msgstr "Horizontal umkehren"
 
-#: ../src/verbs.cpp:3018
+#: ../src/verbs.cpp:3052
 #, fuzzy
 msgid "Flip canvas horizontally"
 msgstr "Knoten Horizontal umkehren"
 
-#: ../src/verbs.cpp:3019
+#: ../src/verbs.cpp:3053
 #, fuzzy
-msgid "Flip Vertical"
-msgstr "_Vertikal umkehren"
+msgid "Flip Vertically"
+msgstr "Vertikal umkehren"
 
-#: ../src/verbs.cpp:3019
+#: ../src/verbs.cpp:3053
 #, fuzzy
 msgid "Flip canvas vertically"
 msgstr "Knoten Vertikal umkehren"
 
-#: ../src/verbs.cpp:3020
+#: ../src/verbs.cpp:3054
 #, fuzzy
-msgid "Flip None"
-msgstr "Knoten umkehren"
+msgid "Reset Flip"
+msgstr "Gitter zurücksetzen"
 
-#: ../src/verbs.cpp:3020
+#: ../src/verbs.cpp:3054
 msgid "Undo any flip"
 msgstr ""
 
 #. WHY ARE THE FOLLOWING ZoomVerbs???
 #. View
-#: ../src/verbs.cpp:3026
+#: ../src/verbs.cpp:3060
 msgid "_Rulers"
 msgstr "_Lineale"
 
-#: ../src/verbs.cpp:3026
+#: ../src/verbs.cpp:3060
 msgid "Show or hide the canvas rulers"
 msgstr "Arbeitsflächenlineale anzeigen oder ausblenden"
 
-#: ../src/verbs.cpp:3027
+#: ../src/verbs.cpp:3061
 msgid "Scroll_bars"
 msgstr "Roll_balken"
 
-#: ../src/verbs.cpp:3027
+#: ../src/verbs.cpp:3061
 msgid "Show or hide the canvas scrollbars"
 msgstr "Arbeitsflächen-Rollbalken anzeigen oder ausblenden"
 
-#: ../src/verbs.cpp:3028
+#: ../src/verbs.cpp:3062
 msgid "Page _Grid"
 msgstr "Seiten_gitter"
 
-#: ../src/verbs.cpp:3028
+#: ../src/verbs.cpp:3062
 msgid "Show or hide the page grid"
 msgstr "Seitengitter anzeigen oder ausblenden"
 
-#: ../src/verbs.cpp:3029
+#: ../src/verbs.cpp:3063
 msgid "G_uides"
 msgstr "Hi_lfslinien"
 
-#: ../src/verbs.cpp:3029
+#: ../src/verbs.cpp:3063
 msgid "Show or hide guides (drag from a ruler to create a guide)"
 msgstr ""
 "Hilfslinien zeigen oder verstecken (von einem Lineal ziehen, um eine "
 "Hilfslinie zu erzeugen)"
 
-#: ../src/verbs.cpp:3030
+#: ../src/verbs.cpp:3064
 msgid "Enable snapping"
 msgstr "Einrasten einschalten"
 
-#: ../src/verbs.cpp:3031
+#: ../src/verbs.cpp:3065
 msgid "_Commands Bar"
 msgstr "Befehlsleiste"
 
-#: ../src/verbs.cpp:3031
+#: ../src/verbs.cpp:3065
 msgid "Show or hide the Commands bar (under the menu)"
 msgstr "Befehlsleiste anzeigen oder ausblenden (Leiste unter dem Hauptmenü)"
 
-#: ../src/verbs.cpp:3032
+#: ../src/verbs.cpp:3066
 msgid "Sn_ap Controls Bar"
 msgstr "Einrasten-Kontrollleiste"
 
-#: ../src/verbs.cpp:3032
+#: ../src/verbs.cpp:3066
 msgid "Show or hide the snapping controls"
 msgstr "Kontrollen für Einrasten ein-/ausblenden"
 
-#: ../src/verbs.cpp:3033
+#: ../src/verbs.cpp:3067
 msgid "T_ool Controls Bar"
 msgstr "Werkzeugeinstellungsleiste"
 
-#: ../src/verbs.cpp:3033
+#: ../src/verbs.cpp:3067
 msgid "Show or hide the Tool Controls bar"
 msgstr "Einstellungsleiste für das Werkzeug ein-/ausblenden"
 
-#: ../src/verbs.cpp:3034
+#: ../src/verbs.cpp:3068
 msgid "_Toolbox"
 msgstr "Werkzeugleis_te"
 
-#: ../src/verbs.cpp:3034
+#: ../src/verbs.cpp:3068
 msgid "Show or hide the main toolbox (on the left)"
 msgstr "Werkzeugleiste (auf der linken Seite) an- oder abschalten"
 
-#: ../src/verbs.cpp:3035
+#: ../src/verbs.cpp:3069
 msgid "_Palette"
 msgstr "_Palette"
 
-#: ../src/verbs.cpp:3035
+#: ../src/verbs.cpp:3069
 msgid "Show or hide the color palette"
 msgstr "Farbpalette ein-/ausblenden"
 
-#: ../src/verbs.cpp:3036
+#: ../src/verbs.cpp:3070
 msgid "_Statusbar"
 msgstr "_Statuszeile"
 
-#: ../src/verbs.cpp:3036
+#: ../src/verbs.cpp:3070
 msgid "Show or hide the statusbar (at the bottom of the window)"
 msgstr "Statusleiste an- oder abschalten (am unteren Ende des Fensters)"
 
-#: ../src/verbs.cpp:3038
+#: ../src/verbs.cpp:3072
 msgid "_Fullscreen"
 msgstr "Voll_bild"
 
-#: ../src/verbs.cpp:3038 ../src/verbs.cpp:3040
+#: ../src/verbs.cpp:3072 ../src/verbs.cpp:3074
 msgid "Stretch this document window to full screen"
 msgstr "Dieses Dokumentenfenster auf Vollbild aufziehen"
 
-#: ../src/verbs.cpp:3040
+#: ../src/verbs.cpp:3074
 msgid "Fullscreen & Focus Mode"
 msgstr "Vollbild und Fokusmodus"
 
-#: ../src/verbs.cpp:3042
+#: ../src/verbs.cpp:3076
 msgid "Toggle _Focus Mode"
 msgstr "Schaltet _Fokusmodus um"
 
-#: ../src/verbs.cpp:3042
+#: ../src/verbs.cpp:3076
 msgid "Remove excess toolbars to focus on drawing"
 msgstr "Entfernt überzählige Werkzeugleisten, um Abeitsfläche zu maximieren"
 
-#: ../src/verbs.cpp:3044
+#: ../src/verbs.cpp:3078
 msgid "Duplic_ate Window"
 msgstr "Fenster d_uplizieren"
 
-#: ../src/verbs.cpp:3044
+#: ../src/verbs.cpp:3078
 msgid "Open a new window with the same document"
 msgstr "Das momentan geöffnete Dokument in einem neuen Fenster darstellen"
 
-#: ../src/verbs.cpp:3046
+#: ../src/verbs.cpp:3080
 msgid "_New View Preview"
 msgstr "_Neue Vorschau"
 
-#: ../src/verbs.cpp:3047
+#: ../src/verbs.cpp:3081
 msgid "New View Preview"
 msgstr "Neue Vorschau"
 
 #. "view_new_preview"
-#: ../src/verbs.cpp:3049 ../src/verbs.cpp:3057
+#: ../src/verbs.cpp:3083 ../src/verbs.cpp:3091
 msgid "_Normal"
 msgstr "_Normal"
 
-#: ../src/verbs.cpp:3050
+#: ../src/verbs.cpp:3084
 msgid "Switch to normal display mode"
 msgstr "In den normalen Anzeigemodus wechseln"
 
-#: ../src/verbs.cpp:3051
+#: ../src/verbs.cpp:3085
 msgid "No _Filters"
 msgstr "Keine _Filter"
 
-#: ../src/verbs.cpp:3052
+#: ../src/verbs.cpp:3086
 msgid "Switch to normal display without filters"
 msgstr "Wechselt in den normalen Anzeigemodus ohne Filter"
 
-#: ../src/verbs.cpp:3053
+#: ../src/verbs.cpp:3087
 msgid "_Outline"
 msgstr "_Umriss"
 
-#: ../src/verbs.cpp:3054
+#: ../src/verbs.cpp:3088
 msgid "Switch to outline (wireframe) display mode"
 msgstr "In den Umriss-(Drahtgitter)-Anzeigemodus wechseln"
 
 #. new ZoomVerb(SP_VERB_VIEW_COLOR_MODE_PRINT_COLORS_PREVIEW, "ViewColorModePrintColorsPreview", N_("_Print Colors Preview"),
 #. N_("Switch to print colors preview mode"), NULL),
-#: ../src/verbs.cpp:3055 ../src/verbs.cpp:3063
+#: ../src/verbs.cpp:3089 ../src/verbs.cpp:3097
 msgid "_Toggle"
 msgstr "_Umschalten"
 
-#: ../src/verbs.cpp:3056
+#: ../src/verbs.cpp:3090
 msgid "Toggle between normal and outline display modes"
 msgstr "Zwischen normaler und Umriss-Ansicht umschalten"
 
-#: ../src/verbs.cpp:3058
+#: ../src/verbs.cpp:3092
 msgid "Switch to normal color display mode"
 msgstr "In den normalen Anzeigemodus wechseln"
 
-#: ../src/verbs.cpp:3059
+#: ../src/verbs.cpp:3093
 msgid "_Grayscale"
 msgstr "_Graustufen"
 
-#: ../src/verbs.cpp:3060
+#: ../src/verbs.cpp:3094
 msgid "Switch to grayscale display mode"
 msgstr "In den Graustufen-Anzeigemodus wechseln"
 
-#: ../src/verbs.cpp:3064
+#: ../src/verbs.cpp:3098
 msgid "Toggle between normal and grayscale color display modes"
 msgstr "Zwischen normaler und Graustufen-Farb-Ansicht umschalten"
 
 # ???
-#: ../src/verbs.cpp:3066
+#: ../src/verbs.cpp:3100
 msgid "Color-managed view"
 msgstr "Farbverwaltungsansicht"
 
 # ???
-#: ../src/verbs.cpp:3067
+#: ../src/verbs.cpp:3101
 msgid "Toggle color-managed display for this document window"
 msgstr "Ansicht mit Farbverwaltung ein-/ausschalten"
 
-#: ../src/verbs.cpp:3069
+#: ../src/verbs.cpp:3103
 msgid "Ico_n Preview..."
 msgstr "Sy_mbolvorschau..."
 
-#: ../src/verbs.cpp:3070
+#: ../src/verbs.cpp:3104
 msgid "Open a window to preview objects at different icon resolutions"
 msgstr ""
 "Vorschaufenster öffnen, um Elemente bei verschiedenen Icon-Auflösungsstufen "
 "zu sehen"
 
 #. Dialogs
-#: ../src/verbs.cpp:3073
+#: ../src/verbs.cpp:3107
 msgid "Prototype..."
 msgstr ""
 
-#: ../src/verbs.cpp:3074
+#: ../src/verbs.cpp:3108
 msgid "Prototype Dialog"
 msgstr ""
 
-#: ../src/verbs.cpp:3075
+#: ../src/verbs.cpp:3109
 msgid "P_references..."
 msgstr "Einstellungen"
 
-#: ../src/verbs.cpp:3076
+#: ../src/verbs.cpp:3110
 msgid "Edit global Inkscape preferences"
 msgstr "Globale Einstellungen für Inkscape bearbeiten"
 
-#: ../src/verbs.cpp:3077
+#: ../src/verbs.cpp:3111
 msgid "_Document Properties..."
 msgstr "_Dokumenteinstellungen..."
 
-#: ../src/verbs.cpp:3078
+#: ../src/verbs.cpp:3112
 msgid "Edit properties of this document (to be saved with the document)"
 msgstr "Einstellungen bearbeiten, die mit dem Dokument gespeichert werden"
 
-#: ../src/verbs.cpp:3079
+#: ../src/verbs.cpp:3113
 msgid "Document _Metadata..."
 msgstr "Dokument_metadaten..."
 
-#: ../src/verbs.cpp:3080
+#: ../src/verbs.cpp:3114
 msgid "Edit document metadata (to be saved with the document)"
 msgstr "Dokument-Metadaten bearbeiten, die mit dem Dokument gespeichert werden"
 
-#: ../src/verbs.cpp:3082
+#: ../src/verbs.cpp:3116
 msgid ""
 "Edit objects' colors, gradients, arrowheads, and other fill and stroke "
 "properties..."
@@ -29125,118 +29462,118 @@ msgstr ""
 "Objektfarben, Farbverläufe, Strichbreiten, Pfeile, Strichmuster usw. ändern"
 
 #. FIXME: Probably better to either use something from the icon naming spec or ship our own "select-font" icon
-#: ../src/verbs.cpp:3084
+#: ../src/verbs.cpp:3118
 msgid "Gl_yphs..."
 msgstr "Gl_yphen..."
 
-#: ../src/verbs.cpp:3085
+#: ../src/verbs.cpp:3119
 msgid "Select characters from a glyphs palette"
 msgstr "Wählen Sie ein Zeichen aus einer Glyphenpalette aus"
 
 #. FIXME: Probably better to either use something from the icon naming spec or ship our own "select-color" icon
 #. TRANSLATORS: "Swatches" means: color samples
-#: ../src/verbs.cpp:3088
+#: ../src/verbs.cpp:3122
 msgid "S_watches..."
 msgstr "_Farbfelder-Palette..."
 
-#: ../src/verbs.cpp:3089
+#: ../src/verbs.cpp:3123
 msgid "Select colors from a swatches palette"
 msgstr "Farben aus einer Farbfelder-Palette auswählen"
 
-#: ../src/verbs.cpp:3090
+#: ../src/verbs.cpp:3124
 msgid "S_ymbols..."
 msgstr "S_ymbole..."
 
-#: ../src/verbs.cpp:3091
+#: ../src/verbs.cpp:3125
 msgid "Select symbol from a symbols palette"
 msgstr "Symbol aus einer Symbol-Palette auswählen"
 
-#: ../src/verbs.cpp:3092
+#: ../src/verbs.cpp:3126
 msgid "Transfor_m..."
 msgstr "_Transformation..."
 
-#: ../src/verbs.cpp:3093
+#: ../src/verbs.cpp:3127
 msgid "Precisely control objects' transformations"
 msgstr "Transformationen eines Objektes präzise einstellen"
 
-#: ../src/verbs.cpp:3094
+#: ../src/verbs.cpp:3128
 msgid "_Align and Distribute..."
 msgstr "_Ausrichten und verteilen..."
 
-#: ../src/verbs.cpp:3095
+#: ../src/verbs.cpp:3129
 msgid "Align and distribute objects"
 msgstr "Objekte ausrichten und ihre Abstände ausgleichen"
 
-#: ../src/verbs.cpp:3096
+#: ../src/verbs.cpp:3130
 msgid "_Spray options..."
 msgstr "_Spraydosen-Optionen"
 
-#: ../src/verbs.cpp:3097
+#: ../src/verbs.cpp:3131
 msgid "Some options for the spray"
 msgstr "Einige Optionen des Sprühwerkzeuges"
 
-#: ../src/verbs.cpp:3098
+#: ../src/verbs.cpp:3132
 msgid "Undo _History..."
 msgstr "Bearbeitungs_historie..."
 
-#: ../src/verbs.cpp:3099
+#: ../src/verbs.cpp:3133
 msgid "Undo History"
 msgstr "Bearbeitungshistorie"
 
-#: ../src/verbs.cpp:3101
+#: ../src/verbs.cpp:3135
 msgid "View and select font family, font size and other text properties"
 msgstr ""
 "Schriftfamilie, Schriftgröße und andere Texteigenschaften ansehen und ändern"
 
-#: ../src/verbs.cpp:3102
+#: ../src/verbs.cpp:3136
 msgid "_XML Editor..."
 msgstr "_XML-Editor..."
 
-#: ../src/verbs.cpp:3103
+#: ../src/verbs.cpp:3137
 msgid "View and edit the XML tree of the document"
 msgstr "Zeige und ändere den XML-Baum des Dokuments"
 
-#: ../src/verbs.cpp:3104
+#: ../src/verbs.cpp:3138
 msgid "_Find/Replace..."
 msgstr "_Suchen/Ersetzen..."
 
-#: ../src/verbs.cpp:3105
+#: ../src/verbs.cpp:3139
 msgid "Find objects in document"
 msgstr "Objekte im Dokument suchen"
 
-#: ../src/verbs.cpp:3106
+#: ../src/verbs.cpp:3140
 msgid "Find and _Replace Text..."
 msgstr "Text suchen und e_rsetzen..."
 
-#: ../src/verbs.cpp:3107
+#: ../src/verbs.cpp:3141
 msgid "Find and replace text in document"
 msgstr "Text im Dokument suchen und ersetzen"
 
-#: ../src/verbs.cpp:3109
+#: ../src/verbs.cpp:3143
 msgid "Check spelling of text in document"
 msgstr "Rechtschreibprüfung für Text im Dokument"
 
-#: ../src/verbs.cpp:3110
+#: ../src/verbs.cpp:3144
 msgid "_Messages..."
 msgstr "_Nachrichten..."
 
-#: ../src/verbs.cpp:3111
+#: ../src/verbs.cpp:3145
 msgid "View debug messages"
 msgstr "Nachrichten zur Fehlersuche anzeigen"
 
-#: ../src/verbs.cpp:3112
+#: ../src/verbs.cpp:3146
 msgid "Show/Hide D_ialogs"
 msgstr "_Dialoge anzeigen oder ausblenden"
 
-#: ../src/verbs.cpp:3113
+#: ../src/verbs.cpp:3147
 msgid "Show or hide all open dialogs"
 msgstr "Alle offenen Dialoge zeigen oder ausblenden"
 
-#: ../src/verbs.cpp:3114
+#: ../src/verbs.cpp:3148
 msgid "Create Tiled Clones..."
 msgstr "Gekachelte Klone erzeugen..."
 
-#: ../src/verbs.cpp:3115
+#: ../src/verbs.cpp:3149
 msgid ""
 "Create multiple clones of selected object, arranging them into a pattern or "
 "scattering"
@@ -29244,398 +29581,438 @@ msgstr ""
 "Mehrere Klone des gewählten Objekts erstellen, die in einem Muster oder "
 "verstreut angeordnet sind"
 
-#: ../src/verbs.cpp:3116
+#: ../src/verbs.cpp:3150
 msgid "_Object attributes..."
 msgstr "_Objekteigenschaften..."
 
-#: ../src/verbs.cpp:3117
+#: ../src/verbs.cpp:3151
 msgid "Edit the object attributes..."
 msgstr "Objektattribute bearbeiten..."
 
-#: ../src/verbs.cpp:3119
+#: ../src/verbs.cpp:3153
 msgid "Edit the ID, locked and visible status, and other object properties"
 msgstr ""
 "Kennung, Status (gesperrt, sichtbar) und andere Objekteigenschaften ändern"
 
-#: ../src/verbs.cpp:3120
+#: ../src/verbs.cpp:3154
 msgid "_Input Devices..."
 msgstr "_Eingabegeräte..."
 
-#: ../src/verbs.cpp:3121
+#: ../src/verbs.cpp:3155
 msgid "Configure extended input devices, such as a graphics tablet"
 msgstr "Erweiterte Eingabegeräte konfigurieren, wie z. B. Grafiktabletts"
 
-#: ../src/verbs.cpp:3122
+#: ../src/verbs.cpp:3156
 msgid "_Extensions..."
 msgstr "_Erweiterungen..."
 
-#: ../src/verbs.cpp:3123
+#: ../src/verbs.cpp:3157
 msgid "Query information about extensions"
 msgstr "Informationen über Erweiterungen abfragen"
 
-#: ../src/verbs.cpp:3124
+#: ../src/verbs.cpp:3158
 msgid "Layer_s..."
 msgstr "_Ebenen..."
 
-#: ../src/verbs.cpp:3125
+#: ../src/verbs.cpp:3159
 msgid "View Layers"
 msgstr "Ebenen anzeigen"
 
-#: ../src/verbs.cpp:3126
+#: ../src/verbs.cpp:3160
 msgid "Object_s..."
 msgstr "_Objekte..."
 
-#: ../src/verbs.cpp:3127
+#: ../src/verbs.cpp:3161
 msgid "View Objects"
 msgstr "Objekte ansehen"
 
-#: ../src/verbs.cpp:3128
+#: ../src/verbs.cpp:3162
 msgid "Selection se_ts..."
 msgstr "Aus_wahlgruppen..."
 
-#: ../src/verbs.cpp:3129
+#: ../src/verbs.cpp:3163
 msgid "View Tags"
 msgstr "Tags anzeigen"
 
-#: ../src/verbs.cpp:3130
+#: ../src/verbs.cpp:3164
 msgid "Style Dialog..."
 msgstr ""
 
-#: ../src/verbs.cpp:3131
+#: ../src/verbs.cpp:3165
 msgid "View Style Dialog"
 msgstr ""
 
-#: ../src/verbs.cpp:3132
+#: ../src/verbs.cpp:3166
 #, fuzzy
 msgid "Css Dialog..."
 msgstr "Dialog"
 
-#: ../src/verbs.cpp:3133
+#: ../src/verbs.cpp:3167
 msgid "View Css Dialog"
 msgstr ""
 
-#: ../src/verbs.cpp:3134
+#: ../src/verbs.cpp:3168
 msgid "Path E_ffects ..."
 msgstr "Pfade_ffekte..."
 
-#: ../src/verbs.cpp:3135
+#: ../src/verbs.cpp:3169
 msgid "Manage, edit, and apply path effects"
 msgstr "Pfadeffekte verwalten, bearbeiten und anwenden"
 
-#: ../src/verbs.cpp:3136
+#: ../src/verbs.cpp:3170
 msgid "Filter _Editor..."
 msgstr "Filter_editor..."
 
-#: ../src/verbs.cpp:3137
+#: ../src/verbs.cpp:3171
 msgid "Manage, edit, and apply SVG filters"
 msgstr "SVG-Filter verwalten, bearbeiten und anwenden"
 
-#: ../src/verbs.cpp:3138
+#: ../src/verbs.cpp:3172
 msgid "SVG Font Editor..."
 msgstr "SVG-Schriftarteneditor..."
 
-#: ../src/verbs.cpp:3139
+#: ../src/verbs.cpp:3173
 msgid "Edit SVG fonts"
 msgstr "SVG-Schriften bearbeiten"
 
-#: ../src/verbs.cpp:3140
+#: ../src/verbs.cpp:3174
 msgid "Print Colors..."
 msgstr "Druckfarben..."
 
-#: ../src/verbs.cpp:3141
+#: ../src/verbs.cpp:3175
 msgid ""
 "Select which color separations to render in Print Colors Preview rendermode"
 msgstr ""
 "Wählen Sie die zu rendernden Farbseparationen im Druckfarben-Vorschau-"
 "Rendermodus aus"
 
-#: ../src/verbs.cpp:3142
+#: ../src/verbs.cpp:3176
 msgid "_Export PNG Image..."
 msgstr "PNG-Bild _exportieren..."
 
-#: ../src/verbs.cpp:3143
+#: ../src/verbs.cpp:3177
 msgid "Export this document or a selection as a PNG image"
 msgstr "Das Dokument oder eine Auswahl als Bitmap-Bild exportieren"
 
 #. Help
-#: ../src/verbs.cpp:3145
+#: ../src/verbs.cpp:3179
 msgid "About E_xtensions"
 msgstr "Über _Erweiterungen"
 
-#: ../src/verbs.cpp:3146
+#: ../src/verbs.cpp:3180
 msgid "Information on Inkscape extensions"
 msgstr "Informationen über Inkscape-Erweiterungen"
 
-#: ../src/verbs.cpp:3147
+#: ../src/verbs.cpp:3181
 msgid "About _Memory"
 msgstr "_Speichernutzung"
 
-#: ../src/verbs.cpp:3148
+#: ../src/verbs.cpp:3182
 msgid "Memory usage information"
 msgstr "Informationen über die Speichernutzung"
 
-#: ../src/verbs.cpp:3149
+#: ../src/verbs.cpp:3183
 msgid "_About Inkscape"
 msgstr "Ü_ber Inkscape"
 
-#: ../src/verbs.cpp:3150
+#: ../src/verbs.cpp:3184
 msgid "Inkscape version, authors, license"
 msgstr "Inkscape-Version, Autoren, Lizenz"
 
 #. new HelpVerb(SP_VERB_SHOW_LICENSE, "ShowLicense", N_("_License"),
 #. N_("Distribution terms"), /*"show_license"*/"inkscape_options"),
 #. Tutorials
-#: ../src/verbs.cpp:3155
+#: ../src/verbs.cpp:3189
 msgid "Inkscape: _Basic"
 msgstr "Inkscape: _Grundlagen"
 
-#: ../src/verbs.cpp:3156
+#: ../src/verbs.cpp:3190
 msgid "Getting started with Inkscape"
 msgstr "Erste Schritte mit Inkscape"
 
 #. "tutorial_basic"
-#: ../src/verbs.cpp:3157
+#: ../src/verbs.cpp:3191
 msgid "Inkscape: _Shapes"
 msgstr "Inkscape: _Formen"
 
-#: ../src/verbs.cpp:3158
+#: ../src/verbs.cpp:3192
 msgid "Using shape tools to create and edit shapes"
 msgstr "Benutzung der Formen-Werkzeuge zum Erzeugen und Verändern von Formen"
 
-#: ../src/verbs.cpp:3159
+#: ../src/verbs.cpp:3193
 msgid "Inkscape: _Advanced"
 msgstr "Inkscape: Fortgeschrittene _Benutzung"
 
-#: ../src/verbs.cpp:3160
+#: ../src/verbs.cpp:3194
 msgid "Advanced Inkscape topics"
 msgstr "Fortgeschrittene Themen bei der Benutzung von Inkscape"
 
 #. TRANSLATORS: "to trace" means "to convert a bitmap to vector graphics" (to vectorize)
-#: ../src/verbs.cpp:3164
+#: ../src/verbs.cpp:3198
 msgid "Inkscape: T_racing"
 msgstr "Inkscape: _Nachzeichnen"
 
-#: ../src/verbs.cpp:3165
+#: ../src/verbs.cpp:3199
 msgid "Using bitmap tracing"
 msgstr "Verwendung der Bitmap-Nachzeichnung"
 
-#: ../src/verbs.cpp:3168
+#: ../src/verbs.cpp:3202
 msgid "Inkscape: Tracing Pixel Art"
 msgstr "Inkscape: Pixelkunst nachzeichnen"
 
-#: ../src/verbs.cpp:3169
+#: ../src/verbs.cpp:3203
 msgid "Using Trace Pixel Art dialog"
 msgstr "Pixelkunst nachzeichnen-Dialog verwenden"
 
-#: ../src/verbs.cpp:3170
+#: ../src/verbs.cpp:3204
 msgid "Inkscape: _Calligraphy"
 msgstr "Inkscape: _Kalligrafie"
 
-#: ../src/verbs.cpp:3171
+#: ../src/verbs.cpp:3205
 msgid "Using the Calligraphy pen tool"
 msgstr "Verwendung des kalligrafischen Füllers"
 
-#: ../src/verbs.cpp:3172
+#: ../src/verbs.cpp:3206
 msgid "Inkscape: _Interpolate"
 msgstr "Inkscape: _Interpolieren"
 
-#: ../src/verbs.cpp:3173
+#: ../src/verbs.cpp:3207
 msgid "Using the interpolate extension"
 msgstr "Benutzt die Erweiterung Interpolieren"
 
 #. "tutorial_interpolate"
-#: ../src/verbs.cpp:3174
+#: ../src/verbs.cpp:3208
 msgid "_Elements of Design"
 msgstr "_Elemente des Designs"
 
-#: ../src/verbs.cpp:3175
+#: ../src/verbs.cpp:3209
 msgid "Principles of design in the tutorial form"
 msgstr "Gestaltungsprinzipen"
 
 #. "tutorial_design"
-#: ../src/verbs.cpp:3176
+#: ../src/verbs.cpp:3210
 msgid "_Tips and Tricks"
 msgstr "_Tipps und Tricks"
 
-#: ../src/verbs.cpp:3177
+#: ../src/verbs.cpp:3211
 msgid "Miscellaneous tips and tricks"
 msgstr "Verschiedene Tipps und Tricks"
 
 #. "tutorial_tips"
 #. Effect -- renamed Extension
-#: ../src/verbs.cpp:3180
+#: ../src/verbs.cpp:3214
 msgid "Previous Exte_nsion"
 msgstr "Vorherige Erweiterungen"
 
-#: ../src/verbs.cpp:3181
+#: ../src/verbs.cpp:3215
 msgid "Repeat the last extension with the same settings"
 msgstr "Letzten Effekt mit den gleichen Einstellungen anwenden"
 
-#: ../src/verbs.cpp:3182
+#: ../src/verbs.cpp:3216
 msgid "_Previous Extension Settings..."
 msgstr "_Vorherige Erweiterungseinstellungen..."
 
-#: ../src/verbs.cpp:3183
+#: ../src/verbs.cpp:3217
 msgid "Repeat the last extension with new settings"
 msgstr "Letzte Erweiterung mit anderen Einstellungen wiederholen"
 
 # !!!
-#: ../src/verbs.cpp:3187
+#: ../src/verbs.cpp:3221
 msgid "Fit the page to the current selection"
 msgstr "Die Seite in die aktuelle Auswahl einpassen"
 
 # !!!
-#: ../src/verbs.cpp:3189
+#: ../src/verbs.cpp:3223
 msgid "Fit the page to the drawing"
 msgstr "Die Seite in die Zeichnungsgröße einpassen"
 
-#: ../src/verbs.cpp:3190
+#: ../src/verbs.cpp:3224
 msgid "_Resize Page to Selection"
 msgstr "Seiteng_röße auf Auswahlgröße"
 
-#: ../src/verbs.cpp:3191
+#: ../src/verbs.cpp:3225
 msgid ""
 "Fit the page to the current selection or the drawing if there is no selection"
 msgstr ""
 "Die Seite in die aktuelle Auswahl einpassen (oder die ganze Zeichnung, wenn "
 "es keine Auswahl gibt)"
 
-#: ../src/verbs.cpp:3195
+#: ../src/verbs.cpp:3229
 msgid "Unlock All in All Layers"
 msgstr "Alles in allen Ebenen entsperren"
 
 # !!! mnemonics
-#: ../src/verbs.cpp:3197
+#: ../src/verbs.cpp:3231
 msgid "Unhide All"
 msgstr "Alles einblenden"
 
-#: ../src/verbs.cpp:3199
+#: ../src/verbs.cpp:3233
 msgid "Unhide All in All Layers"
 msgstr "Alles in allen Ebenen einblenden"
 
-#: ../src/verbs.cpp:3203
+#: ../src/verbs.cpp:3237
 msgid "Link an ICC color profile"
 msgstr "Verknüpfung mit ICC-Farbprofil"
 
-#: ../src/verbs.cpp:3204
+#: ../src/verbs.cpp:3238
 msgid "Remove Color Profile"
 msgstr "Farbprofil entfernen"
 
-#: ../src/verbs.cpp:3205
+#: ../src/verbs.cpp:3239
 msgid "Remove a linked ICC color profile"
 msgstr "Entfernt ein verknüpftes ICC-Farbprofil"
 
-#: ../src/verbs.cpp:3208
+#: ../src/verbs.cpp:3242
 msgid "Add External Script"
 msgstr "Füge externes Script hinzu"
 
-#: ../src/verbs.cpp:3208
+#: ../src/verbs.cpp:3242
 msgid "Add an external script"
 msgstr "Füge ein externes Script hinzu"
 
-#: ../src/verbs.cpp:3210
+#: ../src/verbs.cpp:3244
 msgid "Add Embedded Script"
 msgstr "Füge eingebettetes Script hinzu"
 
-#: ../src/verbs.cpp:3210
+#: ../src/verbs.cpp:3244
 msgid "Add an embedded script"
 msgstr "Füge ein eingebettetes Script hinzu"
 
-#: ../src/verbs.cpp:3212
+#: ../src/verbs.cpp:3246
 msgid "Edit Embedded Script"
 msgstr "Eingebettetes Script bearbeiten"
 
-#: ../src/verbs.cpp:3212
+#: ../src/verbs.cpp:3246
 msgid "Edit an embedded script"
 msgstr "Ein eingebettetes Script bearbeiten"
 
-#: ../src/verbs.cpp:3214
+#: ../src/verbs.cpp:3248
 msgid "Remove External Script"
 msgstr "Lösche externes Script"
 
-#: ../src/verbs.cpp:3214
+#: ../src/verbs.cpp:3248
 msgid "Remove an external script"
 msgstr "Lösche ein externes Script"
 
-#: ../src/verbs.cpp:3216
+#: ../src/verbs.cpp:3250
 msgid "Remove Embedded Script"
 msgstr "Eingebettetes Script entfernen"
 
-#: ../src/verbs.cpp:3216
+#: ../src/verbs.cpp:3250
 msgid "Remove an embedded script"
 msgstr "Ein eingebettetes Script entfernen"
 
-#: ../src/verbs.cpp:3238 ../src/verbs.cpp:3239
+#: ../src/verbs.cpp:3272 ../src/verbs.cpp:3273
 msgid "Center on horizontal and vertical axis"
 msgstr "An horizontalen und vertikalen Achsen ausrichten"
 
-#: ../src/widgets/arc-toolbar.cpp:128
+#: ../src/widgets/arc-toolbar.cpp:140
+#, fuzzy
+msgid "Change arc"
+msgstr "Weichzeichner ändern"
+
+#: ../src/widgets/arc-toolbar.cpp:206
 msgid "Arc: Change start/end"
 msgstr "Bogen: Beginn/Ende ändern"
 
-#: ../src/widgets/arc-toolbar.cpp:198
+#: ../src/widgets/arc-toolbar.cpp:274
 #, fuzzy
 msgid "Arc: Changed arc type"
 msgstr "Bogen: Beginn/Ende ändern"
 
 # !!!
-#: ../src/widgets/arc-toolbar.cpp:295 ../src/widgets/arc-toolbar.cpp:325
-#: ../src/widgets/rect-toolbar.cpp:256 ../src/widgets/rect-toolbar.cpp:295
-#: ../src/widgets/spiral-toolbar.cpp:207 ../src/widgets/spiral-toolbar.cpp:231
-#: ../src/widgets/star-toolbar.cpp:380 ../src/widgets/star-toolbar.cpp:442
+#: ../src/widgets/arc-toolbar.cpp:409 ../src/widgets/arc-toolbar.cpp:448
+#: ../src/widgets/rect-toolbar.cpp:262 ../src/widgets/rect-toolbar.cpp:301
+#: ../src/widgets/spiral-toolbar.cpp:213 ../src/widgets/spiral-toolbar.cpp:237
+#: ../src/widgets/star-toolbar.cpp:380 ../src/widgets/star-toolbar.cpp:454
 msgid "<b>New:</b>"
 msgstr "<b>Neu:</b>"
 
 # !!!
 #. FIXME: implement averaging of all parameters for multiple selected
 #. gtk_label_set_markup(GTK_LABEL(l), _("<b>Average:</b>"));
-#: ../src/widgets/arc-toolbar.cpp:298 ../src/widgets/arc-toolbar.cpp:309
-#: ../src/widgets/rect-toolbar.cpp:264 ../src/widgets/rect-toolbar.cpp:282
-#: ../src/widgets/spiral-toolbar.cpp:209 ../src/widgets/spiral-toolbar.cpp:220
+#: ../src/widgets/arc-toolbar.cpp:412 ../src/widgets/arc-toolbar.cpp:429
+#: ../src/widgets/rect-toolbar.cpp:270 ../src/widgets/rect-toolbar.cpp:288
+#: ../src/widgets/spiral-toolbar.cpp:215 ../src/widgets/spiral-toolbar.cpp:226
 #: ../src/widgets/star-toolbar.cpp:382
 msgid "<b>Change:</b>"
 msgstr "<b>Ändern:</b>"
 
-#: ../src/widgets/arc-toolbar.cpp:334
+#: ../src/widgets/arc-toolbar.cpp:459 ../src/widgets/rect-toolbar.cpp:353
+msgid "Horizontal radius"
+msgstr "Horizontaler Radius"
+
+#: ../src/widgets/arc-toolbar.cpp:459 ../src/widgets/rect-toolbar.cpp:353
+msgid "Rx:"
+msgstr "Rx:"
+
+#: ../src/widgets/arc-toolbar.cpp:459
+#, fuzzy
+msgid "Horizontal radius of the circle, ellipse, or arc"
+msgstr "Horizontaler Radius einer abgerundeten Ecke"
+
+#: ../src/widgets/arc-toolbar.cpp:476 ../src/widgets/rect-toolbar.cpp:368
+msgid "Vertical radius"
+msgstr "Vertikaler Radius"
+
+#: ../src/widgets/arc-toolbar.cpp:476 ../src/widgets/rect-toolbar.cpp:368
+msgid "Ry:"
+msgstr "Ry:"
+
+#: ../src/widgets/arc-toolbar.cpp:476
+#, fuzzy
+msgid "Vertical radius of the circle, ellipse, or arc"
+msgstr "Kreise, Ellipsen und Bögen erstellen"
+
+#. Add the units menu.
+#: ../src/widgets/arc-toolbar.cpp:490 ../src/widgets/lpe-toolbar.cpp:380
+#: ../src/widgets/node-toolbar.cpp:611
+#: ../src/widgets/paintbucket-toolbar.cpp:166
+#: ../src/widgets/rect-toolbar.cpp:380 ../src/widgets/select-toolbar.cpp:520
+#: ../src/widgets/text-toolbar.cpp:2322
+msgid "Units"
+msgstr "Einheiten"
+
+#: ../src/widgets/arc-toolbar.cpp:497
 msgid "Start:"
 msgstr "Anfang:"
 
-#: ../src/widgets/arc-toolbar.cpp:335
+#: ../src/widgets/arc-toolbar.cpp:498
 msgid "The angle (in degrees) from the horizontal to the arc's start point"
 msgstr ""
 "Der Winkel (in Grad) von der Horizontalen bis zum Startpunkt des Bogens"
 
-#: ../src/widgets/arc-toolbar.cpp:347
+#: ../src/widgets/arc-toolbar.cpp:510
 msgid "End:"
 msgstr "Ende:"
 
-#: ../src/widgets/arc-toolbar.cpp:348
+#: ../src/widgets/arc-toolbar.cpp:511
 msgid "The angle (in degrees) from the horizontal to the arc's end point"
 msgstr "Der Winkel (in Grad) von der Horizontalen bis zum Endpunkt des Bogens"
 
-#: ../src/widgets/arc-toolbar.cpp:365
+#: ../src/widgets/arc-toolbar.cpp:530
 #, fuzzy
 msgid "Switch to slice (closed shape with two radii)"
 msgstr "Zu Segment (geschlossene Form mit zwei Radien) umschalten"
 
-#: ../src/widgets/arc-toolbar.cpp:371
+#: ../src/widgets/arc-toolbar.cpp:535
 msgid "Arc (Open)"
 msgstr ""
 
-#: ../src/widgets/arc-toolbar.cpp:372
+#: ../src/widgets/arc-toolbar.cpp:536
 msgid "Switch to arc (unclosed shape)"
 msgstr "Zu Bogen umschalten (offene Form)"
 
-#: ../src/widgets/arc-toolbar.cpp:379
+#: ../src/widgets/arc-toolbar.cpp:542
 #, fuzzy
 msgid "Switch to chord (closed shape)"
 msgstr "Zu Bogen umschalten (offene Form)"
 
-#: ../src/widgets/arc-toolbar.cpp:402
+#: ../src/widgets/arc-toolbar.cpp:567
 msgid "Make whole"
 msgstr "Schließen"
 
-#: ../src/widgets/arc-toolbar.cpp:403
+#: ../src/widgets/arc-toolbar.cpp:568
 msgid "Make the shape a whole ellipse, not arc or segment"
 msgstr "Die Form zur ganzen Ellipse anstelle eines Bogens oder Segments machen"
 
@@ -29708,85 +30085,83 @@ msgstr ""
 "Fluchtpunkt in Z-Richtung zwischen 'endlich' und 'unendlich' (=parallel) "
 "umschalten"
 
-#. gint preset_index = ege_select_one_action_get_active( sel );
-#: ../src/widgets/calligraphy-toolbar.cpp:218
-#: ../src/widgets/calligraphy-toolbar.cpp:262
-#: ../src/widgets/calligraphy-toolbar.cpp:267
+#: ../src/widgets/calligraphy-toolbar.cpp:216
+#: ../src/widgets/calligraphy-toolbar.cpp:257
 msgid "No preset"
 msgstr "Keine Vorlage"
 
 #. Width
-#: ../src/widgets/calligraphy-toolbar.cpp:427
-#: ../src/widgets/eraser-toolbar.cpp:184
+#: ../src/widgets/calligraphy-toolbar.cpp:398
+#: ../src/widgets/eraser-toolbar.cpp:188
 msgid "(hairline)"
 msgstr "(Haarline)"
 
 #. Mean
 #. Rotation
 #. Scale
-#: ../src/widgets/calligraphy-toolbar.cpp:427
-#: ../src/widgets/calligraphy-toolbar.cpp:460
-#: ../src/widgets/eraser-toolbar.cpp:184 ../src/widgets/pencil-toolbar.cpp:374
+#: ../src/widgets/calligraphy-toolbar.cpp:398
+#: ../src/widgets/calligraphy-toolbar.cpp:431
+#: ../src/widgets/eraser-toolbar.cpp:188 ../src/widgets/pencil-toolbar.cpp:532
 #: ../src/widgets/spray-toolbar.cpp:294 ../src/widgets/spray-toolbar.cpp:323
-#: ../src/widgets/spray-toolbar.cpp:339 ../src/widgets/spray-toolbar.cpp:408
-#: ../src/widgets/spray-toolbar.cpp:438 ../src/widgets/spray-toolbar.cpp:456
-#: ../src/widgets/spray-toolbar.cpp:605 ../src/widgets/tweak-toolbar.cpp:125
+#: ../src/widgets/spray-toolbar.cpp:339 ../src/widgets/spray-toolbar.cpp:406
+#: ../src/widgets/spray-toolbar.cpp:436 ../src/widgets/spray-toolbar.cpp:454
+#: ../src/widgets/spray-toolbar.cpp:603 ../src/widgets/tweak-toolbar.cpp:125
 #: ../src/widgets/tweak-toolbar.cpp:142 ../src/widgets/tweak-toolbar.cpp:350
 msgid "(default)"
 msgstr "(Standard)"
 
-#: ../src/widgets/calligraphy-toolbar.cpp:427
-#: ../src/widgets/eraser-toolbar.cpp:184
+#: ../src/widgets/calligraphy-toolbar.cpp:398
+#: ../src/widgets/eraser-toolbar.cpp:188
 msgid "(broad stroke)"
 msgstr "(breiter Strich)"
 
-#: ../src/widgets/calligraphy-toolbar.cpp:430
-#: ../src/widgets/eraser-toolbar.cpp:187
+#: ../src/widgets/calligraphy-toolbar.cpp:401
+#: ../src/widgets/eraser-toolbar.cpp:191
 msgid "Pen Width"
 msgstr "Stiftbreite"
 
-#: ../src/widgets/calligraphy-toolbar.cpp:431
+#: ../src/widgets/calligraphy-toolbar.cpp:402
 msgid "The width of the calligraphic pen (relative to the visible canvas area)"
 msgstr ""
 "Breite des kalligrafischen Füllers (relativ zur sichtbaren Arbeitsfläche)"
 
 #. Thinning
-#: ../src/widgets/calligraphy-toolbar.cpp:444
-#: ../src/widgets/eraser-toolbar.cpp:214
+#: ../src/widgets/calligraphy-toolbar.cpp:415
+#: ../src/widgets/eraser-toolbar.cpp:221
 msgid "(speed blows up stroke)"
 msgstr "(Geschwindigkeit verdickt Strich)"
 
-#: ../src/widgets/calligraphy-toolbar.cpp:444
-#: ../src/widgets/eraser-toolbar.cpp:214
+#: ../src/widgets/calligraphy-toolbar.cpp:415
+#: ../src/widgets/eraser-toolbar.cpp:221
 msgid "(slight widening)"
 msgstr "(schwache Verdickung)"
 
-#: ../src/widgets/calligraphy-toolbar.cpp:444
-#: ../src/widgets/eraser-toolbar.cpp:214
+#: ../src/widgets/calligraphy-toolbar.cpp:415
+#: ../src/widgets/eraser-toolbar.cpp:221
 msgid "(constant width)"
 msgstr "(konstante Breite)"
 
-#: ../src/widgets/calligraphy-toolbar.cpp:444
-#: ../src/widgets/eraser-toolbar.cpp:214
+#: ../src/widgets/calligraphy-toolbar.cpp:415
+#: ../src/widgets/eraser-toolbar.cpp:221
 msgid "(slight thinning, default)"
 msgstr "(schwache Ausdünnung, Standard)"
 
-#: ../src/widgets/calligraphy-toolbar.cpp:444
-#: ../src/widgets/eraser-toolbar.cpp:214
+#: ../src/widgets/calligraphy-toolbar.cpp:415
+#: ../src/widgets/eraser-toolbar.cpp:221
 msgid "(speed deflates stroke)"
 msgstr "(Geschwindigkeit dünnt Strich aus)"
 
-#: ../src/widgets/calligraphy-toolbar.cpp:447
+#: ../src/widgets/calligraphy-toolbar.cpp:418
 msgid "Stroke Thinning"
 msgstr "Strichstärke verringern"
 
-#: ../src/widgets/calligraphy-toolbar.cpp:447
-#: ../src/widgets/eraser-toolbar.cpp:217
+#: ../src/widgets/calligraphy-toolbar.cpp:418
+#: ../src/widgets/eraser-toolbar.cpp:224
 msgid "Thinning:"
 msgstr "Ausdünnung:"
 
-#: ../src/widgets/calligraphy-toolbar.cpp:448
-#: ../src/widgets/eraser-toolbar.cpp:218
+#: ../src/widgets/calligraphy-toolbar.cpp:419
+#: ../src/widgets/eraser-toolbar.cpp:225
 msgid ""
 "How much velocity thins the stroke (> 0 makes fast strokes thinner, < 0 "
 "makes them broader, 0 makes width independent of velocity)"
@@ -29795,28 +30170,28 @@ msgstr ""
 "Strichzüge dünner, < 0 breiter, 0 unabhängig von der Geschwindigkeit)"
 
 #. Angle
-#: ../src/widgets/calligraphy-toolbar.cpp:460
+#: ../src/widgets/calligraphy-toolbar.cpp:431
 msgid "(left edge up)"
 msgstr "(linke Kante oben)"
 
-#: ../src/widgets/calligraphy-toolbar.cpp:460
+#: ../src/widgets/calligraphy-toolbar.cpp:431
 msgid "(horizontal)"
 msgstr "(horizontal)"
 
-#: ../src/widgets/calligraphy-toolbar.cpp:460
+#: ../src/widgets/calligraphy-toolbar.cpp:431
 msgid "(right edge up)"
 msgstr "(rechte Kante oben)"
 
-#: ../src/widgets/calligraphy-toolbar.cpp:463
+#: ../src/widgets/calligraphy-toolbar.cpp:434
 msgid "Pen Angle"
 msgstr "Stiftwinkel"
 
-#: ../src/widgets/calligraphy-toolbar.cpp:463
+#: ../src/widgets/calligraphy-toolbar.cpp:434
 #: ../share/extensions/motion.inx.h:3 ../share/extensions/restack.inx.h:5
 msgid "Angle:"
 msgstr "Winkel:"
 
-#: ../src/widgets/calligraphy-toolbar.cpp:464
+#: ../src/widgets/calligraphy-toolbar.cpp:435
 msgid ""
 "The angle of the pen's nib (in degrees; 0 = horizontal; has no effect if "
 "fixation = 0)"
@@ -29825,27 +30200,27 @@ msgstr ""
 "Fixierung: 0)"
 
 #. Fixation
-#: ../src/widgets/calligraphy-toolbar.cpp:478
+#: ../src/widgets/calligraphy-toolbar.cpp:449
 msgid "(perpendicular to stroke, \"brush\")"
 msgstr "(senkrecht zum Strich, \"Pinsel\")"
 
-#: ../src/widgets/calligraphy-toolbar.cpp:478
+#: ../src/widgets/calligraphy-toolbar.cpp:449
 msgid "(almost fixed, default)"
 msgstr "(fast fixiert, Standard)"
 
-#: ../src/widgets/calligraphy-toolbar.cpp:478
+#: ../src/widgets/calligraphy-toolbar.cpp:449
 msgid "(fixed by Angle, \"pen\")"
 msgstr "(fixiert mit Winkel, \"Stift\")"
 
-#: ../src/widgets/calligraphy-toolbar.cpp:481
+#: ../src/widgets/calligraphy-toolbar.cpp:452
 msgid "Fixation"
 msgstr "Fixierung"
 
-#: ../src/widgets/calligraphy-toolbar.cpp:481
+#: ../src/widgets/calligraphy-toolbar.cpp:452
 msgid "Fixation:"
 msgstr "Fixierung:"
 
-#: ../src/widgets/calligraphy-toolbar.cpp:482
+#: ../src/widgets/calligraphy-toolbar.cpp:453
 msgid ""
 "Angle behavior (0 = nib always perpendicular to stroke direction, 100 = "
 "fixed angle)"
@@ -29854,38 +30229,38 @@ msgstr ""
 "Winkel)"
 
 #. Cap Rounding
-#: ../src/widgets/calligraphy-toolbar.cpp:494
-#: ../src/widgets/eraser-toolbar.cpp:230
+#: ../src/widgets/calligraphy-toolbar.cpp:465
+#: ../src/widgets/eraser-toolbar.cpp:239
 msgid "(blunt caps, default)"
 msgstr "(stumpfe Enden, Standard)"
 
-#: ../src/widgets/calligraphy-toolbar.cpp:494
-#: ../src/widgets/eraser-toolbar.cpp:230
+#: ../src/widgets/calligraphy-toolbar.cpp:465
+#: ../src/widgets/eraser-toolbar.cpp:239
 msgid "(slightly bulging)"
 msgstr "(leicht wölbend)"
 
-#: ../src/widgets/calligraphy-toolbar.cpp:494
-#: ../src/widgets/eraser-toolbar.cpp:230
+#: ../src/widgets/calligraphy-toolbar.cpp:465
+#: ../src/widgets/eraser-toolbar.cpp:239
 msgid "(approximately round)"
 msgstr "(ungefähr rund)"
 
-#: ../src/widgets/calligraphy-toolbar.cpp:494
-#: ../src/widgets/eraser-toolbar.cpp:230
+#: ../src/widgets/calligraphy-toolbar.cpp:465
+#: ../src/widgets/eraser-toolbar.cpp:239
 msgid "(long protruding caps)"
 msgstr "(lange hervorstehende Enden)"
 
-#: ../src/widgets/calligraphy-toolbar.cpp:498
+#: ../src/widgets/calligraphy-toolbar.cpp:469
 msgid "Cap rounding"
 msgstr "Spitzen abrunden"
 
-#: ../src/widgets/calligraphy-toolbar.cpp:498
-#: ../src/widgets/eraser-toolbar.cpp:234
+#: ../src/widgets/calligraphy-toolbar.cpp:469
+#: ../src/widgets/eraser-toolbar.cpp:243
 msgid "Caps:"
 msgstr "Linienenden:"
 
 # !!! check
-#: ../src/widgets/calligraphy-toolbar.cpp:499
-#: ../src/widgets/eraser-toolbar.cpp:235
+#: ../src/widgets/calligraphy-toolbar.cpp:470
+#: ../src/widgets/eraser-toolbar.cpp:244
 msgid ""
 "Increase to make caps at the ends of strokes protrude more (0 = no caps, 1 = "
 "round caps)"
@@ -29894,105 +30269,105 @@ msgstr ""
 "Abschluss, 1 = runder Abschluss)"
 
 #. Tremor
-#: ../src/widgets/calligraphy-toolbar.cpp:511
-#: ../src/widgets/eraser-toolbar.cpp:248
+#: ../src/widgets/calligraphy-toolbar.cpp:482
+#: ../src/widgets/eraser-toolbar.cpp:258
 msgid "(smooth line)"
 msgstr "(glatte Linie)"
 
-#: ../src/widgets/calligraphy-toolbar.cpp:511
-#: ../src/widgets/eraser-toolbar.cpp:248
+#: ../src/widgets/calligraphy-toolbar.cpp:482
+#: ../src/widgets/eraser-toolbar.cpp:258
 msgid "(slight tremor)"
 msgstr "(leichtes Zittern)"
 
-#: ../src/widgets/calligraphy-toolbar.cpp:511
-#: ../src/widgets/eraser-toolbar.cpp:248
+#: ../src/widgets/calligraphy-toolbar.cpp:482
+#: ../src/widgets/eraser-toolbar.cpp:258
 msgid "(noticeable tremor)"
 msgstr "(deutliches Zittern)"
 
-#: ../src/widgets/calligraphy-toolbar.cpp:511
-#: ../src/widgets/eraser-toolbar.cpp:248
+#: ../src/widgets/calligraphy-toolbar.cpp:482
+#: ../src/widgets/eraser-toolbar.cpp:258
 msgid "(maximum tremor)"
 msgstr "(maximales Zittern)"
 
-#: ../src/widgets/calligraphy-toolbar.cpp:514
+#: ../src/widgets/calligraphy-toolbar.cpp:485
 msgid "Stroke Tremor"
 msgstr "Zittern der Linie"
 
-#: ../src/widgets/calligraphy-toolbar.cpp:514
-#: ../src/widgets/eraser-toolbar.cpp:251
+#: ../src/widgets/calligraphy-toolbar.cpp:485
+#: ../src/widgets/eraser-toolbar.cpp:261
 msgid "Tremor:"
 msgstr "Zittern:"
 
-#: ../src/widgets/calligraphy-toolbar.cpp:515
-#: ../src/widgets/eraser-toolbar.cpp:252
+#: ../src/widgets/calligraphy-toolbar.cpp:486
+#: ../src/widgets/eraser-toolbar.cpp:262
 msgid "Increase to make strokes rugged and trembling"
 msgstr "Erhöhen, um Striche zittrig und ausgefranst zu machen"
 
 #. Wiggle
-#: ../src/widgets/calligraphy-toolbar.cpp:529
+#: ../src/widgets/calligraphy-toolbar.cpp:500
 msgid "(no wiggle)"
 msgstr "(kein Wackeln)"
 
-#: ../src/widgets/calligraphy-toolbar.cpp:529
+#: ../src/widgets/calligraphy-toolbar.cpp:500
 msgid "(slight deviation)"
 msgstr "(leichte Abweichung)"
 
-#: ../src/widgets/calligraphy-toolbar.cpp:529
+#: ../src/widgets/calligraphy-toolbar.cpp:500
 msgid "(wild waves and curls)"
 msgstr "(wilde Wellen und Kringel)"
 
-#: ../src/widgets/calligraphy-toolbar.cpp:532
+#: ../src/widgets/calligraphy-toolbar.cpp:503
 msgid "Pen Wiggle"
 msgstr "Stift Verwackeln:"
 
-#: ../src/widgets/calligraphy-toolbar.cpp:532
+#: ../src/widgets/calligraphy-toolbar.cpp:503
 msgid "Wiggle:"
 msgstr "Wackeln:"
 
-#: ../src/widgets/calligraphy-toolbar.cpp:533
+#: ../src/widgets/calligraphy-toolbar.cpp:504
 msgid "Increase to make the pen waver and wiggle"
 msgstr "Erhöhen, um den Füller wacklig zu machen"
 
 #. Mass
-#: ../src/widgets/calligraphy-toolbar.cpp:546
-#: ../src/widgets/eraser-toolbar.cpp:266
+#: ../src/widgets/calligraphy-toolbar.cpp:517
+#: ../src/widgets/eraser-toolbar.cpp:278
 msgid "(no inertia)"
 msgstr "(keine Trägheit)"
 
-#: ../src/widgets/calligraphy-toolbar.cpp:546
-#: ../src/widgets/eraser-toolbar.cpp:266
+#: ../src/widgets/calligraphy-toolbar.cpp:517
+#: ../src/widgets/eraser-toolbar.cpp:278
 msgid "(slight smoothing, default)"
 msgstr "(leichte Glättung, Standard)"
 
-#: ../src/widgets/calligraphy-toolbar.cpp:546
-#: ../src/widgets/eraser-toolbar.cpp:266
+#: ../src/widgets/calligraphy-toolbar.cpp:517
+#: ../src/widgets/eraser-toolbar.cpp:278
 msgid "(noticeable lagging)"
 msgstr "(deutliches Hinterherschleppen)"
 
-#: ../src/widgets/calligraphy-toolbar.cpp:546
-#: ../src/widgets/eraser-toolbar.cpp:266
+#: ../src/widgets/calligraphy-toolbar.cpp:517
+#: ../src/widgets/eraser-toolbar.cpp:278
 msgid "(maximum inertia)"
 msgstr "(maximale Trägheit)"
 
-#: ../src/widgets/calligraphy-toolbar.cpp:549
+#: ../src/widgets/calligraphy-toolbar.cpp:520
 msgid "Pen Mass"
 msgstr "Stiftmasse:"
 
-#: ../src/widgets/calligraphy-toolbar.cpp:549
-#: ../src/widgets/eraser-toolbar.cpp:269
+#: ../src/widgets/calligraphy-toolbar.cpp:520
+#: ../src/widgets/eraser-toolbar.cpp:281
 msgid "Mass:"
 msgstr "Masse:"
 
-#: ../src/widgets/calligraphy-toolbar.cpp:550
+#: ../src/widgets/calligraphy-toolbar.cpp:521
 msgid "Increase to make the pen drag behind, as if slowed by inertia"
 msgstr "Erhöhen, um den Füller nachzuschleppen, wie durch Trägheit verlangsamt"
 
 # !!!
-#: ../src/widgets/calligraphy-toolbar.cpp:565
+#: ../src/widgets/calligraphy-toolbar.cpp:536
 msgid "Trace Background"
 msgstr "Hintergrund nachzeichnen"
 
-#: ../src/widgets/calligraphy-toolbar.cpp:566
+#: ../src/widgets/calligraphy-toolbar.cpp:537
 msgid ""
 "Trace the lightness of the background by the width of the pen (white - "
 "minimum width, black - maximum width)"
@@ -30000,32 +30375,34 @@ msgstr ""
 "Der Helligkeit des Hintergrunds mit der Breite des Stifts nachzeichnen (weiß "
 "- minimale Breite, schwarz - maximale Breite)"
 
-#: ../src/widgets/calligraphy-toolbar.cpp:579
-#: ../src/widgets/eraser-toolbar.cpp:203
+#: ../src/widgets/calligraphy-toolbar.cpp:550
+#: ../src/widgets/eraser-toolbar.cpp:209
 msgid "Use the pressure of the input device to alter the width of the pen"
 msgstr ""
 "Druckempfindlichkeit des Eingabegeräts benutzen, um die Strichbreite des "
 "Füllers zu beeinflussen"
 
-#: ../src/widgets/calligraphy-toolbar.cpp:591
+#: ../src/widgets/calligraphy-toolbar.cpp:562
 msgid "Tilt"
 msgstr "Neigung"
 
-#: ../src/widgets/calligraphy-toolbar.cpp:592
+#: ../src/widgets/calligraphy-toolbar.cpp:563
 msgid "Use the tilt of the input device to alter the angle of the pen's nib"
 msgstr ""
 "Neigungsempfindlichkeit des Eingabegeräts benutzen, um den Winkel der "
 "Füllerspitze zu beeinflussen"
 
-#: ../src/widgets/calligraphy-toolbar.cpp:607
+#. Name
+#. Label
+#: ../src/widgets/calligraphy-toolbar.cpp:584
 msgid "Choose a preset"
 msgstr "Wählen Sie eine Vorlage"
 
-#: ../src/widgets/calligraphy-toolbar.cpp:622
+#: ../src/widgets/calligraphy-toolbar.cpp:602
 msgid "Add/Edit Profile"
 msgstr "Profil hinzufügen oder editieren"
 
-#: ../src/widgets/calligraphy-toolbar.cpp:623
+#: ../src/widgets/calligraphy-toolbar.cpp:603
 msgid "Add or edit calligraphic profile"
 msgstr "Kalligrafisches Profil hinzufügen oder editieren"
 
@@ -30045,72 +30422,72 @@ msgstr "Krümmung der Objektverbinder ändern"
 msgid "Change connector spacing"
 msgstr "Abstand der Objektverbinder ändern"
 
-#: ../src/widgets/connector-toolbar.cpp:306
+#: ../src/widgets/connector-toolbar.cpp:309
 msgid "Avoid"
 msgstr "Ausweichen"
 
 # Related to 'Make connectors ignore selected objects'
-#: ../src/widgets/connector-toolbar.cpp:316
+#: ../src/widgets/connector-toolbar.cpp:319
 msgid "Ignore"
 msgstr "Ignorieren"
 
-#: ../src/widgets/connector-toolbar.cpp:327
+#: ../src/widgets/connector-toolbar.cpp:330
 msgid "Orthogonal"
 msgstr "Orthogonal"
 
-#: ../src/widgets/connector-toolbar.cpp:328
+#: ../src/widgets/connector-toolbar.cpp:331
 msgid "Make connector orthogonal or polyline"
 msgstr "Erstelle den Verbinder winkelrecht oder als Polylinie"
 
-#: ../src/widgets/connector-toolbar.cpp:342
+#: ../src/widgets/connector-toolbar.cpp:345
 msgid "Connector Curvature"
 msgstr "Krümmung der Objektverbinder"
 
-#: ../src/widgets/connector-toolbar.cpp:342
+#: ../src/widgets/connector-toolbar.cpp:345
 msgid "Curvature:"
 msgstr "Krümmung"
 
-#: ../src/widgets/connector-toolbar.cpp:343
+#: ../src/widgets/connector-toolbar.cpp:346
 msgid "The amount of connectors curvature"
 msgstr "Der Krümmungswert der Verbindungslinie"
 
-#: ../src/widgets/connector-toolbar.cpp:353
+#: ../src/widgets/connector-toolbar.cpp:356
 msgid "Connector Spacing"
 msgstr "Verbinderabstand"
 
-#: ../src/widgets/connector-toolbar.cpp:353
+#: ../src/widgets/connector-toolbar.cpp:356
 msgid "Spacing:"
 msgstr "Abstand:"
 
-#: ../src/widgets/connector-toolbar.cpp:354
+#: ../src/widgets/connector-toolbar.cpp:357
 msgid "The amount of space left around objects by auto-routing connectors"
 msgstr "Platz, der von den Objektverbindern um Objekte herum gelassen wird"
 
-#: ../src/widgets/connector-toolbar.cpp:365
+#: ../src/widgets/connector-toolbar.cpp:368
 msgid "Graph"
 msgstr "Graph"
 
-#: ../src/widgets/connector-toolbar.cpp:375
+#: ../src/widgets/connector-toolbar.cpp:378
 msgid "Connector Length"
 msgstr "Verbinderlänge"
 
-#: ../src/widgets/connector-toolbar.cpp:375
+#: ../src/widgets/connector-toolbar.cpp:378
 msgid "Length:"
 msgstr "Länge:"
 
-#: ../src/widgets/connector-toolbar.cpp:376
+#: ../src/widgets/connector-toolbar.cpp:379
 msgid "Ideal length for connectors when layout is applied"
 msgstr "Ideale Länge für Objektverbinder wenn das Layout angewendet wird"
 
-#: ../src/widgets/connector-toolbar.cpp:388
+#: ../src/widgets/connector-toolbar.cpp:391
 msgid "Downwards"
 msgstr "Nach unten"
 
-#: ../src/widgets/connector-toolbar.cpp:389
+#: ../src/widgets/connector-toolbar.cpp:392
 msgid "Make connectors with end-markers (arrows) point downwards"
 msgstr "Objektverbinder mit Endemarkierungen (Pfeilen) zeigen nach unten"
 
-#: ../src/widgets/connector-toolbar.cpp:405
+#: ../src/widgets/connector-toolbar.cpp:408
 msgid "Do not allow overlapping shapes"
 msgstr "Keine überlappenden Formen erlauben"
 
@@ -30122,12 +30499,12 @@ msgstr "Muster der Strichlinien"
 msgid "Pattern offset"
 msgstr "Versatz des Musters"
 
-#: ../src/widgets/desktop-widget.cpp:422
+#: ../src/widgets/desktop-widget.cpp:437
 msgid "Zoom drawing if window size changes"
 msgstr "Zeichnungsgröße mit Fenstergröße verändern"
 
 #. Display the initial welcome message in the statusbar
-#: ../src/widgets/desktop-widget.cpp:566
+#: ../src/widgets/desktop-widget.cpp:580
 msgid ""
 "<b>Welcome to Inkscape!</b> Use shape or freehand tools to create objects; "
 "use selector (arrow) to move or transform them."
@@ -30135,53 +30512,53 @@ msgstr ""
 "<b>Willkommen zu Inkscape!</b> Formen- und Freihandwerkzeuge erstellen "
 "Objekte; das Auswahlwerkzeug (Pfeil) verschiebt und bearbeitet."
 
-#: ../src/widgets/desktop-widget.cpp:600
+#: ../src/widgets/desktop-widget.cpp:614
 msgid "Rotation. (Also Ctrl+Shift+Scroll)"
 msgstr ""
 
-#: ../src/widgets/desktop-widget.cpp:634
+#: ../src/widgets/desktop-widget.cpp:648
 msgid "Cursor coordinates"
 msgstr "Zeigerkoordinaten"
 
-#: ../src/widgets/desktop-widget.cpp:646
+#: ../src/widgets/desktop-widget.cpp:660
 msgid "Z:"
 msgstr "Z:"
 
-#: ../src/widgets/desktop-widget.cpp:786
+#: ../src/widgets/desktop-widget.cpp:799
 msgid "outline"
 msgstr "Umriss"
 
-#: ../src/widgets/desktop-widget.cpp:788
+#: ../src/widgets/desktop-widget.cpp:801
 msgid "no filters"
 msgstr "Keine _Filter"
 
-#: ../src/widgets/desktop-widget.cpp:797
+#: ../src/widgets/desktop-widget.cpp:810
 msgid "grayscale"
 msgstr "Graustufen"
 
-#: ../src/widgets/desktop-widget.cpp:799
+#: ../src/widgets/desktop-widget.cpp:812
 msgid "print colors preview"
 msgstr "_Druckfarben-Vorschau"
 
-#: ../src/widgets/desktop-widget.cpp:999
+#: ../src/widgets/desktop-widget.cpp:1012
 msgid "Locked all guides"
 msgstr "Alle Hilfslinien gesperrt"
 
-#: ../src/widgets/desktop-widget.cpp:1001
+#: ../src/widgets/desktop-widget.cpp:1014
 msgid "Unlocked all guides"
 msgstr "Alle Hilfslinien entsperrt"
 
 # ???
-#: ../src/widgets/desktop-widget.cpp:1018
+#: ../src/widgets/desktop-widget.cpp:1031
 msgid "Color-managed display is <b>enabled</b> in this window"
 msgstr "Farbverwaltungsansicht ist in diesem Fenster <b>aktiviert</b>"
 
 # ???
-#: ../src/widgets/desktop-widget.cpp:1020
+#: ../src/widgets/desktop-widget.cpp:1033
 msgid "Color-managed display is <b>disabled</b> in this window"
 msgstr "Farbverwaltungsansicht ist in diesem Fenster <b>deaktiviert</b>"
 
-#: ../src/widgets/desktop-widget.cpp:1075
+#: ../src/widgets/desktop-widget.cpp:1088
 #, c-format
 msgid ""
 "<span weight=\"bold\" size=\"larger\">Save changes to document \"%s\" before "
@@ -30194,12 +30571,12 @@ msgstr ""
 "\n"
 "Wenn Sie schließen, ohne zu speichern, dann gehen Ihre Änderungen verloren."
 
-#: ../src/widgets/desktop-widget.cpp:1085
-#: ../src/widgets/desktop-widget.cpp:1144
+#: ../src/widgets/desktop-widget.cpp:1098
+#: ../src/widgets/desktop-widget.cpp:1157
 msgid "Close _without saving"
 msgstr "Schließen, _ohne zu speichern"
 
-#: ../src/widgets/desktop-widget.cpp:1134
+#: ../src/widgets/desktop-widget.cpp:1147
 #, c-format
 msgid ""
 "<span weight=\"bold\" size=\"larger\">The file \"%s\" was saved with a "
@@ -30212,12 +30589,12 @@ msgstr ""
 "\n"
 "Möchten Sie das Dokument als Inkscape-SVG speichern?"
 
-#: ../src/widgets/desktop-widget.cpp:1146
+#: ../src/widgets/desktop-widget.cpp:1159
 msgid "_Save as Inkscape SVG"
 msgstr "Als Inkscape-_SVG speichern"
 
 # CHECK
-#: ../src/widgets/desktop-widget.cpp:1360
+#: ../src/widgets/desktop-widget.cpp:1373
 msgid "Note:"
 msgstr "Hinweis:"
 
@@ -30256,68 +30633,68 @@ msgstr "Zuweisen"
 msgid "remove"
 msgstr "entfernen"
 
-#: ../src/widgets/eraser-toolbar.cpp:146
-msgid "Delete objects touched by the eraser"
+#: ../src/widgets/eraser-toolbar.cpp:152
+#, fuzzy
+msgid "Delete objects touched by eraser"
 msgstr "Lösche Objekte, die vom Radierer berührt werden"
 
-#: ../src/widgets/eraser-toolbar.cpp:152
+#: ../src/widgets/eraser-toolbar.cpp:157
 msgid "Cut"
 msgstr "A_usschneiden"
 
-#: ../src/widgets/eraser-toolbar.cpp:153
+#: ../src/widgets/eraser-toolbar.cpp:158
 #, fuzzy
 msgid "Cut out from paths and shapes"
 msgstr "Untenliegenden Pfad in Teile zerschneiden"
 
-#: ../src/widgets/eraser-toolbar.cpp:159
+#: ../src/widgets/eraser-toolbar.cpp:163
 #, fuzzy
 msgid "Clip"
 msgstr "Beschneide zu:"
 
-#: ../src/widgets/eraser-toolbar.cpp:160
+#: ../src/widgets/eraser-toolbar.cpp:164
 #, fuzzy
 msgid "Clip from objects"
 msgstr "Aus Objekt herausschneiden"
 
-#. Width
-#: ../src/widgets/eraser-toolbar.cpp:184
+#: ../src/widgets/eraser-toolbar.cpp:188
 msgid "(no width)"
 msgstr "(Nullbreite) "
 
-#: ../src/widgets/eraser-toolbar.cpp:188
+#: ../src/widgets/eraser-toolbar.cpp:192
 msgid "The width of the eraser pen (relative to the visible canvas area)"
 msgstr "Die Größe des Radierers (relativ zur sichtbaren Arbeitsfläche)"
 
-#: ../src/widgets/eraser-toolbar.cpp:202
+#: ../src/widgets/eraser-toolbar.cpp:208
 #, fuzzy
 msgid "Eraser Pressure"
 msgstr "Einstellungen für das Löschwerkzeug"
 
-#: ../src/widgets/eraser-toolbar.cpp:217
+#: ../src/widgets/eraser-toolbar.cpp:224
 #, fuzzy
 msgid "Eraser Stroke Thinning"
 msgstr "Strichstärke verringern"
 
-#: ../src/widgets/eraser-toolbar.cpp:234
+#: ../src/widgets/eraser-toolbar.cpp:243
 #, fuzzy
 msgid "Eraser Cap rounding"
 msgstr "Spitzen abrunden"
 
-#: ../src/widgets/eraser-toolbar.cpp:251
+#: ../src/widgets/eraser-toolbar.cpp:261
 #, fuzzy
 msgid "EraserStroke Tremor"
 msgstr "Zittern der Linie"
 
-#: ../src/widgets/eraser-toolbar.cpp:269
+#: ../src/widgets/eraser-toolbar.cpp:281
 msgid "Eraser Mass"
 msgstr "Masse des Radierers"
 
-#: ../src/widgets/eraser-toolbar.cpp:270
+#: ../src/widgets/eraser-toolbar.cpp:282
 msgid "Increase to make the eraser drag behind, as if slowed by inertia"
 msgstr ""
 "Erhöhen, um den Radierer nachzuschleppen, wie durch Trägheit verlangsamt"
 
-#: ../src/widgets/eraser-toolbar.cpp:284 ../src/widgets/eraser-toolbar.cpp:285
+#: ../src/widgets/eraser-toolbar.cpp:298 ../src/widgets/eraser-toolbar.cpp:299
 msgid "Break apart cut items"
 msgstr "Aufgetrennte Objekte zerlegen"
 
@@ -30357,67 +30734,67 @@ msgstr "Muster für die Füllung setzen"
 msgid "Set pattern on stroke"
 msgstr "Muster für die Kontur setzen"
 
-#: ../src/widgets/font-selector.cpp:103 ../src/widgets/text-toolbar.cpp:1366
-#: ../src/widgets/text-toolbar.cpp:1738
+#: ../src/widgets/font-selector.cpp:101 ../src/widgets/text-toolbar.cpp:1583
+#: ../src/widgets/text-toolbar.cpp:2040
 msgid "Font size"
 msgstr "Schriftgröße"
 
 #. gtk_box_set_homogeneous(GTK_BOX(fsel), TRUE);
 #. gtk_box_set_spacing(GTK_BOX(fsel), 4);
 #. Family frame
-#: ../src/widgets/font-selector.cpp:117
+#: ../src/widgets/font-selector.cpp:115
 msgid "Font family"
 msgstr "Schriftfamilie"
 
 #. Style frame
-#: ../src/widgets/font-selector.cpp:166
+#: ../src/widgets/font-selector.cpp:164
 msgctxt "Font selector"
 msgid "Style"
 msgstr "Stil"
 
 # !!!
-#: ../src/widgets/font-selector.cpp:194
+#: ../src/widgets/font-selector.cpp:192
 msgid "Face"
 msgstr "Schnitt"
 
-#: ../src/widgets/font-selector.cpp:219 ../share/extensions/dots.inx.h:3
+#: ../src/widgets/font-selector.cpp:217 ../share/extensions/dots.inx.h:3
 #: ../share/extensions/nicechart.inx.h:17
 msgid "Font size:"
 msgstr "Schriftgröße:"
 
-#: ../src/widgets/gimp/ruler.cpp:185
+#: ../src/widgets/gimp/ruler.cpp:188
 msgid "The orientation of the ruler"
 msgstr "Die Ausrichtung des Lineals"
 
-#: ../src/widgets/gimp/ruler.cpp:195
+#: ../src/widgets/gimp/ruler.cpp:198
 msgid "Unit of the ruler"
 msgstr "Einheit des Lineals"
 
-#: ../src/widgets/gimp/ruler.cpp:202
+#: ../src/widgets/gimp/ruler.cpp:205
 msgid "Lower"
 msgstr "Untere"
 
-#: ../src/widgets/gimp/ruler.cpp:203
+#: ../src/widgets/gimp/ruler.cpp:206
 msgid "Lower limit of ruler"
 msgstr "Untergrenze des Lineals"
 
-#: ../src/widgets/gimp/ruler.cpp:212
+#: ../src/widgets/gimp/ruler.cpp:215
 msgid "Upper"
 msgstr "Obere"
 
-#: ../src/widgets/gimp/ruler.cpp:213
+#: ../src/widgets/gimp/ruler.cpp:216
 msgid "Upper limit of ruler"
 msgstr "Obergrenze des Lineals"
 
-#: ../src/widgets/gimp/ruler.cpp:223
+#: ../src/widgets/gimp/ruler.cpp:226
 msgid "Position of mark on the ruler"
 msgstr "Position der Markierung auf dem Lineal"
 
-#: ../src/widgets/gimp/ruler.cpp:232
+#: ../src/widgets/gimp/ruler.cpp:235
 msgid "Max Size"
 msgstr "Maximale Größe"
 
-#: ../src/widgets/gimp/ruler.cpp:233
+#: ../src/widgets/gimp/ruler.cpp:236
 msgid "Maximum size of the ruler"
 msgstr "Maximalgröße des Lineals"
 
@@ -30430,7 +30807,7 @@ msgid "Edit gradient"
 msgstr "Farbverlauf bearbeiten"
 
 #: ../src/widgets/gradient-selector.cpp:266
-#: ../src/widgets/paint-selector.cpp:221
+#: ../src/widgets/paint-selector.cpp:223
 msgid "Swatch"
 msgstr "Farbmuster"
 
@@ -30438,112 +30815,103 @@ msgstr "Farbmuster"
 msgid "Rename gradient"
 msgstr "Farbverlauf umbenennen"
 
-#: ../src/widgets/gradient-toolbar.cpp:157
-#: ../src/widgets/gradient-toolbar.cpp:170
-#: ../src/widgets/gradient-toolbar.cpp:759
-#: ../src/widgets/gradient-toolbar.cpp:1098
+#: ../src/widgets/gradient-toolbar.cpp:139
+#: ../src/widgets/gradient-toolbar.cpp:159
+#: ../src/widgets/gradient-toolbar.cpp:535
+#: ../src/widgets/gradient-toolbar.cpp:938
 msgid "No gradient"
 msgstr "Kein Farbverlauf"
 
-#: ../src/widgets/gradient-toolbar.cpp:177
+#: ../src/widgets/gradient-toolbar.cpp:149
+#, fuzzy
+msgid "Nothing Selected"
+msgstr "Nichts ausgewählt"
+
+#: ../src/widgets/gradient-toolbar.cpp:168
 msgid "Multiple gradients"
 msgstr "Mehrfache Farbverläufe"
 
-#: ../src/widgets/gradient-toolbar.cpp:679
-msgid "Multiple stops"
-msgstr "Mehrere Zwischenfarben"
-
-#: ../src/widgets/gradient-toolbar.cpp:777
-#: ../src/widgets/gradient-vector.cpp:578
+#: ../src/widgets/gradient-toolbar.cpp:545
+#: ../src/widgets/gradient-vector.cpp:562
 msgid "No stops in gradient"
 msgstr "Keine Zwischenfarben im Farbverlauf"
 
-#: ../src/widgets/gradient-toolbar.cpp:931
+#: ../src/widgets/gradient-toolbar.cpp:659
+msgid "Multiple stops"
+msgstr "Mehrere Zwischenfarben"
+
+#: ../src/widgets/gradient-toolbar.cpp:742
 msgid "Assign gradient to object"
 msgstr "Farbverlauf einem Objekt zuweisen"
 
-#: ../src/widgets/gradient-toolbar.cpp:953
+#: ../src/widgets/gradient-toolbar.cpp:770
 msgid "Set gradient repeat"
 msgstr "Setze Verlaufswiederholung"
 
-#: ../src/widgets/gradient-toolbar.cpp:991
-#: ../src/widgets/gradient-vector.cpp:691
+#: ../src/widgets/gradient-toolbar.cpp:833
+#: ../src/widgets/gradient-vector.cpp:670
 msgid "Change gradient stop offset"
 msgstr "Versatz der Zwischenfarben des Farbverlaufs ändern"
 
-#: ../src/widgets/gradient-toolbar.cpp:1038
+#: ../src/widgets/gradient-toolbar.cpp:862
 msgid "linear"
 msgstr "linear"
 
-#: ../src/widgets/gradient-toolbar.cpp:1038
+#: ../src/widgets/gradient-toolbar.cpp:863
 msgid "Create linear gradient"
 msgstr "Linearen Farbverlauf erzeugen"
 
-#: ../src/widgets/gradient-toolbar.cpp:1042
+#: ../src/widgets/gradient-toolbar.cpp:868
 msgid "radial"
 msgstr "radial"
 
-#: ../src/widgets/gradient-toolbar.cpp:1042
+#: ../src/widgets/gradient-toolbar.cpp:869
 msgid "Create radial (elliptic or circular) gradient"
 msgstr "Radialen (elliptischen oder kreisförmigen) Farbverlauf erzeugen"
 
-#: ../src/widgets/gradient-toolbar.cpp:1045 ../src/widgets/mesh-toolbar.cpp:396
-msgid "New:"
-msgstr "Neu:"
-
-#: ../src/widgets/gradient-toolbar.cpp:1068 ../src/widgets/mesh-toolbar.cpp:419
+#: ../src/widgets/gradient-toolbar.cpp:900 ../src/widgets/mesh-toolbar.cpp:423
 msgid "fill"
 msgstr "füllen"
 
-#: ../src/widgets/gradient-toolbar.cpp:1068 ../src/widgets/mesh-toolbar.cpp:419
+#: ../src/widgets/gradient-toolbar.cpp:901 ../src/widgets/mesh-toolbar.cpp:424
 msgid "Create gradient in the fill"
 msgstr "Farbverlauf für die Füllung erzeugen"
 
-#: ../src/widgets/gradient-toolbar.cpp:1072 ../src/widgets/mesh-toolbar.cpp:423
+#: ../src/widgets/gradient-toolbar.cpp:906 ../src/widgets/mesh-toolbar.cpp:429
 msgid "stroke"
 msgstr "Kontur"
 
-#: ../src/widgets/gradient-toolbar.cpp:1072 ../src/widgets/mesh-toolbar.cpp:423
+#: ../src/widgets/gradient-toolbar.cpp:907 ../src/widgets/mesh-toolbar.cpp:430
 msgid "Create gradient in the stroke"
 msgstr "Farbverlauf für die Kontur erzeugen"
 
-# CHECK
-#: ../src/widgets/gradient-toolbar.cpp:1075 ../src/widgets/mesh-toolbar.cpp:426
-msgid "on:"
-msgstr "auf:"
-
-#: ../src/widgets/gradient-toolbar.cpp:1100
+#. Name
+#: ../src/widgets/gradient-toolbar.cpp:945
 msgid "Select"
 msgstr "Auswählen"
 
-#: ../src/widgets/gradient-toolbar.cpp:1100
-msgid "Choose a gradient"
-msgstr "Wählen Sie einen Verlauf"
-
-#: ../src/widgets/gradient-toolbar.cpp:1101
-msgid "Select:"
-msgstr "Auswählen:"
-
 # CHECK
-#: ../src/widgets/gradient-toolbar.cpp:1116
+#: ../src/widgets/gradient-toolbar.cpp:972
 msgctxt "Gradient repeat type"
 msgid "None"
 msgstr "Keine"
 
-#: ../src/widgets/gradient-toolbar.cpp:1119
+#: ../src/widgets/gradient-toolbar.cpp:978
 msgid "Reflected"
 msgstr "Reflektierend"
 
-#: ../src/widgets/gradient-toolbar.cpp:1122
+#: ../src/widgets/gradient-toolbar.cpp:984
 msgid "Direct"
 msgstr "Direkt"
 
-#: ../src/widgets/gradient-toolbar.cpp:1124
+#. Name
+#: ../src/widgets/gradient-toolbar.cpp:991
 msgid "Repeat"
 msgstr "Wiederholen"
 
+#. Label
 #. TRANSLATORS: for info, see http://www.w3.org/TR/2000/CR-SVG-20000802/pservers.html#LinearGradientSpreadMethodAttribute
-#: ../src/widgets/gradient-toolbar.cpp:1126
+#: ../src/widgets/gradient-toolbar.cpp:993
 msgid ""
 "Whether to fill with flat color beyond the ends of the gradient vector "
 "(spreadMethod=\"pad\"), or repeat the gradient in the same direction "
@@ -30555,97 +30923,86 @@ msgstr ""
 "Richtung (spreadMethod=\"repeat\"), oder Wiederholung in abwechselnd "
 "entgegengesetzte Richtungen (spreadMethod=\"reflect\")"
 
-#: ../src/widgets/gradient-toolbar.cpp:1131
-msgid "Repeat:"
-msgstr "Wiederholung:"
-
-#: ../src/widgets/gradient-toolbar.cpp:1145
+#: ../src/widgets/gradient-toolbar.cpp:1020
 msgid "No stops"
 msgstr "Keine Zwischenfarben"
 
-#: ../src/widgets/gradient-toolbar.cpp:1147
+#. Name
+#: ../src/widgets/gradient-toolbar.cpp:1027
 msgid "Stops"
 msgstr "Zwischenfarben"
 
-#: ../src/widgets/gradient-toolbar.cpp:1147
-msgid "Select a stop for the current gradient"
-msgstr "Zwischenfarbe für derzeitigen Farbverlauf auswählen"
-
-#: ../src/widgets/gradient-toolbar.cpp:1148
-msgid "Stops:"
-msgstr "Zwischenfarben:"
-
 #. Label
-#: ../src/widgets/gradient-toolbar.cpp:1160
-#: ../src/widgets/gradient-vector.cpp:868
+#: ../src/widgets/gradient-toolbar.cpp:1049
+#: ../src/widgets/gradient-vector.cpp:847
 msgctxt "Gradient"
 msgid "Offset:"
 msgstr "Versatz:"
 
-#: ../src/widgets/gradient-toolbar.cpp:1160
+#: ../src/widgets/gradient-toolbar.cpp:1049
 msgid "Offset of selected stop"
 msgstr "Die gewählten Zwischenfarbe verschieben"
 
-#: ../src/widgets/gradient-toolbar.cpp:1178
-#: ../src/widgets/gradient-toolbar.cpp:1179
+#: ../src/widgets/gradient-toolbar.cpp:1067
+#: ../src/widgets/gradient-toolbar.cpp:1068
 msgid "Insert new stop"
 msgstr "Zwischenfarbe einfügen"
 
-#: ../src/widgets/gradient-toolbar.cpp:1192
-#: ../src/widgets/gradient-toolbar.cpp:1193
-#: ../src/widgets/gradient-vector.cpp:854
+#: ../src/widgets/gradient-toolbar.cpp:1081
+#: ../src/widgets/gradient-toolbar.cpp:1082
+#: ../src/widgets/gradient-vector.cpp:833
 msgid "Delete stop"
 msgstr "Zwischenfarbe löschen"
 
-#: ../src/widgets/gradient-toolbar.cpp:1207
+#: ../src/widgets/gradient-toolbar.cpp:1096
 msgid "Reverse the direction of the gradient"
 msgstr "Die Richtung des Verlaufs umkehren"
 
-#: ../src/widgets/gradient-toolbar.cpp:1221
+#: ../src/widgets/gradient-toolbar.cpp:1110
 msgid "Link gradients"
 msgstr "Verknüpfe Farbverläufe"
 
-#: ../src/widgets/gradient-toolbar.cpp:1222
+#: ../src/widgets/gradient-toolbar.cpp:1111
 msgid "Link gradients to change all related gradients"
 msgstr "Verknüpfe Farbverläufe, um alle verbundenen Farbverläufe zu ändern"
 
-#: ../src/widgets/gradient-vector.cpp:289 ../src/widgets/paint-selector.cpp:917
-#: ../src/widgets/paint-selector.cpp:1269
-#: ../src/widgets/stroke-marker-selector.cpp:149
+#: ../src/widgets/gradient-vector.cpp:288 ../src/widgets/paint-selector.cpp:904
+#: ../src/widgets/paint-selector.cpp:1240
+#: ../src/widgets/stroke-marker-selector.cpp:148
 msgid "No document selected"
 msgstr "Kein Dokument gewählt"
 
-#: ../src/widgets/gradient-vector.cpp:293
+#: ../src/widgets/gradient-vector.cpp:292
 msgid "No gradients in document"
 msgstr "Keine Farbverläufe im Dokument"
 
-#: ../src/widgets/gradient-vector.cpp:297
+#: ../src/widgets/gradient-vector.cpp:296
 msgid "No gradient selected"
 msgstr "Kein Farbverlauf markiert"
 
 #. TRANSLATORS: "Stop" means: a "phase" of a gradient
-#: ../src/widgets/gradient-vector.cpp:849
+#: ../src/widgets/gradient-vector.cpp:828
 msgid "Add stop"
 msgstr "Zwischenfarbe hinzufügen"
 
-#: ../src/widgets/gradient-vector.cpp:852
+#: ../src/widgets/gradient-vector.cpp:831
 msgid "Add another control stop to gradient"
 msgstr "Weitere Zwischenfarbe zum Verlauf hinzufügen"
 
-#: ../src/widgets/gradient-vector.cpp:857
+#: ../src/widgets/gradient-vector.cpp:836
 msgid "Delete current control stop from gradient"
 msgstr "Aktuelle Zwischenfarbe aus dem Farbverlauf löschen"
 
 #. TRANSLATORS: "Stop" means: a "phase" of a gradient
-#: ../src/widgets/gradient-vector.cpp:918
+#: ../src/widgets/gradient-vector.cpp:897
 msgid "Stop Color"
 msgstr "Zwischenfarbe"
 
-#: ../src/widgets/gradient-vector.cpp:957
+#: ../src/widgets/gradient-vector.cpp:936
 msgid "Gradient editor"
 msgstr "Farbverlaufs-Editor"
 
-#: ../src/widgets/gradient-vector.cpp:1301
+#: ../src/widgets/gradient-vector.cpp:1280
 msgid "Change gradient stop color"
 msgstr "Zwischenfarbe des Farbverlaufs ändern"
 
@@ -30706,14 +31063,6 @@ msgstr "Messwert anzeigen"
 msgid "Display measuring info for selected items"
 msgstr "Messwert aür ausgewählte Objekte anzeigen"
 
-#. Add the units menu.
-#: ../src/widgets/lpe-toolbar.cpp:380 ../src/widgets/node-toolbar.cpp:611
-#: ../src/widgets/paintbucket-toolbar.cpp:166
-#: ../src/widgets/rect-toolbar.cpp:374 ../src/widgets/select-toolbar.cpp:520
-#: ../src/widgets/text-toolbar.cpp:2020
-msgid "Units"
-msgstr "Einheiten"
-
 #: ../src/widgets/lpe-toolbar.cpp:390
 msgid "Open LPE dialog"
 msgstr "LPE Dialog öffnen"
@@ -30731,117 +31080,137 @@ msgid "Start and end measures active."
 msgstr "Anfangs- und Endpunkt aktiv."
 
 #: ../src/widgets/measure-toolbar.cpp:175
+#, fuzzy
+msgid "Measures only selected."
+msgstr "Nur ausgewählte Knoten ändern"
+
+#: ../src/widgets/measure-toolbar.cpp:177
+#, fuzzy
+msgid "Measure all."
+msgstr "Pfad ausmessen"
+
+#: ../src/widgets/measure-toolbar.cpp:193
 msgid "Show all crossings."
 msgstr "Alle Schnittpunkte anzeigen"
 
-#: ../src/widgets/measure-toolbar.cpp:177
+#: ../src/widgets/measure-toolbar.cpp:195
 msgid "Show visible crossings."
 msgstr "Nur sichtbare Schnittpunkte anzeigen"
 
-#: ../src/widgets/measure-toolbar.cpp:193
+#: ../src/widgets/measure-toolbar.cpp:211
 msgid "Use all layers in the measure."
 msgstr "Alle Ebenen bei Messung berücksichtigen."
 
-#: ../src/widgets/measure-toolbar.cpp:195
+#: ../src/widgets/measure-toolbar.cpp:213
 msgid "Use current layer in the measure."
 msgstr "Nur die aktuelle Ebene bei Messung berücksichtigen."
 
-#: ../src/widgets/measure-toolbar.cpp:211
+#: ../src/widgets/measure-toolbar.cpp:229
 msgid "Compute all elements."
 msgstr "Alle Teilstrecken auswerten."
 
-#: ../src/widgets/measure-toolbar.cpp:213
+#: ../src/widgets/measure-toolbar.cpp:231
 msgid "Compute max length."
 msgstr "Gesamtsrecke auswerten."
 
-#: ../src/widgets/measure-toolbar.cpp:274 ../src/widgets/text-toolbar.cpp:1741
+#: ../src/widgets/measure-toolbar.cpp:292 ../src/widgets/text-toolbar.cpp:2043
 msgid "Font Size"
 msgstr "Schriftgröße"
 
-#: ../src/widgets/measure-toolbar.cpp:274
+#: ../src/widgets/measure-toolbar.cpp:292
 msgid "Font Size:"
 msgstr "Schriftgröße:"
 
-#: ../src/widgets/measure-toolbar.cpp:275
+#: ../src/widgets/measure-toolbar.cpp:293
 msgid "The font size to be used in the measurement labels"
 msgstr "Die Schriftgröße, die für Bemaßungen verwendet wird"
 
-#: ../src/widgets/measure-toolbar.cpp:286
-#: ../src/widgets/measure-toolbar.cpp:294
+#: ../src/widgets/measure-toolbar.cpp:304
+#: ../src/widgets/measure-toolbar.cpp:312
 msgid "The units to be used for the measurements"
 msgstr "Die Einheiten, die für die Bemaßungen verwendet werden"
 
-#: ../src/widgets/measure-toolbar.cpp:302 ../share/extensions/measure.inx.h:14
+#: ../src/widgets/measure-toolbar.cpp:320 ../share/extensions/measure.inx.h:14
 msgid "Precision:"
 msgstr "Genauigkeit:"
 
-#: ../src/widgets/measure-toolbar.cpp:303
+#: ../src/widgets/measure-toolbar.cpp:321
 msgid "Decimal precision of measure"
 msgstr "Anzahl Dezimalstellen in Bemaßungen"
 
-#: ../src/widgets/measure-toolbar.cpp:315
+#: ../src/widgets/measure-toolbar.cpp:333
+msgid "Scale %"
+msgstr "Skalierung"
+
+#: ../src/widgets/measure-toolbar.cpp:333
 msgid "Scale %:"
 msgstr "Skalierung:"
 
-#: ../src/widgets/measure-toolbar.cpp:316
+#: ../src/widgets/measure-toolbar.cpp:334
 msgid "Scale the results"
 msgstr "Skalierung der Maße (in Prozent)"
 
-#: ../src/widgets/measure-toolbar.cpp:329
+#: ../src/widgets/measure-toolbar.cpp:347
 #, fuzzy
 msgid "Mark dimension offset"
 msgstr "Bemaßung erstellen"
 
-#: ../src/widgets/measure-toolbar.cpp:341
-#: ../src/widgets/measure-toolbar.cpp:342
+#: ../src/widgets/measure-toolbar.cpp:359
+#: ../src/widgets/measure-toolbar.cpp:360
+#, fuzzy
+msgid "Measure only selected"
+msgstr "Nur ausgewählte Knoten ändern"
+
+#: ../src/widgets/measure-toolbar.cpp:371
+#: ../src/widgets/measure-toolbar.cpp:372
 msgid "Ignore first and last"
 msgstr "Anfangs- und Endpunkt ignorieren"
 
-#: ../src/widgets/measure-toolbar.cpp:352
-#: ../src/widgets/measure-toolbar.cpp:353
+#: ../src/widgets/measure-toolbar.cpp:382
+#: ../src/widgets/measure-toolbar.cpp:383
 msgid "Show hidden intersections"
 msgstr "Zeige versteckte Überschneidungen"
 
-#: ../src/widgets/measure-toolbar.cpp:363
-#: ../src/widgets/measure-toolbar.cpp:364
+#: ../src/widgets/measure-toolbar.cpp:393
+#: ../src/widgets/measure-toolbar.cpp:394
 msgid "Show measures between items"
 msgstr "Bemaßungen zwischen Überschneidungen anzeigen"
 
-#: ../src/widgets/measure-toolbar.cpp:374
-#: ../src/widgets/measure-toolbar.cpp:375
+#: ../src/widgets/measure-toolbar.cpp:404
+#: ../src/widgets/measure-toolbar.cpp:405
 msgid "Measure all layers"
 msgstr "Allen Ebenen für die Messung berücksichtigen"
 
-#: ../src/widgets/measure-toolbar.cpp:385
-#: ../src/widgets/measure-toolbar.cpp:386
+#: ../src/widgets/measure-toolbar.cpp:415
+#: ../src/widgets/measure-toolbar.cpp:416
 msgid "Reverse measure"
 msgstr "Maßstab umkehren"
 
-#: ../src/widgets/measure-toolbar.cpp:395
-#: ../src/widgets/measure-toolbar.cpp:396
+#: ../src/widgets/measure-toolbar.cpp:425
+#: ../src/widgets/measure-toolbar.cpp:426
 msgid "Phantom measure"
 msgstr "Phantombild des aktuellen Maßstabs erstellen"
 
-#: ../src/widgets/measure-toolbar.cpp:405
-#: ../src/widgets/measure-toolbar.cpp:406
+#: ../src/widgets/measure-toolbar.cpp:435
+#: ../src/widgets/measure-toolbar.cpp:436
 msgid "To guides"
 msgstr "In Hilfslinien umwandeln"
 
-#: ../src/widgets/measure-toolbar.cpp:415
-#: ../src/widgets/measure-toolbar.cpp:416
+#: ../src/widgets/measure-toolbar.cpp:445
+#: ../src/widgets/measure-toolbar.cpp:446
 msgid "Mark Dimension"
 msgstr "Bemaßung erstellen"
 
-#: ../src/widgets/measure-toolbar.cpp:425
-#: ../src/widgets/measure-toolbar.cpp:426
+#: ../src/widgets/measure-toolbar.cpp:455
+#: ../src/widgets/measure-toolbar.cpp:456
 msgid "Convert to item"
 msgstr "In Zeichenobjekte umwandeln"
 
-#: ../src/widgets/mesh-toolbar.cpp:284
+#: ../src/widgets/mesh-toolbar.cpp:276
 msgid "Set mesh type"
 msgstr "Gittertyp festlegen"
 
-#: ../src/widgets/mesh-toolbar.cpp:357
+#: ../src/widgets/mesh-toolbar.cpp:349
 msgid ""
 "Mesh gradients are part of SVG 2:\n"
 "* Syntax may change.\n"
@@ -30858,112 +31227,116 @@ msgstr ""
 "erstellen).\n"
 "Zum Drucken: als PDF exportieren."
 
-#: ../src/widgets/mesh-toolbar.cpp:389
+#: ../src/widgets/mesh-toolbar.cpp:385
 msgid "normal"
 msgstr "Normal"
 
-#: ../src/widgets/mesh-toolbar.cpp:389
+#: ../src/widgets/mesh-toolbar.cpp:386
 msgid "Create mesh gradient"
 msgstr "Verlaufsgitter erzeugen"
 
-#: ../src/widgets/mesh-toolbar.cpp:393
+#: ../src/widgets/mesh-toolbar.cpp:391
 msgid "conical"
 msgstr "konisch"
 
-#: ../src/widgets/mesh-toolbar.cpp:393
+#: ../src/widgets/mesh-toolbar.cpp:392
 msgid "Create conical gradient"
 msgstr "Konischen Farbverlauf erzeugen"
 
-#: ../src/widgets/mesh-toolbar.cpp:448
+#. Name
+#: ../src/widgets/mesh-toolbar.cpp:398
+msgid "New:"
+msgstr "Neu:"
+
+#: ../src/widgets/mesh-toolbar.cpp:457
 msgid "Rows"
 msgstr "Reihen"
 
-#: ../src/widgets/mesh-toolbar.cpp:448
+#: ../src/widgets/mesh-toolbar.cpp:457
 #: ../share/extensions/guides_creator.inx.h:5
 #: ../share/extensions/layout_nup.inx.h:12
 msgid "Rows:"
 msgstr "Reihen:"
 
-#: ../src/widgets/mesh-toolbar.cpp:448
+#: ../src/widgets/mesh-toolbar.cpp:457
 msgid "Number of rows in new mesh"
 msgstr "Anzahl der Zeilen im neuen Gitter"
 
-#: ../src/widgets/mesh-toolbar.cpp:464
+#: ../src/widgets/mesh-toolbar.cpp:473
 msgid "Columns"
 msgstr "Spalten"
 
-#: ../src/widgets/mesh-toolbar.cpp:464
+#: ../src/widgets/mesh-toolbar.cpp:473
 #: ../share/extensions/guides_creator.inx.h:4
 msgid "Columns:"
 msgstr "Spalten:"
 
-#: ../src/widgets/mesh-toolbar.cpp:464
+#: ../src/widgets/mesh-toolbar.cpp:473
 msgid "Number of columns in new mesh"
 msgstr "Anzahl der Spalten im neuen Gitter"
 
-#: ../src/widgets/mesh-toolbar.cpp:478
+#: ../src/widgets/mesh-toolbar.cpp:487
 msgid "Edit Fill"
 msgstr "Füllung bearbeiten"
 
-#: ../src/widgets/mesh-toolbar.cpp:479
+#: ../src/widgets/mesh-toolbar.cpp:488
 msgid "Edit fill mesh"
 msgstr "Füllungsgitter bearbeiten"
 
-#: ../src/widgets/mesh-toolbar.cpp:491
+#: ../src/widgets/mesh-toolbar.cpp:500
 msgid "Edit Stroke"
 msgstr "Kontur bearbeiten"
 
-#: ../src/widgets/mesh-toolbar.cpp:492
+#: ../src/widgets/mesh-toolbar.cpp:501
 msgid "Edit stroke mesh"
 msgstr "Konturgitter bearbeiten"
 
-#: ../src/widgets/mesh-toolbar.cpp:504 ../src/widgets/node-toolbar.cpp:519
+#: ../src/widgets/mesh-toolbar.cpp:513 ../src/widgets/node-toolbar.cpp:519
 msgid "Show Handles"
 msgstr "Anfasser zeigen"
 
-#: ../src/widgets/mesh-toolbar.cpp:521 ../src/widgets/mesh-toolbar.cpp:522
+#: ../src/widgets/mesh-toolbar.cpp:530 ../src/widgets/mesh-toolbar.cpp:531
 msgid "WARNING: Mesh SVG Syntax Subject to Change"
 msgstr "WARNUNG: SVG Syntax zu Verlaufsgittern noch im Entwurfsstadium"
 
-#: ../src/widgets/mesh-toolbar.cpp:536
+#: ../src/widgets/mesh-toolbar.cpp:548
 msgctxt "Type"
 msgid "Coons"
 msgstr "Coons"
 
-#: ../src/widgets/mesh-toolbar.cpp:539
+#: ../src/widgets/mesh-toolbar.cpp:554
 msgid "Bicubic"
 msgstr "Bikubisch"
 
-#. TRANSLATORS: Type of Smoothing. See https://en.wikipedia.org/wiki/Coons_patch
-#: ../src/widgets/mesh-toolbar.cpp:542
-msgid "Coons"
-msgstr "Coons"
-
-#: ../src/widgets/mesh-toolbar.cpp:543
-msgid "Coons: no smoothing. Bicubic: smoothing across patch boundaries."
-msgstr "Coons: Keine Glättung. Bikubisch: Glättung über Feldgrenzen hinweg."
-
-#: ../src/widgets/mesh-toolbar.cpp:545 ../src/widgets/pencil-toolbar.cpp:377
-msgid "Smoothing:"
+#. Name
+#: ../src/widgets/mesh-toolbar.cpp:562
+#, fuzzy
+msgid "Smoothing"
 msgstr "Glättung:"
 
-#: ../src/widgets/mesh-toolbar.cpp:555
+#. Label
+#: ../src/widgets/mesh-toolbar.cpp:563
+#, fuzzy
+msgid "Coons: no smothing. Bicubic: smothing across patch boundaries."
+msgstr "Coons: Keine Glättung. Bikubisch: Glättung über Feldgrenzen hinweg."
+
+#: ../src/widgets/mesh-toolbar.cpp:582
 msgid "Toggle Sides"
 msgstr "Seiten umschalten"
 
-#: ../src/widgets/mesh-toolbar.cpp:556
+#: ../src/widgets/mesh-toolbar.cpp:583
 msgid "Toggle selected sides between Beziers and lines."
 msgstr "Ausgewählte Seiten zu Bézierkurven oder Linien machen"
 
-#: ../src/widgets/mesh-toolbar.cpp:559
+#: ../src/widgets/mesh-toolbar.cpp:586
 msgid "Toggle side:"
 msgstr "Seite umschalten:"
 
-#: ../src/widgets/mesh-toolbar.cpp:566
+#: ../src/widgets/mesh-toolbar.cpp:593
 msgid "Make elliptical"
 msgstr "Elliptisch machen"
 
-#: ../src/widgets/mesh-toolbar.cpp:567
+#: ../src/widgets/mesh-toolbar.cpp:594
 msgid ""
 "Make selected sides elliptical by changing length of handles. Works best if "
 "handles already approximate ellipse."
@@ -30972,34 +31345,34 @@ msgstr ""
 "Funktioniert am besten, wenn die Anfasser bereits annäherungsweise eine "
 "Ellipsenform bilden."
 
-#: ../src/widgets/mesh-toolbar.cpp:570
+#: ../src/widgets/mesh-toolbar.cpp:597
 msgid "Make elliptical:"
 msgstr "Elliptisch machen:"
 
-#: ../src/widgets/mesh-toolbar.cpp:577
+#: ../src/widgets/mesh-toolbar.cpp:604
 msgid "Pick colors:"
 msgstr "Farben übernehmen:"
 
-#: ../src/widgets/mesh-toolbar.cpp:578
+#: ../src/widgets/mesh-toolbar.cpp:605
 msgid "Pick colors for selected corner nodes from underneath mesh."
 msgstr ""
 "Farben der ausgewählten Knoten an Hand der Objekte unterhalb des Gitters "
 "übernehmen."
 
-#: ../src/widgets/mesh-toolbar.cpp:581
+#: ../src/widgets/mesh-toolbar.cpp:608
 msgid "Pick Color"
 msgstr "Farbe übernehmen"
 
-#: ../src/widgets/mesh-toolbar.cpp:589
+#: ../src/widgets/mesh-toolbar.cpp:616
 msgid "Scale mesh to bounding box:"
 msgstr "Verlaufsgitter auf Größe des Objektrahmens skalieren:"
 
-#: ../src/widgets/mesh-toolbar.cpp:590
+#: ../src/widgets/mesh-toolbar.cpp:617
 msgid "Scale mesh to fit inside bounding box."
 msgstr ""
 "Größe des Verlaufsgitters so ändern, dass es in den Objektrahmen passt."
 
-#: ../src/widgets/mesh-toolbar.cpp:593
+#: ../src/widgets/mesh-toolbar.cpp:620
 msgid "Fit mesh"
 msgstr "Verlaufsgitter einpassen"
 
@@ -31196,32 +31569,32 @@ msgstr "Y-Koordinate:"
 msgid "Y coordinate of selected node(s)"
 msgstr "Y-Koordinate der Auswahl"
 
-#: ../src/widgets/paint-selector.cpp:207
+#: ../src/widgets/paint-selector.cpp:209
 msgid "No paint"
 msgstr "Keine Farbe"
 
-#: ../src/widgets/paint-selector.cpp:209
+#: ../src/widgets/paint-selector.cpp:211
 msgid "Flat color"
 msgstr "Einfache Farbe"
 
-#: ../src/widgets/paint-selector.cpp:211
+#: ../src/widgets/paint-selector.cpp:213
 msgid "Linear gradient"
 msgstr "Linearer Farbverlauf"
 
-#: ../src/widgets/paint-selector.cpp:213
+#: ../src/widgets/paint-selector.cpp:215
 msgid "Radial gradient"
 msgstr "Radialer Farbverlauf"
 
-#: ../src/widgets/paint-selector.cpp:216
+#: ../src/widgets/paint-selector.cpp:218
 msgid "Mesh gradient"
 msgstr "Verlaufsgitter"
 
-#: ../src/widgets/paint-selector.cpp:223
+#: ../src/widgets/paint-selector.cpp:225
 msgid "Unset paint (make it undefined so it can be inherited)"
 msgstr "Farbe nicht setzen (damit sie geerbt werden kann)"
 
 #. TRANSLATORS: for info, see http://www.w3.org/TR/2000/CR-SVG-20000802/painting.html#FillRuleProperty
-#: ../src/widgets/paint-selector.cpp:236
+#: ../src/widgets/paint-selector.cpp:238
 msgid ""
 "Any path self-intersections or subpaths create holes in the fill (fill-rule: "
 "evenodd)"
@@ -31230,53 +31603,53 @@ msgstr ""
 "Füllung (Füllregel: evenodd)"
 
 #. TRANSLATORS: for info, see http://www.w3.org/TR/2000/CR-SVG-20000802/painting.html#FillRuleProperty
-#: ../src/widgets/paint-selector.cpp:247
+#: ../src/widgets/paint-selector.cpp:249
 msgid ""
 "Fill is solid unless a subpath is counterdirectional (fill-rule: nonzero)"
 msgstr ""
 "Vollständige Füllung, solange kein Pfadabschnitt in entgegengesetzter "
 "Richtung verläuft (Füllregel: nonzero)"
 
-#: ../src/widgets/paint-selector.cpp:589
+#: ../src/widgets/paint-selector.cpp:591
 msgid "<b>No objects</b>"
 msgstr "<b>Keine Objekte</b>"
 
-#: ../src/widgets/paint-selector.cpp:600
+#: ../src/widgets/paint-selector.cpp:602
 msgid "<b>Multiple styles</b>"
 msgstr "<b>Mehrfachstile</b>"
 
-#: ../src/widgets/paint-selector.cpp:611
+#: ../src/widgets/paint-selector.cpp:613
 msgid "<b>Paint is undefined</b>"
 msgstr "<b>Farbe ist undefiniert</b>"
 
-#: ../src/widgets/paint-selector.cpp:622
+#: ../src/widgets/paint-selector.cpp:624
 msgid "<b>No paint</b>"
 msgstr "<b>Keine Farbe</b>"
 
-#: ../src/widgets/paint-selector.cpp:702
+#: ../src/widgets/paint-selector.cpp:704
 msgid "<b>Flat color</b>"
 msgstr "<b>Einfache Farbe</b>"
 
 #. sp_gradient_selector_set_mode(SP_GRADIENT_SELECTOR(gsel), SP_GRADIENT_SELECTOR_MODE_LINEAR);
-#: ../src/widgets/paint-selector.cpp:766
+#: ../src/widgets/paint-selector.cpp:768
 msgid "<b>Linear gradient</b>"
 msgstr "<b>Linearer Farbverlauf</b>"
 
-#: ../src/widgets/paint-selector.cpp:769
+#: ../src/widgets/paint-selector.cpp:771
 msgid "<b>Radial gradient</b>"
 msgstr "<b>Radialer Farbverlauf</b>"
 
-#: ../src/widgets/paint-selector.cpp:1038
+#: ../src/widgets/paint-selector.cpp:1025
 msgid "Use the <b>Mesh tool</b> to modify the mesh."
 msgstr ""
 "Das Verlaufsgitter kann mit dem <b>Verlaufsgitterwerkzeug</b> bearbeitet "
 "werden."
 
-#: ../src/widgets/paint-selector.cpp:1051
+#: ../src/widgets/paint-selector.cpp:1038
 msgid "<b>Mesh fill</b>"
 msgstr "<b>Füllung mit Verlaufsgitter</b>"
 
-#: ../src/widgets/paint-selector.cpp:1390
+#: ../src/widgets/paint-selector.cpp:1361
 msgid ""
 "Use the <b>Node tool</b> to adjust position, scale, and rotation of the "
 "pattern on canvas. Use <b>Object &gt; Pattern &gt; Objects to Pattern</b> to "
@@ -31287,11 +31660,11 @@ msgstr ""
 "Objekte in Füllmuster umwandeln</b> lassen sich neue Füllmuster von "
 "ausgewählten Objekten erzeugen."
 
-#: ../src/widgets/paint-selector.cpp:1403
+#: ../src/widgets/paint-selector.cpp:1374
 msgid "<b>Pattern fill</b>"
 msgstr "<b>Füllmuster</b>"
 
-#: ../src/widgets/paint-selector.cpp:1497
+#: ../src/widgets/paint-selector.cpp:1468
 msgid "<b>Swatch fill</b>"
 msgstr "<b>Farbmuster</b>"
 
@@ -31339,8 +31712,8 @@ msgid "Close gaps:"
 msgstr "Lücken schließen:"
 
 #: ../src/widgets/paintbucket-toolbar.cpp:210
-#: ../src/widgets/pencil-toolbar.cpp:398 ../src/widgets/spiral-toolbar.cpp:282
-#: ../src/widgets/star-toolbar.cpp:562
+#: ../src/widgets/pencil-toolbar.cpp:556 ../src/widgets/spiral-toolbar.cpp:288
+#: ../src/widgets/star-toolbar.cpp:574
 msgid "Defaults"
 msgstr "Standardeinstellungen"
 
@@ -31352,93 +31725,135 @@ msgstr ""
 "Die Parameter des Farbeimers auf Standardwerte zurücksetzen (Menü Datei > "
 "Inkscape-Einstellungen > Werkzeuge, um die Standardeinstellungen zu ändern)"
 
-#: ../src/widgets/pencil-toolbar.cpp:102
+#: ../src/widgets/pencil-toolbar.cpp:124
 msgid "Bezier"
 msgstr "Bézier"
 
-#: ../src/widgets/pencil-toolbar.cpp:103
+#: ../src/widgets/pencil-toolbar.cpp:125
 msgid "Create regular Bezier path"
 msgstr "Erstelle gewöhnlichen Bézier-Pfad"
 
-#: ../src/widgets/pencil-toolbar.cpp:110
+#: ../src/widgets/pencil-toolbar.cpp:132
 msgid "Create Spiro path"
 msgstr "Erstelle Spiro-Pfad"
 
-#: ../src/widgets/pencil-toolbar.cpp:116
+#: ../src/widgets/pencil-toolbar.cpp:138
 msgid "Create BSpline path"
 msgstr "Erstelle B-Spline-Pfad"
 
-#: ../src/widgets/pencil-toolbar.cpp:122
+#: ../src/widgets/pencil-toolbar.cpp:144
 msgid "Zigzag"
 msgstr "Zickzack"
 
-#: ../src/widgets/pencil-toolbar.cpp:123
+#: ../src/widgets/pencil-toolbar.cpp:145
 msgid "Create a sequence of straight line segments"
 msgstr "Erstelle eine Folge von geraden Liniensegmenten"
 
-#: ../src/widgets/pencil-toolbar.cpp:129
+#: ../src/widgets/pencil-toolbar.cpp:151
 msgid "Paraxial"
 msgstr "achsenparallel"
 
-#: ../src/widgets/pencil-toolbar.cpp:130
+#: ../src/widgets/pencil-toolbar.cpp:152
 msgid "Create a sequence of paraxial line segments"
 msgstr "Erstelle eine Folge von Achsenparallelen Liniensegmenten"
 
-#: ../src/widgets/pencil-toolbar.cpp:138
+#: ../src/widgets/pencil-toolbar.cpp:159
 msgid "Mode of new lines drawn by this tool"
 msgstr "Modus für neue Linie mit diesem Werkzeug"
 
+#: ../src/widgets/pencil-toolbar.cpp:176 ../src/widgets/pencil-toolbar.cpp:177
+#, fuzzy
+msgid "LPE spiro or bspline flatten"
+msgstr "Vereinfachen-Pfadeffekt in normalen Pfad umwandeln"
+
 # CHECK
-#: ../src/widgets/pencil-toolbar.cpp:173
+#: ../src/widgets/pencil-toolbar.cpp:218
 msgctxt "Freehand shape"
 msgid "None"
 msgstr "Keine"
 
-#: ../src/widgets/pencil-toolbar.cpp:174
+#: ../src/widgets/pencil-toolbar.cpp:219
 msgid "Triangle in"
 msgstr "Dreieck Anfang"
 
-#: ../src/widgets/pencil-toolbar.cpp:175
+#: ../src/widgets/pencil-toolbar.cpp:220
 msgid "Triangle out"
 msgstr "Dreieck Ende"
 
-#: ../src/widgets/pencil-toolbar.cpp:177
+#: ../src/widgets/pencil-toolbar.cpp:222
 msgid "From clipboard"
 msgstr "Aus Zwischenablage"
 
-#: ../src/widgets/pencil-toolbar.cpp:178
+#: ../src/widgets/pencil-toolbar.cpp:223
 msgid "Bend from clipboard"
 msgstr "Kurve aus Zwischenablage"
 
-#: ../src/widgets/pencil-toolbar.cpp:179
+#: ../src/widgets/pencil-toolbar.cpp:224
 msgid "Last applied"
 msgstr "Zuletzt angewendet"
 
-#: ../src/widgets/pencil-toolbar.cpp:204 ../src/widgets/pencil-toolbar.cpp:205
+#: ../src/widgets/pencil-toolbar.cpp:235 ../src/widgets/pencil-toolbar.cpp:236
 msgid "Shape:"
 msgstr "Form:"
 
-#: ../src/widgets/pencil-toolbar.cpp:204
+#: ../src/widgets/pencil-toolbar.cpp:235
 msgid "Shape of new paths drawn by this tool"
 msgstr "Stil von neuen Pfaden mit diesem Werkzeug"
 
-#: ../src/widgets/pencil-toolbar.cpp:374
+#: ../src/widgets/pencil-toolbar.cpp:479
+#, fuzzy
+msgid "Min pressure"
+msgstr "Druck"
+
+#: ../src/widgets/pencil-toolbar.cpp:479
+msgid "Min:"
+msgstr ""
+
+#: ../src/widgets/pencil-toolbar.cpp:479
+#, fuzzy
+msgid "Min percent of pressure"
+msgstr "Eine Beschreibung des Dokuments"
+
+#: ../src/widgets/pencil-toolbar.cpp:497
+#, fuzzy
+msgid "Max pressure"
+msgstr "Druck"
+
+#: ../src/widgets/pencil-toolbar.cpp:497
+msgid "Max:"
+msgstr ""
+
+#: ../src/widgets/pencil-toolbar.cpp:497
+#, fuzzy
+msgid "Max percent of pressure"
+msgstr "Wachsdruck-auf-Stoff-Textur"
+
+#: ../src/widgets/pencil-toolbar.cpp:514 ../src/widgets/pencil-toolbar.cpp:515
+#, fuzzy
+msgid "Use pressure input"
+msgstr "Einstellungen für das Löschwerkzeug"
+
+#: ../src/widgets/pencil-toolbar.cpp:532
 msgid "(many nodes, rough)"
 msgstr "(viele Knoten, grob)"
 
-#: ../src/widgets/pencil-toolbar.cpp:374
+#: ../src/widgets/pencil-toolbar.cpp:532
 msgid "(few nodes, smooth)"
 msgstr "(wenige Knoten, weich)"
 
-#: ../src/widgets/pencil-toolbar.cpp:377
+#: ../src/widgets/pencil-toolbar.cpp:535
+msgid "Smoothing:"
+msgstr "Glättung:"
+
+#: ../src/widgets/pencil-toolbar.cpp:535
 msgid "Smoothing: "
 msgstr "Glättung:"
 
-#: ../src/widgets/pencil-toolbar.cpp:378
+#: ../src/widgets/pencil-toolbar.cpp:536
 msgid "How much smoothing (simplifying) is applied to the line"
 msgstr "Wie stark die Linie geglättet (vereinfacht) wird"
 
-#: ../src/widgets/pencil-toolbar.cpp:399
+#: ../src/widgets/pencil-toolbar.cpp:557
 msgid ""
 "Reset pencil parameters to defaults (use Inkscape Preferences > Tools to "
 "change defaults)"
@@ -31446,11 +31861,11 @@ msgstr ""
 "Die Parameter des Stiftes auf Standardwerte zurücksetzen (Menü Datei > "
 "Inkscape-Einstellungen > Werkzeuge, um die Grundeinstellungen zu ändern)"
 
-#: ../src/widgets/pencil-toolbar.cpp:409 ../src/widgets/pencil-toolbar.cpp:410
+#: ../src/widgets/pencil-toolbar.cpp:566 ../src/widgets/pencil-toolbar.cpp:567
 msgid "LPE based interactive simplify"
 msgstr "Pfadeffektbasiertes interaktives Vereinfachen"
 
-#: ../src/widgets/pencil-toolbar.cpp:420 ../src/widgets/pencil-toolbar.cpp:421
+#: ../src/widgets/pencil-toolbar.cpp:584 ../src/widgets/pencil-toolbar.cpp:585
 msgid "LPE simplify flatten"
 msgstr "Vereinfachen-Pfadeffekt in normalen Pfad umwandeln"
 
@@ -31458,55 +31873,39 @@ msgstr "Vereinfachen-Pfadeffekt in normalen Pfad umwandeln"
 msgid "Change rectangle"
 msgstr "Rechteck ändern"
 
-#: ../src/widgets/rect-toolbar.cpp:313
+#: ../src/widgets/rect-toolbar.cpp:319
 msgid "W:"
 msgstr "W:"
 
-#: ../src/widgets/rect-toolbar.cpp:313
+#: ../src/widgets/rect-toolbar.cpp:319
 msgid "Width of rectangle"
 msgstr "Breite des Rechtecks"
 
-#: ../src/widgets/rect-toolbar.cpp:330
+#: ../src/widgets/rect-toolbar.cpp:336
 msgid "H:"
 msgstr "H:"
 
-#: ../src/widgets/rect-toolbar.cpp:330
+#: ../src/widgets/rect-toolbar.cpp:336
 msgid "Height of rectangle"
 msgstr "Höhe des Rechtecks"
 
-#: ../src/widgets/rect-toolbar.cpp:344 ../src/widgets/rect-toolbar.cpp:359
+#: ../src/widgets/rect-toolbar.cpp:350 ../src/widgets/rect-toolbar.cpp:365
 msgid "not rounded"
 msgstr "nicht abgerundet"
 
-#: ../src/widgets/rect-toolbar.cpp:347
-msgid "Horizontal radius"
-msgstr "Horizontaler Radius"
-
-#: ../src/widgets/rect-toolbar.cpp:347
-msgid "Rx:"
-msgstr "Rx:"
-
-#: ../src/widgets/rect-toolbar.cpp:347
+#: ../src/widgets/rect-toolbar.cpp:353
 msgid "Horizontal radius of rounded corners"
 msgstr "Horizontaler Radius einer abgerundeten Ecke"
 
-#: ../src/widgets/rect-toolbar.cpp:362
-msgid "Vertical radius"
-msgstr "Vertikaler Radius"
-
-#: ../src/widgets/rect-toolbar.cpp:362
-msgid "Ry:"
-msgstr "Ry:"
-
-#: ../src/widgets/rect-toolbar.cpp:362
+#: ../src/widgets/rect-toolbar.cpp:368
 msgid "Vertical radius of rounded corners"
 msgstr "Vertikaler Radius einer abgerundeten Ecke"
 
-#: ../src/widgets/rect-toolbar.cpp:381
+#: ../src/widgets/rect-toolbar.cpp:387
 msgid "Not rounded"
 msgstr "Nicht abgerundet"
 
-#: ../src/widgets/rect-toolbar.cpp:382
+#: ../src/widgets/rect-toolbar.cpp:388
 msgid "Make corners sharp"
 msgstr "Spitze Ecken"
 
@@ -31674,10 +32073,6 @@ msgstr "Attribut festlegen"
 msgid "Unnamed"
 msgstr "Unbenannt"
 
-#: ../src/widgets/sp-xmlview-attr-list.cpp:55
-msgid "Value"
-msgstr "Wert"
-
 #: ../src/widgets/sp-xmlview-content.cpp:134
 msgid "Type text in a text node"
 msgstr "Text in einem Text-Knoten tippen"
@@ -31686,87 +32081,87 @@ msgstr "Text in einem Text-Knoten tippen"
 msgid "Change spiral"
 msgstr "Spirale ändern"
 
-#: ../src/widgets/spiral-toolbar.cpp:239
+#: ../src/widgets/spiral-toolbar.cpp:245
 msgid "just a curve"
 msgstr "Kurve ziehen"
 
-#: ../src/widgets/spiral-toolbar.cpp:239
+#: ../src/widgets/spiral-toolbar.cpp:245
 msgid "one full revolution"
 msgstr "eine volle Umdrehung"
 
-#: ../src/widgets/spiral-toolbar.cpp:242
+#: ../src/widgets/spiral-toolbar.cpp:248
 msgid "Number of turns"
 msgstr "Anzahl der Drehungen"
 
-#: ../src/widgets/spiral-toolbar.cpp:242
+#: ../src/widgets/spiral-toolbar.cpp:248
 msgid "Turns:"
 msgstr "Umdrehungen:"
 
-#: ../src/widgets/spiral-toolbar.cpp:242
+#: ../src/widgets/spiral-toolbar.cpp:248
 msgid "Number of revolutions"
 msgstr "Anzahl der Umdrehungen"
 
-#: ../src/widgets/spiral-toolbar.cpp:253
+#: ../src/widgets/spiral-toolbar.cpp:259
 msgid "circle"
 msgstr "Kreis"
 
-#: ../src/widgets/spiral-toolbar.cpp:253
+#: ../src/widgets/spiral-toolbar.cpp:259
 msgid "edge is much denser"
 msgstr "Kante ist viel dichter"
 
-#: ../src/widgets/spiral-toolbar.cpp:253
+#: ../src/widgets/spiral-toolbar.cpp:259
 msgid "edge is denser"
 msgstr "Kante ist dichter"
 
-#: ../src/widgets/spiral-toolbar.cpp:253
+#: ../src/widgets/spiral-toolbar.cpp:259
 msgid "even"
 msgstr "eben"
 
-#: ../src/widgets/spiral-toolbar.cpp:253
+#: ../src/widgets/spiral-toolbar.cpp:259
 msgid "center is denser"
 msgstr "Mittelpunkt ist dichter"
 
-#: ../src/widgets/spiral-toolbar.cpp:253
+#: ../src/widgets/spiral-toolbar.cpp:259
 msgid "center is much denser"
 msgstr "Zentrum ist viel dichter"
 
-#: ../src/widgets/spiral-toolbar.cpp:256
+#: ../src/widgets/spiral-toolbar.cpp:262
 msgid "Divergence"
 msgstr "Abweichung"
 
-#: ../src/widgets/spiral-toolbar.cpp:256
+#: ../src/widgets/spiral-toolbar.cpp:262
 msgid "Divergence:"
 msgstr "Abweichung:"
 
-#: ../src/widgets/spiral-toolbar.cpp:256
+#: ../src/widgets/spiral-toolbar.cpp:262
 msgid "How much denser/sparser are outer revolutions; 1 = uniform"
 msgstr "Dichte der äußeren Umdrehungen; 1 = gleichförmig"
 
-#: ../src/widgets/spiral-toolbar.cpp:267
+#: ../src/widgets/spiral-toolbar.cpp:273
 msgid "starts from center"
 msgstr "startet vom Mittelpunkt"
 
-#: ../src/widgets/spiral-toolbar.cpp:267
+#: ../src/widgets/spiral-toolbar.cpp:273
 msgid "starts mid-way"
 msgstr "beginnt mittig"
 
-#: ../src/widgets/spiral-toolbar.cpp:267
+#: ../src/widgets/spiral-toolbar.cpp:273
 msgid "starts near edge"
 msgstr "Startet nahe der Ecke"
 
-#: ../src/widgets/spiral-toolbar.cpp:270
+#: ../src/widgets/spiral-toolbar.cpp:276
 msgid "Inner radius"
 msgstr "Innerer Radius"
 
-#: ../src/widgets/spiral-toolbar.cpp:270
+#: ../src/widgets/spiral-toolbar.cpp:276
 msgid "Inner radius:"
 msgstr "Innerer Radius:"
 
-#: ../src/widgets/spiral-toolbar.cpp:270
+#: ../src/widgets/spiral-toolbar.cpp:276
 msgid "Radius of the innermost revolution (relative to the spiral size)"
 msgstr "Radius der innersten Umdrehung (relativ zur Gesamtgröße der Spirale)"
 
-#: ../src/widgets/spiral-toolbar.cpp:283 ../src/widgets/star-toolbar.cpp:563
+#: ../src/widgets/spiral-toolbar.cpp:289 ../src/widgets/star-toolbar.cpp:575
 msgid ""
 "Reset shape parameters to defaults (use Inkscape Preferences > Tools to "
 "change defaults)"
@@ -31833,11 +32228,11 @@ msgstr "Streuung:"
 msgid "Increase to scatter sprayed objects"
 msgstr "Vergrößern der Streuung gesprühter Objekte"
 
-#: ../src/widgets/spray-toolbar.cpp:361
+#: ../src/widgets/spray-toolbar.cpp:363
 msgid "Spray copies of the initial selection"
 msgstr "Sprühe Kopien vom zuletzt ausgewählten Objekt"
 
-#: ../src/widgets/spray-toolbar.cpp:368
+#: ../src/widgets/spray-toolbar.cpp:369
 msgid "Spray clones of the initial selection"
 msgstr "Sprühe Klone vom zuletzt ausgewählten Objekt"
 
@@ -31849,51 +32244,51 @@ msgstr "Sprühe einzelnen Pfad"
 msgid "Spray objects in a single path"
 msgstr "Sprüht Objekte in einen einzelnen Pfad"
 
-#: ../src/widgets/spray-toolbar.cpp:383
+#: ../src/widgets/spray-toolbar.cpp:382
 msgid "Delete sprayed items"
 msgstr "Gesprühte Objekte löschen"
 
-#: ../src/widgets/spray-toolbar.cpp:384
+#: ../src/widgets/spray-toolbar.cpp:383
 msgid "Delete sprayed items from selection"
 msgstr "Gesprühte Objekte aus der Auswahl löschen"
 
 #. Population
-#: ../src/widgets/spray-toolbar.cpp:408
+#: ../src/widgets/spray-toolbar.cpp:406
 msgid "(low population)"
 msgstr "(niedrige Population)"
 
-#: ../src/widgets/spray-toolbar.cpp:408
+#: ../src/widgets/spray-toolbar.cpp:406
 msgid "(high population)"
 msgstr "(hoher Zuwachs)"
 
-#: ../src/widgets/spray-toolbar.cpp:411
+#: ../src/widgets/spray-toolbar.cpp:409
 msgid "Amount"
 msgstr "Menge"
 
-#: ../src/widgets/spray-toolbar.cpp:412
+#: ../src/widgets/spray-toolbar.cpp:410
 msgid "Adjusts the number of items sprayed per click"
 msgstr "Anzahl der Objekte festlegen, die per Klick gesprüht werden"
 
-#: ../src/widgets/spray-toolbar.cpp:428
+#: ../src/widgets/spray-toolbar.cpp:426
 msgid ""
 "Use the pressure of the input device to alter the amount of sprayed objects"
 msgstr ""
 "Druckempfindlichkeit des Eingabegeräts benutzen, um die Anzahl der "
 "gesprühten Objekte zu beeinflussen"
 
-#: ../src/widgets/spray-toolbar.cpp:438
+#: ../src/widgets/spray-toolbar.cpp:436
 msgid "(high rotation variation)"
 msgstr "(starke Abweichung)"
 
-#: ../src/widgets/spray-toolbar.cpp:441
+#: ../src/widgets/spray-toolbar.cpp:439
 msgid "Rotation"
 msgstr "Drehung"
 
-#: ../src/widgets/spray-toolbar.cpp:441
+#: ../src/widgets/spray-toolbar.cpp:439
 msgid "Rotation:"
 msgstr "Drehung:"
 
-#: ../src/widgets/spray-toolbar.cpp:443
+#: ../src/widgets/spray-toolbar.cpp:441
 #, no-c-format
 msgid ""
 "Variation of the rotation of the sprayed objects; 0% for the same rotation "
@@ -31902,21 +32297,21 @@ msgstr ""
 "Variiert die Drehung der zu sprühenden Objekte. 0% bedeutet gleiche Drehung "
 "wie das Originalobjekt."
 
-#: ../src/widgets/spray-toolbar.cpp:456
+#: ../src/widgets/spray-toolbar.cpp:454
 msgid "(high scale variation)"
 msgstr "(starke Abweichung)"
 
-#: ../src/widgets/spray-toolbar.cpp:459
+#: ../src/widgets/spray-toolbar.cpp:457
 msgctxt "Spray tool"
 msgid "Scale"
 msgstr "Skalieren"
 
-#: ../src/widgets/spray-toolbar.cpp:459
+#: ../src/widgets/spray-toolbar.cpp:457
 msgctxt "Spray tool"
 msgid "Scale:"
 msgstr "Skalieren"
 
-#: ../src/widgets/spray-toolbar.cpp:461
+#: ../src/widgets/spray-toolbar.cpp:459
 #, no-c-format
 msgid ""
 "Variation in the scale of the sprayed objects; 0% for the same scale than "
@@ -31925,13 +32320,13 @@ msgstr ""
 "Variiert die Größe der zu sprühenden Objekte. 0% bedeutet gleiche Größe wie "
 "das Originalobjekt."
 
-#: ../src/widgets/spray-toolbar.cpp:477
+#: ../src/widgets/spray-toolbar.cpp:475
 msgid "Use the pressure of the input device to alter the scale of new items"
 msgstr ""
 "Druckempfindlichkeit des Eingabegeräts benutzen, um die Skalierung neuer "
 "Objekte zu beeinflussen"
 
-#: ../src/widgets/spray-toolbar.cpp:489 ../src/widgets/spray-toolbar.cpp:490
+#: ../src/widgets/spray-toolbar.cpp:487 ../src/widgets/spray-toolbar.cpp:488
 msgid ""
 "Pick color from the drawing. You can use clonetiler trace dialog for "
 "advanced effects. In clone mode original fill or stroke colors must be unset."
@@ -31940,57 +32335,57 @@ msgstr ""
 "Klone kann für fortgeschrittene Effekte verwendet werden. Im Klon-Modus "
 "müssen Füllung und Konturfarbe des Originalobjekts undefiniert sein."
 
-#: ../src/widgets/spray-toolbar.cpp:502 ../src/widgets/spray-toolbar.cpp:503
+#: ../src/widgets/spray-toolbar.cpp:500 ../src/widgets/spray-toolbar.cpp:501
 msgid "Pick from center instead average area."
 msgstr "Farbe vom Zentrum übernehmen statt über die gesamte Fläche zu mitteln."
 
-#: ../src/widgets/spray-toolbar.cpp:515 ../src/widgets/spray-toolbar.cpp:516
+#: ../src/widgets/spray-toolbar.cpp:513 ../src/widgets/spray-toolbar.cpp:514
 msgid "Inverted pick value, retaining color in advanced trace mode"
 msgstr ""
 "Übernommene Farbe invertieren, behält die Farbe im fortgeschrittenen Modus "
 "bei."
 
-#: ../src/widgets/spray-toolbar.cpp:528 ../src/widgets/spray-toolbar.cpp:529
+#: ../src/widgets/spray-toolbar.cpp:526 ../src/widgets/spray-toolbar.cpp:527
 msgid "Apply picked color to fill"
 msgstr "Gewählte Farbe auf Füllung anwenden"
 
-#: ../src/widgets/spray-toolbar.cpp:541 ../src/widgets/spray-toolbar.cpp:542
+#: ../src/widgets/spray-toolbar.cpp:539 ../src/widgets/spray-toolbar.cpp:540
 msgid "Apply picked color to stroke"
 msgstr "Gewählte Farbe auf Kontur anwenden"
 
-#: ../src/widgets/spray-toolbar.cpp:554 ../src/widgets/spray-toolbar.cpp:555
+#: ../src/widgets/spray-toolbar.cpp:552 ../src/widgets/spray-toolbar.cpp:553
 msgid "No overlap between colors"
 msgstr "Überlappung zwischen unterschiedlichen Farben verhindern"
 
-#: ../src/widgets/spray-toolbar.cpp:567 ../src/widgets/spray-toolbar.cpp:568
+#: ../src/widgets/spray-toolbar.cpp:565 ../src/widgets/spray-toolbar.cpp:566
 msgid "Apply over transparent areas"
 msgstr "Über transparenten Bereichen sprühen"
 
-#: ../src/widgets/spray-toolbar.cpp:580 ../src/widgets/spray-toolbar.cpp:581
+#: ../src/widgets/spray-toolbar.cpp:578 ../src/widgets/spray-toolbar.cpp:579
 msgid "Apply over no transparent areas"
 msgstr "Über nicht transparenten Bereichen sprühen"
 
-#: ../src/widgets/spray-toolbar.cpp:593 ../src/widgets/spray-toolbar.cpp:594
+#: ../src/widgets/spray-toolbar.cpp:591 ../src/widgets/spray-toolbar.cpp:592
 msgid "Prevent overlapping objects"
 msgstr "Überlappung zwischen gesprühten Objekten verhindern"
 
-#: ../src/widgets/spray-toolbar.cpp:605
+#: ../src/widgets/spray-toolbar.cpp:603
 msgid "(minimum offset)"
 msgstr "(minimaler Versatz)"
 
-#: ../src/widgets/spray-toolbar.cpp:605
+#: ../src/widgets/spray-toolbar.cpp:603
 msgid "(maximum offset)"
 msgstr "(maximaler Versatz)"
 
-#: ../src/widgets/spray-toolbar.cpp:608
+#: ../src/widgets/spray-toolbar.cpp:606
 msgid "Offset %"
 msgstr "Versatz"
 
-#: ../src/widgets/spray-toolbar.cpp:608
+#: ../src/widgets/spray-toolbar.cpp:606
 msgid "Offset %:"
 msgstr "Versatz:"
 
-#: ../src/widgets/spray-toolbar.cpp:609
+#: ../src/widgets/spray-toolbar.cpp:607
 msgid "Increase to segregate objects more (value in percent)"
 msgstr ""
 "Erhöhen um Separation zwischen gesprühten Objekten zu erhöhen (Wert in "
@@ -32020,154 +32415,154 @@ msgstr "Stern: Abrundung ändern"
 msgid "Star: Change randomization"
 msgstr "Stern: Zufälligkeit ändern"
 
-#: ../src/widgets/star-toolbar.cpp:461
+#: ../src/widgets/star-toolbar.cpp:473
 msgid "Regular polygon (with one handle) instead of a star"
 msgstr "Gewöhnliches Vieleck (Polygon mit einem Anfasser) statt eines Sterns"
 
-#: ../src/widgets/star-toolbar.cpp:468
+#: ../src/widgets/star-toolbar.cpp:480
 msgid "Star instead of a regular polygon (with one handle)"
 msgstr "Stern statt eines gewöhnlichen Vielecks (Polygon mit einem Anfasser)"
 
-#: ../src/widgets/star-toolbar.cpp:489
+#: ../src/widgets/star-toolbar.cpp:501
 msgid "triangle/tri-star"
 msgstr "Dreieck/Stern mit drei Spitzen"
 
-#: ../src/widgets/star-toolbar.cpp:489
+#: ../src/widgets/star-toolbar.cpp:501
 msgid "square/quad-star"
 msgstr "Quadrat/Stern mit vier Spitzen"
 
-#: ../src/widgets/star-toolbar.cpp:489
+#: ../src/widgets/star-toolbar.cpp:501
 msgid "pentagon/five-pointed star"
 msgstr "Fünfeck/Stern mit fünf Spitzen"
 
-#: ../src/widgets/star-toolbar.cpp:489
+#: ../src/widgets/star-toolbar.cpp:501
 msgid "hexagon/six-pointed star"
 msgstr "Sechseck/Stern mit sechs Spitzen"
 
-#: ../src/widgets/star-toolbar.cpp:492
+#: ../src/widgets/star-toolbar.cpp:504
 msgid "Corners"
 msgstr "Ecken"
 
-#: ../src/widgets/star-toolbar.cpp:492
+#: ../src/widgets/star-toolbar.cpp:504
 msgid "Corners:"
 msgstr "Ecken:"
 
-#: ../src/widgets/star-toolbar.cpp:492
+#: ../src/widgets/star-toolbar.cpp:504
 msgid "Number of corners of a polygon or star"
 msgstr "Zahl der Ecken eines Polygons oder Sterns"
 
-#: ../src/widgets/star-toolbar.cpp:505
+#: ../src/widgets/star-toolbar.cpp:517
 msgid "thin-ray star"
 msgstr "Dünnstrahliger Stern"
 
-#: ../src/widgets/star-toolbar.cpp:505
+#: ../src/widgets/star-toolbar.cpp:517
 msgid "pentagram"
 msgstr "Pentagram"
 
-#: ../src/widgets/star-toolbar.cpp:505
+#: ../src/widgets/star-toolbar.cpp:517
 msgid "hexagram"
 msgstr "hexagram"
 
-#: ../src/widgets/star-toolbar.cpp:505
+#: ../src/widgets/star-toolbar.cpp:517
 msgid "heptagram"
 msgstr "heptagram"
 
-#: ../src/widgets/star-toolbar.cpp:505
+#: ../src/widgets/star-toolbar.cpp:517
 msgid "octagram"
 msgstr "octagram"
 
-#: ../src/widgets/star-toolbar.cpp:505
+#: ../src/widgets/star-toolbar.cpp:517
 msgid "regular polygon"
 msgstr "Regelmäßiges Polygon erstellen"
 
-#: ../src/widgets/star-toolbar.cpp:508
+#: ../src/widgets/star-toolbar.cpp:520
 msgid "Spoke ratio"
 msgstr "Spitzenverhältnis:"
 
-#: ../src/widgets/star-toolbar.cpp:508
+#: ../src/widgets/star-toolbar.cpp:520
 msgid "Spoke ratio:"
 msgstr "Spitzenverhältnis:"
 
 #. TRANSLATORS: Tip radius of a star is the distance from the center to the farthest handle.
 #. Base radius is the same for the closest handle.
-#: ../src/widgets/star-toolbar.cpp:511
+#: ../src/widgets/star-toolbar.cpp:523
 msgid "Base radius to tip radius ratio"
 msgstr "Verhältnis vom Radius des Grundkörpers zum Radius der Spitzen"
 
-#: ../src/widgets/star-toolbar.cpp:529
+#: ../src/widgets/star-toolbar.cpp:541
 msgid "stretched"
 msgstr "gestreckt"
 
-#: ../src/widgets/star-toolbar.cpp:529
+#: ../src/widgets/star-toolbar.cpp:541
 msgid "twisted"
 msgstr "verdreht"
 
-#: ../src/widgets/star-toolbar.cpp:529
+#: ../src/widgets/star-toolbar.cpp:541
 msgid "slightly pinched"
 msgstr "leicht eingedrückt"
 
-#: ../src/widgets/star-toolbar.cpp:529
+#: ../src/widgets/star-toolbar.cpp:541
 msgid "NOT rounded"
 msgstr "NICHT abgerundet"
 
-#: ../src/widgets/star-toolbar.cpp:529
+#: ../src/widgets/star-toolbar.cpp:541
 msgid "slightly rounded"
 msgstr "schwach abgerundet"
 
-#: ../src/widgets/star-toolbar.cpp:529
+#: ../src/widgets/star-toolbar.cpp:541
 msgid "visibly rounded"
 msgstr "sichtbar abgerundet"
 
-#: ../src/widgets/star-toolbar.cpp:529
+#: ../src/widgets/star-toolbar.cpp:541
 msgid "well rounded"
 msgstr "gut abgerundet"
 
-#: ../src/widgets/star-toolbar.cpp:529
+#: ../src/widgets/star-toolbar.cpp:541
 msgid "amply rounded"
 msgstr "reichlich abgerundet"
 
-#: ../src/widgets/star-toolbar.cpp:529 ../src/widgets/star-toolbar.cpp:544
+#: ../src/widgets/star-toolbar.cpp:541 ../src/widgets/star-toolbar.cpp:556
 msgid "blown up"
 msgstr "aufgebläht"
 
-#: ../src/widgets/star-toolbar.cpp:532
+#: ../src/widgets/star-toolbar.cpp:544
 msgid "Rounded:"
 msgstr "Abrundung:"
 
-#: ../src/widgets/star-toolbar.cpp:532
+#: ../src/widgets/star-toolbar.cpp:544
 msgid "How much rounded are the corners (0 for sharp)"
 msgstr "Wie stark werden die Ecken abgerundet (0 für harte Kante)"
 
-#: ../src/widgets/star-toolbar.cpp:544
+#: ../src/widgets/star-toolbar.cpp:556
 msgid "NOT randomized"
 msgstr "NICHT durcheinander"
 
-#: ../src/widgets/star-toolbar.cpp:544
+#: ../src/widgets/star-toolbar.cpp:556
 msgid "slightly irregular"
 msgstr "leicht unregelmäßig"
 
-#: ../src/widgets/star-toolbar.cpp:544
+#: ../src/widgets/star-toolbar.cpp:556
 msgid "visibly randomized"
 msgstr "sichtbar unregelmäßig"
 
-#: ../src/widgets/star-toolbar.cpp:544
+#: ../src/widgets/star-toolbar.cpp:556
 msgid "strongly randomized"
 msgstr "stark unregelmäßig"
 
-#: ../src/widgets/star-toolbar.cpp:547
+#: ../src/widgets/star-toolbar.cpp:559
 msgid "Randomized"
 msgstr "unregelmäßig"
 
-#: ../src/widgets/star-toolbar.cpp:547
+#: ../src/widgets/star-toolbar.cpp:559
 msgid "Randomized:"
 msgstr "Zufallsänderung:"
 
-#: ../src/widgets/star-toolbar.cpp:547
+#: ../src/widgets/star-toolbar.cpp:559
 msgid "Scatter randomly the corners and angles"
 msgstr "Zufällige Variationen der Ecken und Winkel"
 
 # CHECK
-#: ../src/widgets/stroke-marker-selector.cpp:383
+#: ../src/widgets/stroke-marker-selector.cpp:369
 msgctxt "Marker"
 msgid "None"
 msgstr "Keine"
@@ -32299,354 +32694,410 @@ msgstr "Knotenmarkierungsfarbe festlegen"
 msgid "Change swatch color"
 msgstr "Farbmuster-Farbe ändern"
 
-#: ../src/widgets/text-toolbar.cpp:178
+#: ../src/widgets/text-toolbar.cpp:182
 msgid "Text: Change font family"
 msgstr "Text: Schriftfamilie ändern"
 
-#: ../src/widgets/text-toolbar.cpp:272
+#: ../src/widgets/text-toolbar.cpp:276
 msgid "Text: Change font size"
 msgstr "Text: Schriftgröße ändern"
 
-#: ../src/widgets/text-toolbar.cpp:317
+#: ../src/widgets/text-toolbar.cpp:321
 msgid "Text: Change font style"
 msgstr "Text: Schriftstil ändern"
 
-#: ../src/widgets/text-toolbar.cpp:356
+#: ../src/widgets/text-toolbar.cpp:360
 #, fuzzy
 msgid "Text: Unset line height."
 msgstr "Text: Linienhöhe ändern"
 
-#: ../src/widgets/text-toolbar.cpp:433
+#: ../src/widgets/text-toolbar.cpp:437
 msgid "Text: Change superscript or subscript"
 msgstr "Text: Ändern von Hoch- und Tiefgestellt"
 
-#: ../src/widgets/text-toolbar.cpp:574
+#: ../src/widgets/text-toolbar.cpp:578
 msgid "Text: Change alignment"
 msgstr "Text: Ausrichtung ändern"
 
-#: ../src/widgets/text-toolbar.cpp:677
+#: ../src/widgets/text-toolbar.cpp:711
 msgid "Text: Change line-height"
 msgstr "Text: Linienhöhe ändern"
 
-#: ../src/widgets/text-toolbar.cpp:832
+#: ../src/widgets/text-toolbar.cpp:875
 msgid "Text: Change line-height unit"
 msgstr "Text: Einheit für Zeilenabstand ändern"
 
-#: ../src/widgets/text-toolbar.cpp:881
+#: ../src/widgets/text-toolbar.cpp:1055
+#, fuzzy
+msgid "Text: Change line spacing mode"
+msgstr "Textrichtung ändern"
+
+#: ../src/widgets/text-toolbar.cpp:1092
 msgid "Text: Change word-spacing"
 msgstr "Text: Wortabstand ändern"
 
-#: ../src/widgets/text-toolbar.cpp:921
+#: ../src/widgets/text-toolbar.cpp:1132
 msgid "Text: Change letter-spacing"
 msgstr "Text: Buchstabenabstand ändern"
 
-#: ../src/widgets/text-toolbar.cpp:959
+#: ../src/widgets/text-toolbar.cpp:1170
 msgid "Text: Change dx (kern)"
 msgstr "Text: Ändern dx (kern)"
 
-#: ../src/widgets/text-toolbar.cpp:993
+#: ../src/widgets/text-toolbar.cpp:1204
 msgid "Text: Change dy"
 msgstr "Text: Ändern dy"
 
-#: ../src/widgets/text-toolbar.cpp:1028
+#: ../src/widgets/text-toolbar.cpp:1239
 msgid "Text: Change rotate"
 msgstr "Text: Ändern Drehung"
 
-#: ../src/widgets/text-toolbar.cpp:1079
+#: ../src/widgets/text-toolbar.cpp:1290
 msgid "Text: Change writing mode"
 msgstr "Textrichtung ändern"
 
-#: ../src/widgets/text-toolbar.cpp:1131
+#: ../src/widgets/text-toolbar.cpp:1344
 msgid "Text: Change orientation"
 msgstr "Textausrichtung ändern"
 
-#: ../src/widgets/text-toolbar.cpp:1177
+#: ../src/widgets/text-toolbar.cpp:1392
 #, fuzzy
 msgid "Text: Change direction"
 msgstr "Textausrichtung ändern"
 
-#: ../src/widgets/text-toolbar.cpp:1690
+#: ../src/widgets/text-toolbar.cpp:1992
 msgid "Font Family"
 msgstr "Schriftfamilie"
 
-#: ../src/widgets/text-toolbar.cpp:1691
+#: ../src/widgets/text-toolbar.cpp:1993
 msgid "Select Font Family (Alt-X to access)"
 msgstr "Schriftart-Familie auswählen (Alt + X zum Setzen)"
 
 #. Focus widget
 #. Enable entry completion
-#: ../src/widgets/text-toolbar.cpp:1701
+#: ../src/widgets/text-toolbar.cpp:2003
 msgid "Select all text with this font-family"
 msgstr "Wähle allen Text mit dieser Schriftart-Familie aus"
 
-#: ../src/widgets/text-toolbar.cpp:1705
+#: ../src/widgets/text-toolbar.cpp:2007
 msgid "Font not found on system"
 msgstr "Schrift wurde im System nicht gefunden"
 
-#: ../src/widgets/text-toolbar.cpp:1763
+#: ../src/widgets/text-toolbar.cpp:2065
 msgid "Font Style"
 msgstr "Schriftstil"
 
-#: ../src/widgets/text-toolbar.cpp:1764
+#: ../src/widgets/text-toolbar.cpp:2066
 msgid "Font style"
 msgstr "Schriftstil"
 
 #. Name
-#: ../src/widgets/text-toolbar.cpp:1781
+#: ../src/widgets/text-toolbar.cpp:2083
 msgid "Toggle Superscript"
 msgstr "Hochgestellt umschalten"
 
 #. Label
-#: ../src/widgets/text-toolbar.cpp:1782
+#: ../src/widgets/text-toolbar.cpp:2084
 msgid "Toggle superscript"
 msgstr "Hochgestellt umschalten"
 
 #. Name
-#: ../src/widgets/text-toolbar.cpp:1794
+#: ../src/widgets/text-toolbar.cpp:2096
 msgid "Toggle Subscript"
 msgstr "Tiefgestellt umschalten"
 
 #. Label
-#: ../src/widgets/text-toolbar.cpp:1795
+#: ../src/widgets/text-toolbar.cpp:2097
 msgid "Toggle subscript"
 msgstr "Tiefgestellt umschalten"
 
-#: ../src/widgets/text-toolbar.cpp:1831
+#: ../src/widgets/text-toolbar.cpp:2133
 msgid "Justify"
 msgstr "Blocksatz"
 
 # Alignment (left, center, right, block)
 #. Name
-#: ../src/widgets/text-toolbar.cpp:1838
+#: ../src/widgets/text-toolbar.cpp:2140
 msgid "Alignment"
 msgstr "Ausrichtung"
 
 #. Label
-#: ../src/widgets/text-toolbar.cpp:1839
+#: ../src/widgets/text-toolbar.cpp:2141
 msgid "Text alignment"
 msgstr "Textausrichtung"
 
-#: ../src/widgets/text-toolbar.cpp:1868
+#: ../src/widgets/text-toolbar.cpp:2170
 msgid "Vertical — RL"
 msgstr "Vertikal — RL"
 
-#: ../src/widgets/text-toolbar.cpp:1869
+#: ../src/widgets/text-toolbar.cpp:2171
 msgid "Vertical text — lines: right to left"
 msgstr "Vertikaler Text — Zeilen von rechts nach links"
 
-#: ../src/widgets/text-toolbar.cpp:1874
+#: ../src/widgets/text-toolbar.cpp:2176
 msgid "Vertical — LR"
 msgstr "Vertikal — LR"
 
-#: ../src/widgets/text-toolbar.cpp:1875
+#: ../src/widgets/text-toolbar.cpp:2177
 msgid "Vertical text — lines: left to right"
 msgstr "Vertikaler Text — Zeilen von links nach rechts"
 
 # Writing mode (Horizontal, Vertical-LR, Vertical-RL)
 #. Name
-#: ../src/widgets/text-toolbar.cpp:1881
+#: ../src/widgets/text-toolbar.cpp:2183
 msgid "Writing mode"
 msgstr "Textrichtung"
 
 #. Label
-#: ../src/widgets/text-toolbar.cpp:1882
+#: ../src/widgets/text-toolbar.cpp:2184
 msgid "Block progression"
 msgstr "Textrichtung"
 
-#: ../src/widgets/text-toolbar.cpp:1906
+#: ../src/widgets/text-toolbar.cpp:2208
 msgid "Auto glyph orientation"
 msgstr "Automatische Zeichenausrichtung"
 
-#: ../src/widgets/text-toolbar.cpp:1911
+#: ../src/widgets/text-toolbar.cpp:2213
 msgid "Upright"
 msgstr "Aufrecht"
 
-#: ../src/widgets/text-toolbar.cpp:1912
+#: ../src/widgets/text-toolbar.cpp:2214
 msgid "Upright glyph orientation"
 msgstr "Aufrechte Zeichenausrichtung"
 
-#: ../src/widgets/text-toolbar.cpp:1917
+#: ../src/widgets/text-toolbar.cpp:2219
 msgid "Sideways"
 msgstr "Gedreht"
 
-#: ../src/widgets/text-toolbar.cpp:1918
+#: ../src/widgets/text-toolbar.cpp:2220
 msgid "Sideways glyph orientation"
 msgstr "Gedrehte Zeichenausrichtung"
 
 # Text (glyph) orientation (Auto (mixed), Upright, Sideways)
 #. Name
-#: ../src/widgets/text-toolbar.cpp:1924
+#: ../src/widgets/text-toolbar.cpp:2226
 msgid "Text orientation"
 msgstr "Zeichenausrichtung"
 
 #. Label
-#: ../src/widgets/text-toolbar.cpp:1925
+#: ../src/widgets/text-toolbar.cpp:2227
 msgid "Text (glyph) orientation in vertical text."
 msgstr "Zeichenausrichtung in vertikalem Text"
 
-#: ../src/widgets/text-toolbar.cpp:1949
+#: ../src/widgets/text-toolbar.cpp:2251
 msgid "LTR"
 msgstr ""
 
-#: ../src/widgets/text-toolbar.cpp:1950
+#: ../src/widgets/text-toolbar.cpp:2252
 #, fuzzy
 msgid "Left to right text"
 msgstr "Links nach Rechts"
 
-#: ../src/widgets/text-toolbar.cpp:1955
+#: ../src/widgets/text-toolbar.cpp:2257
 msgid "RTL"
 msgstr ""
 
-#: ../src/widgets/text-toolbar.cpp:1956
+#: ../src/widgets/text-toolbar.cpp:2258
 #, fuzzy
 msgid "Right to left text"
 msgstr "Rechts nach Links"
 
 #. Name
-#: ../src/widgets/text-toolbar.cpp:1962
+#: ../src/widgets/text-toolbar.cpp:2264
 #, fuzzy
 msgid "Text direction"
 msgstr "Textrichtung:"
 
 #. Label
-#: ../src/widgets/text-toolbar.cpp:1963
+#: ../src/widgets/text-toolbar.cpp:2265
 msgid "Text direction for normally horizontal text."
 msgstr ""
 
 #. Drop down menu
-#: ../src/widgets/text-toolbar.cpp:1989
+#: ../src/widgets/text-toolbar.cpp:2291
 msgid "Smaller spacing"
 msgstr "Kleinerer Abstand"
 
-#: ../src/widgets/text-toolbar.cpp:1989 ../src/widgets/text-toolbar.cpp:2028
-#: ../src/widgets/text-toolbar.cpp:2059
+#: ../src/widgets/text-toolbar.cpp:2291 ../src/widgets/text-toolbar.cpp:2379
+#: ../src/widgets/text-toolbar.cpp:2410
 msgctxt "Text tool"
 msgid "Normal"
 msgstr "Normal"
 
-#: ../src/widgets/text-toolbar.cpp:1989
+#: ../src/widgets/text-toolbar.cpp:2291
 msgid "Larger spacing"
 msgstr "Größerer Abstand"
 
 #. name
-#: ../src/widgets/text-toolbar.cpp:1994
+#: ../src/widgets/text-toolbar.cpp:2296
 msgid "Line Height"
 msgstr "Linienhöhe"
 
 #. label
-#: ../src/widgets/text-toolbar.cpp:1995
+#: ../src/widgets/text-toolbar.cpp:2297
 msgid "Line:"
 msgstr "Linie:"
 
 #. short label
-#: ../src/widgets/text-toolbar.cpp:1996
+#: ../src/widgets/text-toolbar.cpp:2298
 #, fuzzy
 msgid "Spacing between baselines"
 msgstr "Abstand zwischen Grundlinien (relativ zur Schriftgröße)"
 
+#: ../src/widgets/text-toolbar.cpp:2337
+#, fuzzy
+msgid "Adaptive"
+msgstr "Kombinieren"
+
+#: ../src/widgets/text-toolbar.cpp:2338
+msgid "Line spacing adapts to font size."
+msgstr ""
+
+#: ../src/widgets/text-toolbar.cpp:2343
+#: ../share/extensions/polyhedron_3d.inx.h:54
+msgid "Minimum"
+msgstr "Minimun"
+
+#: ../src/widgets/text-toolbar.cpp:2344
+msgid "Line spacing adapts to fonts size with set minimum spacing."
+msgstr ""
+
+#: ../src/widgets/text-toolbar.cpp:2348
+msgid "Even"
+msgstr ""
+
+#: ../src/widgets/text-toolbar.cpp:2349
+msgid "Lines evenly spaced."
+msgstr ""
+
+#: ../src/widgets/text-toolbar.cpp:2354
+#, fuzzy
+msgid "Adjustable ☠"
+msgstr "Alpha anpassen"
+
+#: ../src/widgets/text-toolbar.cpp:2355
+msgid "Line spacing fully adjustable"
+msgstr ""
+
+#. Name
+#: ../src/widgets/text-toolbar.cpp:2361
+#, fuzzy
+msgid "Line Spacing Mode"
+msgstr "Zeilenabstand:"
+
+#. Label
+#: ../src/widgets/text-toolbar.cpp:2362
+msgid ""
+"How should multiple baselines be spaced?\n"
+" Adaptive: Line spacing adapts to font size.\n"
+" Minimum: Like Adaptive, but with a set minimum.\n"
+" Even: Evenly spaced.\n"
+" Adjustable: No restrictions."
+msgstr ""
+
 #. Drop down menu
-#: ../src/widgets/text-toolbar.cpp:2028 ../src/widgets/text-toolbar.cpp:2059
+#: ../src/widgets/text-toolbar.cpp:2379 ../src/widgets/text-toolbar.cpp:2410
 msgid "Negative spacing"
 msgstr "Negativer Abstand"
 
-#: ../src/widgets/text-toolbar.cpp:2028 ../src/widgets/text-toolbar.cpp:2059
+#: ../src/widgets/text-toolbar.cpp:2379 ../src/widgets/text-toolbar.cpp:2410
 msgid "Positive spacing"
 msgstr "Positiver Abstand"
 
 #. name
-#: ../src/widgets/text-toolbar.cpp:2033
+#: ../src/widgets/text-toolbar.cpp:2384
 msgid "Word spacing"
 msgstr "Wortabstand"
 
 #. label
-#: ../src/widgets/text-toolbar.cpp:2034
+#: ../src/widgets/text-toolbar.cpp:2385
 msgid "Word:"
 msgstr "Wort:"
 
 #. short label
-#: ../src/widgets/text-toolbar.cpp:2035
+#: ../src/widgets/text-toolbar.cpp:2386
 msgid "Spacing between words (px)"
 msgstr "Wortabstand (px)"
 
 #. name
-#: ../src/widgets/text-toolbar.cpp:2064
+#: ../src/widgets/text-toolbar.cpp:2415
 msgid "Letter spacing"
 msgstr "Buchstabenabstand"
 
 #. label
-#: ../src/widgets/text-toolbar.cpp:2065
+#: ../src/widgets/text-toolbar.cpp:2416
 msgid "Letter:"
 msgstr "Buchstabe:"
 
 #. short label
-#: ../src/widgets/text-toolbar.cpp:2066
+#: ../src/widgets/text-toolbar.cpp:2417
 msgid "Spacing between letters (px)"
 msgstr "Zeichenabstand (px)"
 
 #. name
-#: ../src/widgets/text-toolbar.cpp:2095
+#: ../src/widgets/text-toolbar.cpp:2446
 msgid "Kerning"
 msgstr "Unterschneidung"
 
 #. label
-#: ../src/widgets/text-toolbar.cpp:2096
+#: ../src/widgets/text-toolbar.cpp:2447
 msgid "Kern:"
 msgstr "Kern:"
 
 #. short label
-#: ../src/widgets/text-toolbar.cpp:2097
+#: ../src/widgets/text-toolbar.cpp:2448
 msgid "Horizontal kerning (px)"
 msgstr "Horizontale Unterschneidung (px)"
 
 #. name
-#: ../src/widgets/text-toolbar.cpp:2126
+#: ../src/widgets/text-toolbar.cpp:2477
 msgid "Vertical Shift"
 msgstr "Vertikaler Versatz"
 
 #. label
-#: ../src/widgets/text-toolbar.cpp:2127
+#: ../src/widgets/text-toolbar.cpp:2478
 msgid "Vert:"
 msgstr "Vert:"
 
 #. short label
-#: ../src/widgets/text-toolbar.cpp:2128
+#: ../src/widgets/text-toolbar.cpp:2479
 msgid "Vertical shift (px)"
 msgstr "Vertikaler Versatz (px)"
 
 #. name
-#: ../src/widgets/text-toolbar.cpp:2157
+#: ../src/widgets/text-toolbar.cpp:2508
 msgid "Letter rotation"
 msgstr "Buchstabendrehung"
 
 #. label
-#: ../src/widgets/text-toolbar.cpp:2158
+#: ../src/widgets/text-toolbar.cpp:2509
 msgid "Rot:"
 msgstr "Dreh:"
 
 #. short label
-#: ../src/widgets/text-toolbar.cpp:2159
+#: ../src/widgets/text-toolbar.cpp:2510
 msgid "Character rotation (degrees)"
 msgstr "Zeichendrehung (Grad)"
 
 #. Name
-#: ../src/widgets/text-toolbar.cpp:2183
+#: ../src/widgets/text-toolbar.cpp:2534
 #, fuzzy
 msgid "Unset line height"
 msgstr "Zeilen rechts ausrichten"
 
 #. Label
-#: ../src/widgets/text-toolbar.cpp:2184
+#: ../src/widgets/text-toolbar.cpp:2535
 msgid "If enabled, line height is set on part of selection. Click to unset."
 msgstr ""
 
 #. Name
-#: ../src/widgets/text-toolbar.cpp:2196
+#: ../src/widgets/text-toolbar.cpp:2547
 #, fuzzy
 msgid "Show outer style"
 msgstr "Schattige Außenschräge"
 
 #. Label
-#: ../src/widgets/text-toolbar.cpp:2197
+#: ../src/widgets/text-toolbar.cpp:2548
 msgid ""
 "Show style of outermost text element. The 'font-size' and 'line-height' "
 "values of the outermost text element determine the minimum line spacing in "
@@ -32697,133 +33148,133 @@ msgstr "\"Beschreibung fehlt noch!\""
 msgid "Style of Paint Bucket fill objects"
 msgstr "Stil von neuen Farbeimer-Objekten"
 
-#: ../src/widgets/toolbox.cpp:1245
+#: ../src/widgets/toolbox.cpp:1248
 msgid "Bounding box"
 msgstr "Objektrahmen"
 
-#: ../src/widgets/toolbox.cpp:1245
+#: ../src/widgets/toolbox.cpp:1248
 msgid "Snap bounding boxes"
 msgstr "Objektrahmen einrasten"
 
-#: ../src/widgets/toolbox.cpp:1254
+#: ../src/widgets/toolbox.cpp:1257
 msgid "Bounding box edges"
 msgstr "Kanten des Objektrahmens"
 
-#: ../src/widgets/toolbox.cpp:1254
+#: ../src/widgets/toolbox.cpp:1257
 msgid "Snap to edges of a bounding box"
 msgstr "An Kanten eines Objektrahmens einrasten"
 
-#: ../src/widgets/toolbox.cpp:1263
+#: ../src/widgets/toolbox.cpp:1266
 msgid "Bounding box corners"
 msgstr "Ecken des Objektrahmens"
 
-#: ../src/widgets/toolbox.cpp:1263
+#: ../src/widgets/toolbox.cpp:1266
 msgid "Snap bounding box corners"
 msgstr "Ecken des Objektrahmens einrasten"
 
-#: ../src/widgets/toolbox.cpp:1272
+#: ../src/widgets/toolbox.cpp:1275
 msgid "BBox Edge Midpoints"
 msgstr "Mittelpunkte von Objektrahmenlinien"
 
-#: ../src/widgets/toolbox.cpp:1272
+#: ../src/widgets/toolbox.cpp:1275
 msgid "Snap midpoints of bounding box edges"
 msgstr "Mittelpunkte von Objektrahmenlinien einrasten"
 
-#: ../src/widgets/toolbox.cpp:1282
+#: ../src/widgets/toolbox.cpp:1285
 msgid "BBox Centers"
 msgstr "Mittelpunkte von Objektrahmen"
 
-#: ../src/widgets/toolbox.cpp:1282
+#: ../src/widgets/toolbox.cpp:1285
 msgid "Snapping centers of bounding boxes"
 msgstr "Mittelpunkte von Objektrahmen einrasten"
 
-#: ../src/widgets/toolbox.cpp:1291
+#: ../src/widgets/toolbox.cpp:1294
 msgid "Snap nodes, paths, and handles"
 msgstr "Knoten, Pfade und Anfasser einrasten"
 
-#: ../src/widgets/toolbox.cpp:1299
+#: ../src/widgets/toolbox.cpp:1302
 msgid "Snap to paths"
 msgstr "An Pfaden einrasten"
 
-#: ../src/widgets/toolbox.cpp:1308
+#: ../src/widgets/toolbox.cpp:1311
 msgid "Path intersections"
 msgstr "Pfadüberschneidungen"
 
-#: ../src/widgets/toolbox.cpp:1308
+#: ../src/widgets/toolbox.cpp:1311
 msgid "Snap to path intersections"
 msgstr "An Pfadüberschneidungen einrasten"
 
-#: ../src/widgets/toolbox.cpp:1317
+#: ../src/widgets/toolbox.cpp:1320
 msgid "To nodes"
 msgstr "An Knoten"
 
-#: ../src/widgets/toolbox.cpp:1317
+#: ../src/widgets/toolbox.cpp:1320
 msgid "Snap cusp nodes, incl. rectangle corners"
 msgstr "Spitze Knoten einrasten, inkl. Ecken von Rechtecken"
 
-#: ../src/widgets/toolbox.cpp:1326
+#: ../src/widgets/toolbox.cpp:1329
 msgid "Smooth nodes"
 msgstr "Glatte Knoten"
 
-#: ../src/widgets/toolbox.cpp:1326
+#: ../src/widgets/toolbox.cpp:1329
 msgid "Snap smooth nodes, incl. quadrant points of ellipses"
 msgstr "Glatte Knoten einrasten, inkl. Quadrantenpunkte von Ellipsen"
 
-#: ../src/widgets/toolbox.cpp:1335
+#: ../src/widgets/toolbox.cpp:1338
 msgid "Line Midpoints"
 msgstr "Linien-Mittelpunkte"
 
-#: ../src/widgets/toolbox.cpp:1335
+#: ../src/widgets/toolbox.cpp:1338
 msgid "Snap midpoints of line segments"
 msgstr "Mittelpunkte von Liniensegmenten einrasten"
 
-#: ../src/widgets/toolbox.cpp:1344
+#: ../src/widgets/toolbox.cpp:1347
 msgid "Others"
 msgstr "Andere"
 
-#: ../src/widgets/toolbox.cpp:1344
+#: ../src/widgets/toolbox.cpp:1347
 msgid "Snap other points (centers, guide origins, gradient handles, etc.)"
 msgstr ""
 "Andere Punkte einrasten (Mittelpunkte, Ursprünge von Hilfslinien, Anfasser "
 "von Farbverläufen, usw.)"
 
-#: ../src/widgets/toolbox.cpp:1352
+#: ../src/widgets/toolbox.cpp:1355
 msgid "Object Centers"
 msgstr "Objektmittelpunkte"
 
-#: ../src/widgets/toolbox.cpp:1352
+#: ../src/widgets/toolbox.cpp:1355
 msgid "Snap centers of objects"
 msgstr "Objektmittelpunkte einrasten"
 
-#: ../src/widgets/toolbox.cpp:1361
+#: ../src/widgets/toolbox.cpp:1364
 msgid "Rotation Centers"
 msgstr "Drehpunkte"
 
-#: ../src/widgets/toolbox.cpp:1361
+#: ../src/widgets/toolbox.cpp:1364
 msgid "Snap an item's rotation center"
 msgstr "Drehpunkte von Objekten einrasten"
 
-#: ../src/widgets/toolbox.cpp:1370
+#: ../src/widgets/toolbox.cpp:1373
 msgid "Text baseline"
 msgstr "Text-Grundlinie"
 
-#: ../src/widgets/toolbox.cpp:1370
+#: ../src/widgets/toolbox.cpp:1373
 msgid "Snap text anchors and baselines"
 msgstr "Textanker und Grundlinien einrasten"
 
-#: ../src/widgets/toolbox.cpp:1380
+#: ../src/widgets/toolbox.cpp:1383
 msgid "Page border"
 msgstr "Seitenrand"
 
-#: ../src/widgets/toolbox.cpp:1380
+#: ../src/widgets/toolbox.cpp:1383
 msgid "Snap to the page border"
 msgstr "Am Seitenrand einrasten"
 
-#: ../src/widgets/toolbox.cpp:1389
+#: ../src/widgets/toolbox.cpp:1392
 msgid "Snap to grids"
 msgstr "Am Gitter einrasten"
 
-#: ../src/widgets/toolbox.cpp:1398
+#: ../src/widgets/toolbox.cpp:1401
 msgid "Snap guides"
 msgstr "Hilfslinien einrasten"
 
@@ -33465,19 +33916,23 @@ msgstr "Python Version ist:"
 msgid "Please select an object"
 msgstr "Bitte wählen Sie ein Objekt."
 
-#: ../share/extensions/gimp_xcf.py:37
+#: ../share/extensions/gimp_xcf.py:38
 msgid "Inkscape must be installed and set in your path variable."
 msgstr "Inkscape muss installiert und in Ihren Pfadvariablen gesetzt sein."
 
-#: ../share/extensions/gimp_xcf.py:41
+#: ../share/extensions/gimp_xcf.py:42
 msgid "Gimp must be installed and set in your path variable."
 msgstr "Gimp muss installiert und in Ihren Pfadvariablen gesetzt sein."
 
-#: ../share/extensions/gimp_xcf.py:45
+#: ../share/extensions/gimp_xcf.py:46
 msgid "An error occurred while processing the XCF file."
 msgstr "Es ist beim Verarbeiten der XCF-Datei ein fehler aufgetreten."
 
-#: ../share/extensions/gimp_xcf.py:183
+#: ../share/extensions/gimp_xcf.py:92 ../share/extensions/inkex.py:358
+msgid "SVG Width not set correctly! Assuming width = 100"
+msgstr "Breite des SVGs nicht richtig gesetzt. Benutze width = 100"
+
+#: ../share/extensions/gimp_xcf.py:228
 msgid "This extension requires at least one non empty layer."
 msgstr "Diese Erweiterung benötigt mindestens eine nicht leere Ebene."
 
@@ -33507,7 +33962,7 @@ msgstr ""
 "fehlen Teile des Inhalts der Zeichnung."
 
 #. issue error if no paths found
-#: ../share/extensions/hpgl_output.py:57
+#: ../share/extensions/hpgl_output.py:58
 msgid ""
 "No paths where found. Please convert all objects you want to save into paths."
 msgstr ""
@@ -33549,11 +34004,12 @@ msgstr "Konnte die Objekt-Mitgliedschaftsdatei nicht öffnen: %s"
 msgid "No matching node for expression: %s"
 msgstr "Kein passender Knoten für Ausdruck: %s"
 
-#: ../share/extensions/inkex.py:358
-msgid "SVG Width not set correctly! Assuming width = 100"
-msgstr "Breite des SVGs nicht richtig gesetzt. Benutze width = 100"
+#: ../share/extensions/interp_att_g.py:146
+#, fuzzy
+msgid "You selected 'Other'. Please enter an attribute to interpolate."
+msgstr "Alle ausgewählten setzen ein Attribut in dem Letzten"
 
-#: ../share/extensions/interp_att_g.py:175
+#: ../share/extensions/interp_att_g.py:182
 msgid "There is no selection to interpolate"
 msgstr "Es gibt keine Auswahl zum interpolieren"
 
@@ -33827,7 +34283,7 @@ msgstr ""
 "versuchen es erneut. Auf einem Debian-Betriebssystem können Sie dafür "
 "folgenden Befehl nutzen: sudo apt-get install python-numpy"
 
-#: ../share/extensions/perspective.py:60 ../share/extensions/summersnight.py:49
+#: ../share/extensions/perspective.py:69 ../share/extensions/summersnight.py:58
 #, python-format
 msgid ""
 "The first selected object is of type '%s'.\n"
@@ -33836,14 +34292,15 @@ msgstr ""
 "Das erste ausgewählte Objekt ist vom Typ '%s'.\n"
 "Probiere Prozedur Pfad | Objekt in Pfad umwandeln."
 
-#: ../share/extensions/perspective.py:67 ../share/extensions/summersnight.py:57
+#: ../share/extensions/perspective.py:76 ../share/extensions/summersnight.py:66
 msgid ""
 "This extension requires that the second selected path be four nodes long."
 msgstr ""
 "Diese Erweiterung erwartet, dass der als zweites gewählte Pfad vier Knoten "
 "lang ist."
 
-#: ../share/extensions/perspective.py:93 ../share/extensions/summersnight.py:90
+#: ../share/extensions/perspective.py:102
+#: ../share/extensions/summersnight.py:99
 msgid ""
 "The second selected object is a group, not a path.\n"
 "Try using the procedure Object->Ungroup."
@@ -33851,7 +34308,8 @@ msgstr ""
 "Das als zweites gewählte Objekt ist eine Gruppe, kein Pfad.\n"
 " Versuchen Sie den Befehl Objekt | Gruppierung aufheben."
 
-#: ../share/extensions/perspective.py:95 ../share/extensions/summersnight.py:92
+#: ../share/extensions/perspective.py:104
+#: ../share/extensions/summersnight.py:101
 msgid ""
 "The second selected object is not a path.\n"
 "Try using the procedure Path->Object to Path."
@@ -33859,7 +34317,8 @@ msgstr ""
 "Das als zweites ausgewählte Objekt ist kein Pfad.\n"
 " Versuchen Sie den Befehl Pfad | Objekt in Pfad umwandeln."
 
-#: ../share/extensions/perspective.py:98 ../share/extensions/summersnight.py:95
+#: ../share/extensions/perspective.py:107
+#: ../share/extensions/summersnight.py:104
 msgid ""
 "The first selected object is not a path.\n"
 "Try using the procedure Path->Object to Path."
@@ -33868,41 +34327,41 @@ msgstr ""
 " Versuchen sie den Befehl Pfad | Objekt in Pfad umwandeln."
 
 #. issue error if no paths found
-#: ../share/extensions/plotter.py:68
+#: ../share/extensions/plotter.py:69
 msgid ""
 "No paths where found. Please convert all objects you want to plot into paths."
 msgstr ""
 "Keine Pfade gefunden. Bitte alle zu plottenden Objekte in Pfade umwandeln."
 
-#: ../share/extensions/plotter.py:146
+#: ../share/extensions/plotter.py:147
 msgid "pySerial is not installed. Please follow these steps:"
 msgstr "pySerial ist nicht installiert. Bitte folgen Sie diesen Anweisungen:"
 
-#: ../share/extensions/plotter.py:147
+#: ../share/extensions/plotter.py:148
 msgid "1. Download and extract (unzip) this file to your local harddisk:"
 msgstr ""
 "1. Laden Sie diese Datei herunter und entpacken (unzip) Sie sie auf Ihre "
 "lokale Festplatte:"
 
-#: ../share/extensions/plotter.py:149
+#: ../share/extensions/plotter.py:150
 msgid ""
 "2. Copy the \"serial\" folder (Can be found inside the just extracted folder)"
 msgstr ""
 "2. Kopieren Sie den Ordner „serial“ (befindet sich in dem soeben entpackten "
 "Verzeichnis)"
 
-#: ../share/extensions/plotter.py:150
+#: ../share/extensions/plotter.py:151
 msgid ""
 "   into the following Inkscape folder: C:\\[Program files]\\inkscape\\python"
 "\\Lib\\"
 msgstr ""
 "in den folgenden Inkscape-Ordner: C:\\[Programme]\\inkscape\\python\\Lib\\"
 
-#: ../share/extensions/plotter.py:151
+#: ../share/extensions/plotter.py:152
 msgid "3. Close and restart Inkscape."
 msgstr "3. Schließen Sie Inkscape und starten Sie es erneut."
 
-#: ../share/extensions/plotter.py:200
+#: ../share/extensions/plotter.py:201
 msgid ""
 "Could not open port. Please check that your plotter is running, connected "
 "and the settings are correct."
@@ -34157,7 +34616,7 @@ msgstr "Anzahl der Segmente"
 #: ../share/extensions/convert2dashes.inx.h:2
 #: ../share/extensions/edge3d.inx.h:9 ../share/extensions/flatten.inx.h:3
 #: ../share/extensions/fractalize.inx.h:4
-#: ../share/extensions/interp_att_g.inx.h:31
+#: ../share/extensions/interp_att_g.inx.h:34
 #: ../share/extensions/jitternodes.inx.h:14
 #: ../share/extensions/markers_strokepaint.inx.h:13
 #: ../share/extensions/perspective.inx.h:2
@@ -36853,7 +37312,7 @@ msgstr ""
 "aktiviert)"
 
 #: ../share/extensions/hpgl_input.inx.h:9
-#: ../share/extensions/hpgl_output.inx.h:35
+#: ../share/extensions/hpgl_output.inx.h:37
 msgid "HP Graphics Language file (*.hpgl)"
 msgstr "HP Graphics Language-Datei (*.hpgl)"
 
@@ -37050,6 +37509,19 @@ msgstr ""
 
 #: ../share/extensions/hpgl_output.inx.h:34
 #: ../share/extensions/plotter.inx.h:64
+#, fuzzy
+msgid "Convert objects to paths"
+msgstr "Wandle Objekte in Pfade um..."
+
+#: ../share/extensions/hpgl_output.inx.h:35
+#: ../share/extensions/plotter.inx.h:65
+msgid ""
+"Check this to automatically (nondestructively) convert all objects to paths "
+"before plotting (Default: Checked)"
+msgstr ""
+
+#: ../share/extensions/hpgl_output.inx.h:36
+#: ../share/extensions/plotter.inx.h:66
 msgid ""
 "All these settings depend on the plotter you use, for more information "
 "please consult the manual or homepage for your plotter."
@@ -37058,7 +37530,7 @@ msgstr ""
 "beachten Sie dessen Bedienungsanleitung oder die Informationen auf der "
 "Webseite des Plotterherstellers."
 
-#: ../share/extensions/hpgl_output.inx.h:36
+#: ../share/extensions/hpgl_output.inx.h:38
 msgid "Export an HP Graphics Language file"
 msgstr "HP Graphic Language-Datei exportieren"
 
@@ -37233,11 +37705,11 @@ msgstr "Endpfade duplizieren"
 msgid "Interpolate style"
 msgstr "Stil interpolieren"
 
-#: ../share/extensions/interp.inx.h:7 ../share/extensions/interp_att_g.inx.h:10
+#: ../share/extensions/interp.inx.h:7 ../share/extensions/interp_att_g.inx.h:12
 msgid "Use Z-order"
 msgstr "Stapelordnung verwenden"
 
-#: ../share/extensions/interp.inx.h:8 ../share/extensions/interp_att_g.inx.h:11
+#: ../share/extensions/interp.inx.h:8 ../share/extensions/interp_att_g.inx.h:13
 msgid "Workaround for reversed selection order in Live Preview cycles"
 msgstr ""
 "Schafft Abhilfe für die wechselnde Auswahlreihenfolge in Vorschauzyklen"
@@ -37255,72 +37727,87 @@ msgid "Other Attribute:"
 msgstr "Anderes Attribut:"
 
 #: ../share/extensions/interp_att_g.inx.h:5
+msgid "Examples: r, width, inkscape:rounded, sodipodi:sides"
+msgstr ""
+
+#: ../share/extensions/interp_att_g.inx.h:6
 msgid "Other Attribute type:"
 msgstr "Anderer Attributtyp:"
 
-#: ../share/extensions/interp_att_g.inx.h:6
+#: ../share/extensions/interp_att_g.inx.h:7
 msgid "Apply to:"
 msgstr "Anwenden auf:"
 
-#: ../share/extensions/interp_att_g.inx.h:7
+#: ../share/extensions/interp_att_g.inx.h:8
 msgid "Start Value:"
 msgstr "Startwert:"
 
-#: ../share/extensions/interp_att_g.inx.h:8
+#: ../share/extensions/interp_att_g.inx.h:9
+msgid "Examples: 0.5, 5, #rgb, #rrggbb or r, g, b"
+msgstr ""
+
+#: ../share/extensions/interp_att_g.inx.h:10
 msgid "End Value:"
 msgstr "Endwert:"
 
-#: ../share/extensions/interp_att_g.inx.h:15
+#: ../share/extensions/interp_att_g.inx.h:17
 msgid "Translate X"
 msgstr "Verschiebung X"
 
-#: ../share/extensions/interp_att_g.inx.h:16
+#: ../share/extensions/interp_att_g.inx.h:18
 msgid "Translate Y"
 msgstr "Verschiebung Y"
 
-#: ../share/extensions/interp_att_g.inx.h:17
+#: ../share/extensions/interp_att_g.inx.h:19
 #: ../share/extensions/markers_strokepaint.inx.h:9
 msgid "Fill"
 msgstr "Füllung"
 
-#: ../share/extensions/interp_att_g.inx.h:19
+#: ../share/extensions/interp_att_g.inx.h:21
 msgid "Other"
 msgstr "Andere"
 
-#: ../share/extensions/interp_att_g.inx.h:20
+#: ../share/extensions/interp_att_g.inx.h:22
+#, fuzzy
+msgid "Other Attribute"
+msgstr "Anderes Attribut:"
+
+#: ../share/extensions/interp_att_g.inx.h:23
+#, fuzzy
 msgid ""
-"If you select \"Other\", you must know the SVG attributes to identify here "
-"this \"other\"."
+"If you selected \"Other\" above, you must specify the details for this "
+"\"other\" here."
 msgstr ""
 "Falls Sie \"Andere\" wählen, so müssen Sie diese Anderen durch deren SVG-"
 "Attribute spezifizieren:"
 
-#: ../share/extensions/interp_att_g.inx.h:22
+#: ../share/extensions/interp_att_g.inx.h:25
 msgid "Integer Number"
 msgstr "Ganzzahl"
 
-#: ../share/extensions/interp_att_g.inx.h:23
+#: ../share/extensions/interp_att_g.inx.h:26
 msgid "Float Number"
 msgstr "Fließkommazahl"
 
-#: ../share/extensions/interp_att_g.inx.h:25
+#: ../share/extensions/interp_att_g.inx.h:28
 #: ../share/extensions/polyhedron_3d.inx.h:33
 msgid "Style"
 msgstr "Stil"
 
-#: ../share/extensions/interp_att_g.inx.h:26
+#: ../share/extensions/interp_att_g.inx.h:29
 msgid "Transformation"
 msgstr "Transformation"
 
-#: ../share/extensions/interp_att_g.inx.h:27
-msgid "••••••••••••••••••••••••••••••••••••••••••••••••"
-msgstr "••••••••••••••••••••••••••••••••••••••••••••••••"
+#: ../share/extensions/interp_att_g.inx.h:30
+#: ../share/extensions/nicechart.inx.h:38
+msgid "Values"
+msgstr "Werte"
 
-#: ../share/extensions/interp_att_g.inx.h:28
+#: ../share/extensions/interp_att_g.inx.h:31
 msgid "No Unit"
 msgstr "Keine Einheit"
 
-#: ../share/extensions/interp_att_g.inx.h:30
+#: ../share/extensions/interp_att_g.inx.h:33
 msgid ""
 "This effect applies a value for any interpolatable attribute for all "
 "elements inside the selected group or for all elements in a multiple "
@@ -37663,8 +38150,9 @@ msgid "Set number of columns to default:"
 msgstr "Anzahl der Spalten auf Standard setzen:"
 
 #: ../share/extensions/jessyInk_keyBindings.inx.h:45
+#, fuzzy
 msgid ""
-"This extension allows you customise the key bindings JessyInk uses. Please "
+"This extension allows you customize the key bindings JessyInk uses. Please "
 "see code.google.com/p/jessyink for more details."
 msgstr ""
 "Diese Erweiterung erlaubt Ihnen, die Tastenkombinationen zu verändern, die "
@@ -37711,8 +38199,9 @@ msgid "Dragging/zoom"
 msgstr "Ziehen/Zoom"
 
 #: ../share/extensions/jessyInk_mouseHandler.inx.h:7
+#, fuzzy
 msgid ""
-"This extension allows you customise the mouse handler JessyInk uses. Please "
+"This extension allows you customize the mouse handler JessyInk uses. Please "
 "see code.google.com/p/jessyink for more details."
 msgstr ""
 "Diese Erweiterung erlaubt Ihnen, die Mausbedienung in JessyInk zu verändern. "
@@ -38459,10 +38948,6 @@ msgstr "Schatten"
 msgid "SAP"
 msgstr "SAP"
 
-#: ../share/extensions/nicechart.inx.h:38
-msgid "Values"
-msgstr "Werte"
-
 #: ../share/extensions/nicechart.inx.h:39
 msgid "Show values"
 msgstr "Werte anzeigen"
@@ -39119,10 +39604,6 @@ msgstr "Scheitel"
 #: ../share/extensions/polyhedron_3d.inx.h:53
 msgid "Maximum"
 msgstr "Maximum"
-
-#: ../share/extensions/polyhedron_3d.inx.h:54
-msgid "Minimum"
-msgstr "Minimun"
 
 #: ../share/extensions/polyhedron_3d.inx.h:55
 msgid "Mean"
@@ -40913,49 +41394,194 @@ msgid "_Color display mode"
 msgstr "Farb-Anzeigemodus"
 
 #: ../share/ui/menus.xml.h:10
+#, fuzzy
+msgid "_Canvas orientation"
+msgstr "Ausrichtung der Seite:"
+
+#: ../share/ui/menus.xml.h:11
 msgid "Sh_ow/Hide"
 msgstr "Anzeigen/Ausblenden"
 
-#: ../share/ui/menus.xml.h:11
+#: ../share/ui/menus.xml.h:12
 msgid "_Layer"
 msgstr "_Ebene"
 
-#: ../share/ui/menus.xml.h:12
+#: ../share/ui/menus.xml.h:13
 msgid "_Object"
 msgstr "_Objekt"
 
-#: ../share/ui/menus.xml.h:13
+#: ../share/ui/menus.xml.h:14
 msgid "Cli_p"
 msgstr "Ausschneide_pfad"
 
-#: ../share/ui/menus.xml.h:14
+#: ../share/ui/menus.xml.h:15
 msgid "Mas_k"
 msgstr "_Maske"
 
-#: ../share/ui/menus.xml.h:15
+#: ../share/ui/menus.xml.h:16
 msgid "Patter_n"
 msgstr "M_uster"
 
-#: ../share/ui/menus.xml.h:16
+#: ../share/ui/menus.xml.h:17
 msgid "_Path"
 msgstr "_Pfad"
 
 # !!!
-#: ../share/ui/menus.xml.h:18
+#: ../share/ui/menus.xml.h:19
 msgid "Filter_s"
 msgstr "_Filter"
 
-#: ../share/ui/menus.xml.h:19
+#: ../share/ui/menus.xml.h:20
 msgid "Exte_nsions"
 msgstr "E_rweiterungen"
 
-#: ../share/ui/menus.xml.h:20
+#: ../share/ui/menus.xml.h:21
 msgid "_Help"
 msgstr "_Hilfe"
 
-#: ../share/ui/menus.xml.h:21
+#: ../share/ui/menus.xml.h:22
 msgid "Tutorials"
 msgstr "Einführungen"
+
+#, fuzzy
+#~ msgid "Measure Line"
+#~ msgstr "Maßstab"
+
+#, fuzzy
+#~ msgid ". Change custom values for this parameter"
+#~ msgstr "Aufzählungsparameter ändern"
+
+#, fuzzy
+#~ msgid "Scale item %"
+#~ msgstr "Skalierung"
+
+#~ msgid "Preserve position"
+#~ msgstr "Position beibehalten"
+
+#, fuzzy
+#~ msgid "Clone transforms"
+#~ msgstr "Transformationen zurücksetzen"
+
+#, fuzzy
+#~ msgid "Clone fill"
+#~ msgstr "Datei schließen"
+
+#, fuzzy
+#~ msgid "Clone stroke"
+#~ msgstr "Keine Kontur"
+
+#, fuzzy
+#~ msgid "Clone paint order"
+#~ msgstr "Farbmalmodus"
+
+#, fuzzy
+#~ msgid "Clone filter"
+#~ msgstr "Datei schließen"
+
+#, fuzzy
+#~ msgid "Show attributes override"
+#~ msgstr "Attributwert suchen"
+
+#, fuzzy
+#~ msgid "Hide attributes override"
+#~ msgstr "Attribute kürzen"
+
+#, fuzzy
+#~ msgid "Curve on origin"
+#~ msgstr "Hilfslinienursprung"
+
+#, fuzzy
+#~ msgid "Text right/left"
+#~ msgstr "Textausrichtung"
+
+#, fuzzy
+#~ msgid "CSS DIN line"
+#~ msgstr "Neue Zeile"
+
+#, fuzzy
+#~ msgid "CSS anotation"
+#~ msgstr "Sättigung"
+
+#, fuzzy
+#~ msgid "CSS arrows"
+#~ msgstr "Strg+Pfeile"
+
+#~ msgid ""
+#~ "Only for PS/EPS/PDF, sets margin in mm around exported area (default 0)"
+#~ msgstr ""
+#~ "Nur für PS/EPS/PDF. Setzt einen Rand in mm um den exportierten Bereich "
+#~ "(Standard 0)"
+
+#~ msgid "About Inkscape"
+#~ msgstr "Informationen über Inkscape"
+
+# !!!
+#~ msgid "_Splash"
+#~ msgstr "_Begrüßung"
+
+#~ msgid "_Authors"
+#~ msgstr "_Autoren"
+
+#~ msgid "_Translators"
+#~ msgstr "Ü_bersetzer"
+
+#~ msgid "_License"
+#~ msgstr "_Lizenz"
+
+#~ msgid "Show close button on dialogs"
+#~ msgstr "Schaltflächen zum Schließen von Dialogen zeigen"
+
+#~ msgid "Whether dialog windows have a close button (requires restart)"
+#~ msgstr ""
+#~ "Dialogfenster haben Schaltflächen zum Schließen (erfordert Neustart)"
+
+#, fuzzy
+#~ msgid "requires restart"
+#~ msgstr "(erfordert Neustart)"
+
+#~ msgid "_Blur:"
+#~ msgstr "Unschärfe:"
+
+#, fuzzy
+#~ msgid "Rotate Zero"
+#~ msgstr "Drehmodus"
+
+#, fuzzy
+#~ msgid "Flip Horizontal"
+#~ msgstr "_Horizontal umkehren"
+
+#, fuzzy
+#~ msgid "Flip Vertical"
+#~ msgstr "_Vertikal umkehren"
+
+#, fuzzy
+#~ msgid "Flip None"
+#~ msgstr "Knoten umkehren"
+
+# CHECK
+#~ msgid "on:"
+#~ msgstr "auf:"
+
+#~ msgid "Choose a gradient"
+#~ msgstr "Wählen Sie einen Verlauf"
+
+#~ msgid "Select:"
+#~ msgstr "Auswählen:"
+
+#~ msgid "Repeat:"
+#~ msgstr "Wiederholung:"
+
+#~ msgid "Select a stop for the current gradient"
+#~ msgstr "Zwischenfarbe für derzeitigen Farbverlauf auswählen"
+
+#~ msgid "Stops:"
+#~ msgstr "Zwischenfarben:"
+
+#~ msgid "Coons"
+#~ msgstr "Coons"
+
+#~ msgid "••••••••••••••••••••••••••••••••••••••••••••••••"
+#~ msgstr "••••••••••••••••••••••••••••••••••••••••••••••••"
 
 #~ msgid "Color profiles directory (%s) is unavailable."
 #~ msgstr "Farbprofilverzeichnis (%s) ist nicht verfügbar."
@@ -41933,10 +42559,6 @@ msgstr "Einführungen"
 #~ msgctxt "Symbol"
 #~ msgid "Doctors"
 #~ msgstr "Objektverbinder"
-
-#~ msgctxt "Symbol"
-#~ msgid "Power Lines"
-#~ msgstr "Knoten in Linien"
 
 #~ msgctxt "Symbol"
 #~ msgid "Transmitter"
@@ -43138,9 +43760,6 @@ msgstr "Einführungen"
 #~ msgid "Justify lines"
 #~ msgstr "Blocksatz"
 
-#~ msgid "Line spacing:"
-#~ msgstr "Zeilenabstand:"
-
 #~ msgid "%s GDK pixbuf Input"
 #~ msgstr "%s GDK-Pixbuf-Eingabe"
 
@@ -44151,9 +44770,6 @@ msgstr "Einführungen"
 #~ msgstr ""
 #~ "<b>%u von %u Knoten</b> ausgewählt. Ziehen um Knoten auszuwählen und "
 #~ "Klicken um Auswahl zu löschen"
-
-#~ msgid "Title"
-#~ msgstr "Titel"
 
 #~ msgid "Rights"
 #~ msgstr "Rechte"

--- a/master/de.po
+++ b/master/de.po
@@ -16,15 +16,15 @@
 # Benjamin Weis <benjamin.weis@gmx.com>, 2014.
 # Heiko Wöhrle <mail@heikowoehrle.de>, 2014.
 # Sönke Roggatz <s.roggatz@mailing-werkstatt.de>, 2015.
-# Maren Hachmann <marenhachmann@yahoo.com>, 2015, 2016, 2017.
+# Maren Hachmann <marenhachmann@yahoo.com>, 2015, 2016, 2017, 2018.
 # Eduard Braun <eduard.braun2@gmx.de>, 2015-2017.
 msgid ""
 msgstr ""
 "Project-Id-Version: inkscape\n"
 "Report-Msgid-Bugs-To: inkscape-devel@lists.sourceforge.net\n"
 "POT-Creation-Date: 2018-01-29 21:05+0100\n"
-"PO-Revision-Date: 2017-08-05 00:39+0100\n"
-"Last-Translator: Eduard Braun <eduard.braun2@gmx.de>\n"
+"PO-Revision-Date: 2018-02-12 23:56+0100\n"
+"Last-Translator: Maren Hachmann <marenhachmann@yahoo.com>\n"
 "Language-Team: German <kde-i18n-de@kde.org>\n"
 "Language: de\n"
 "MIME-Version: 1.0\n"
@@ -398,7 +398,7 @@ msgstr "Stacheldraht"
 
 #: ../share/filters/filters.svg.h:96
 msgid "Gray bevelled wires with drop shadows"
-msgstr "Graue verworrene Drähte mit abgesetztem Schatten"
+msgstr "Graue verworrene Drähte mit Schlagschatten"
 
 #: ../share/filters/filters.svg.h:98
 msgid "Swiss Cheese"
@@ -7706,7 +7706,7 @@ msgstr "Schnee liegt auf dem Objekt"
 
 #: ../src/extension/internal/filter/shadows.h:57
 msgid "Drop Shadow"
-msgstr "Abgesetzter Schatten"
+msgstr "Schlagschatten"
 
 #: ../src/extension/internal/filter/shadows.h:61
 msgid "Blur radius (px)"
@@ -8483,6 +8483,29 @@ msgid ""
 "More information about this change are available in the <a href='https://"
 "inkscape.org/en/learn/faq#dpi_change'>Inkscape FAQ</a></small>"
 msgstr ""
+"<small>Wir haben Inkscape aktualisiert, um den CSS-Standard von 96 dpi "
+"Auflösung für bessere Kompatibilität mit Webbrowsern zu erfüllen. Früher "
+"haben wir 90 dpi verwendet. Digitales Bildmaterial, das auf einem Bildschirm "
+"dargestellt werden soll, wird ohne Größenänderung zu 96 dpi konvertiert "
+"und sollte nicht betroffen sein. Kunstwerke, die mit 90 dpi für eine "
+"bestimmte physische Größe erstellt worden sind, werden zu klein sein, wenn "
+"sie ohne Größenänderung zu 96 dpi konvertiert werden. Es gibt zwei Methoden "
+"zur Anpassung der Größe:\n"
+"\n"
+"<b>Die Größe des ganzen Dokuments ändern:</b> Dies ist die am wenigsten "
+"fehleranfällige Methode. Sie erhält das Erscheinungsbild der Zeichnung, und "
+"lässt Filter und die Position von Masken usw. unverändert. Die Größe der "
+"Zeichnung im Verhältnis zur Dokumentgröße ist jedoch möglicherweise nicht "
+"korrekt.\n"
+"\n"
+"<b>Die Größe der einzelnen Elemente der Zeichnung ändern:</b> Diese Methode "
+"ist weniger zuverlässig und kann ein verändertes Erscheinungsbild bewirken. "
+"Sie eignet sich jedoch besser für die Ausgabe auf physischen Medien, wenn "
+"eine korrekte Größe und Position wichtig sind (z.B. für den 3D-Druck).\n"
+"\n"
+"Mehr Informationen zu dieser Änderung gibt es in der <a href='https:// "
+"inkscape.org/de/lernen/haufig-gestellte-fragen/#dpi_change'>Inkscape-FAQ</a><"
+"/small>."
 
 #: ../src/file-update.cpp:392
 #, fuzzy
@@ -9774,9 +9797,8 @@ msgstr "ihre Verbindung zum Original verlieren"
 #: ../src/live_effects/lpe-clone-original.cpp:39
 #: ../src/live_effects/lpe-fill-between-many.cpp:36
 #: ../src/live_effects/lpe-fill-between-strokes.cpp:24
-#, fuzzy
 msgid "Allow transforms"
-msgstr "Transformationen zurücksetzen"
+msgstr "Transformationen erlauben"
 
 #: ../src/live_effects/lpe-constructgrid.cpp:24
 msgid "Size _X:"
@@ -12591,6 +12613,8 @@ msgid ""
 "Sets margin around exported area (default 0) in units of page size for SVG "
 "and mm for PS/EPS/PDF"
 msgstr ""
+"Fügt einen Rand um den exportierten Bereich ein. Die Einheit ist für SVG die"
+" Einheit der Seitengröße, für PS/EPS/PDF mm (Standardwert 0)."
 
 #: ../src/main.cpp:359 ../src/main.cpp:401
 msgid "VALUE"
@@ -12843,6 +12867,8 @@ msgid ""
 "Method used to convert pre-.92 document dpi, if needed. ([none|scale-viewbox|"
 "scale-document])"
 msgstr ""
+"Methode, die zur DPI-Konvertierung von pre-0.92-Dokumenten verwendet werden"
+" soll, falls nötig ([none|scale-viewbox|scale-document])"
 
 #: ../src/main.cpp:837 ../src/main.cpp:1185
 msgid ""
@@ -17433,7 +17459,7 @@ msgid ""
 msgstr ""
 "Der Filterbaustein <b>Gaußscher Weichzeichner</b> zeichnet die Quelle weich. "
 "Er wird normalerweise zusammen mit dem Filterbaustein Versatz benutzt, um "
-"abgesetzte Schatten zu erzeugen."
+"Schlagschatten zu erzeugen."
 
 #: ../src/ui/dialog/filter-effects-dialog.cpp:2911
 msgid ""
@@ -17472,7 +17498,7 @@ msgid ""
 "a slightly different position than the actual object."
 msgstr ""
 "Der Filterbaustein <b>Versatz</b> verschiebt das Bild um einen "
-"benutzerdefinierten Betrag. Dies ist z. B. für abgesetzte Schatten nützlich, "
+"benutzerdefinierten Betrag. Dies ist z. B. für Schlagschatten nützlich, "
 "die sich an einer leicht anderen Position als das eigentliche Objekt "
 "befinden."
 
@@ -21459,7 +21485,7 @@ msgstr "Anzahl der Threads:"
 #: ../src/ui/dialog/inkscape-preferences.cpp:1464
 #: ../src/ui/dialog/inkscape-preferences.cpp:1992
 msgid "(requires restart)"
-msgstr "(erfordert Neustart)"
+msgstr "erfordert Neustart"
 
 #: ../src/ui/dialog/inkscape-preferences.cpp:1465
 msgid "Configure number of processors/threads to use when rendering filters"
@@ -21486,15 +21512,17 @@ msgstr ""
 "Null setzen, um Cachen zu deaktivieren"
 
 #: ../src/ui/dialog/inkscape-preferences.cpp:1473
-#, fuzzy
 msgid "Rendering tile multiplier:"
-msgstr "Rendering-Cachegröße:"
+msgstr "Renderkachel-Multiplikator:"
 
 #: ../src/ui/dialog/inkscape-preferences.cpp:1474
 msgid ""
 "Set the relative size of tiles used to render the canvas. The larger the "
 "value, the bigger the tile size."
 msgstr ""
+"Bestimmt die Größe der Kacheln für die Darstellung der Zeichnung "
+"im Verhältnis zur Zeichenfläche. Je größer der Wert, desto größer sind "
+"die einzelnen Kacheln."
 
 #. blur quality
 #. filter quality
@@ -29907,9 +29935,8 @@ msgid "Center on horizontal and vertical axis"
 msgstr "An horizontalen und vertikalen Achsen ausrichten"
 
 #: ../src/widgets/arc-toolbar.cpp:140
-#, fuzzy
 msgid "Change arc"
-msgstr "Weichzeichner ändern"
+msgstr "Bogen ändern"
 
 #: ../src/widgets/arc-toolbar.cpp:206
 msgid "Arc: Change start/end"
@@ -29947,9 +29974,8 @@ msgid "Rx:"
 msgstr "Rx:"
 
 #: ../src/widgets/arc-toolbar.cpp:459
-#, fuzzy
 msgid "Horizontal radius of the circle, ellipse, or arc"
-msgstr "Horizontaler Radius einer abgerundeten Ecke"
+msgstr "Horizontaler Radius des Kreises, der Ellipse oder des Bogens"
 
 #: ../src/widgets/arc-toolbar.cpp:476 ../src/widgets/rect-toolbar.cpp:368
 msgid "Vertical radius"
@@ -29960,9 +29986,8 @@ msgid "Ry:"
 msgstr "Ry:"
 
 #: ../src/widgets/arc-toolbar.cpp:476
-#, fuzzy
 msgid "Vertical radius of the circle, ellipse, or arc"
-msgstr "Kreise, Ellipsen und Bögen erstellen"
+msgstr "Vertikaler Radius des Kreises, der Ellipse oder des Bogens"
 
 #. Add the units menu.
 #: ../src/widgets/arc-toolbar.cpp:490 ../src/widgets/lpe-toolbar.cpp:380
@@ -32761,9 +32786,8 @@ msgid "Text: Change orientation"
 msgstr "Textausrichtung ändern"
 
 #: ../src/widgets/text-toolbar.cpp:1392
-#, fuzzy
 msgid "Text: Change direction"
-msgstr "Textausrichtung ändern"
+msgstr "Text: Schreibrichtung ändern"
 
 #: ../src/widgets/text-toolbar.cpp:1992
 msgid "Font Family"
@@ -32886,32 +32910,29 @@ msgstr "Zeichenausrichtung in vertikalem Text"
 
 #: ../src/widgets/text-toolbar.cpp:2251
 msgid "LTR"
-msgstr ""
+msgstr "LTR"
 
 #: ../src/widgets/text-toolbar.cpp:2252
-#, fuzzy
 msgid "Left to right text"
-msgstr "Links nach Rechts"
+msgstr "Text von links nach rechts"
 
 #: ../src/widgets/text-toolbar.cpp:2257
 msgid "RTL"
-msgstr ""
+msgstr "RTL"
 
 #: ../src/widgets/text-toolbar.cpp:2258
-#, fuzzy
 msgid "Right to left text"
-msgstr "Rechts nach Links"
+msgstr "Text von rechts nach links"
 
 #. Name
 #: ../src/widgets/text-toolbar.cpp:2264
-#, fuzzy
 msgid "Text direction"
-msgstr "Textrichtung:"
+msgstr "Schreibrichtung"
 
 #. Label
 #: ../src/widgets/text-toolbar.cpp:2265
 msgid "Text direction for normally horizontal text."
-msgstr ""
+msgstr "Schreibrichtung für normalerweise horizontal geschriebenen Text"
 
 #. Drop down menu
 #: ../src/widgets/text-toolbar.cpp:2291

--- a/master/inkscape.pot
+++ b/master/inkscape.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: inkscape-devel@lists.sourceforge.net\n"
-"POT-Creation-Date: 2017-07-30 23:09+0200\n"
+"POT-Creation-Date: 2018-01-29 21:05+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -317,7 +317,7 @@ msgstr ""
 
 #. Pencil
 #: ../share/filters/filters.svg.h:78
-#: ../src/ui/dialog/inkscape-preferences.cpp:419
+#: ../src/ui/dialog/inkscape-preferences.cpp:459
 msgid "Pencil"
 msgstr ""
 
@@ -1105,7 +1105,7 @@ msgstr ""
 #: ../share/extensions/color_removered.inx.h:2
 #: ../share/extensions/color_replace.inx.h:6
 #: ../share/extensions/color_rgbbarrel.inx.h:2
-#: ../share/extensions/interp_att_g.inx.h:21
+#: ../share/extensions/interp_att_g.inx.h:24
 msgid "Color"
 msgstr ""
 
@@ -4409,15 +4409,15 @@ msgstr ""
 
 #. 3D box
 #: ../src/box3d.cpp:251 ../src/box3d.cpp:1305
-#: ../src/ui/dialog/inkscape-preferences.cpp:402
+#: ../src/ui/dialog/inkscape-preferences.cpp:442
 msgid "3D Box"
 msgstr ""
 
-#: ../src/color-profile.cpp:897 ../src/color-profile.cpp:914
+#: ../src/color-profile.cpp:913 ../src/color-profile.cpp:930
 msgid "(invalid UTF-8 string)"
 msgstr ""
 
-#: ../src/color-profile.cpp:899
+#: ../src/color-profile.cpp:915
 msgctxt "Profile name"
 msgid "None"
 msgstr ""
@@ -4448,100 +4448,100 @@ msgstr ""
 msgid "<b>Guideline</b>: %s"
 msgstr ""
 
-#: ../src/desktop.cpp:766
+#: ../src/desktop.cpp:760
 msgid "No previous transform."
 msgstr ""
 
-#: ../src/desktop.cpp:789
+#: ../src/desktop.cpp:783
 msgid "No next transform."
 msgstr ""
 
-#: ../src/display/canvas-axonomgrid.cpp:325 ../src/display/canvas-grid.cpp:683
+#: ../src/display/canvas-axonomgrid.cpp:325 ../src/display/canvas-grid.cpp:680
 msgid "Grid _units:"
 msgstr ""
 
-#: ../src/display/canvas-axonomgrid.cpp:327 ../src/display/canvas-grid.cpp:685
+#: ../src/display/canvas-axonomgrid.cpp:327 ../src/display/canvas-grid.cpp:682
 msgid "_Origin X:"
 msgstr ""
 
-#: ../src/display/canvas-axonomgrid.cpp:327 ../src/display/canvas-grid.cpp:685
-#: ../src/ui/dialog/inkscape-preferences.cpp:777
-#: ../src/ui/dialog/inkscape-preferences.cpp:802
+#: ../src/display/canvas-axonomgrid.cpp:327 ../src/display/canvas-grid.cpp:682
+#: ../src/ui/dialog/inkscape-preferences.cpp:832
+#: ../src/ui/dialog/inkscape-preferences.cpp:857
 msgid "X coordinate of grid origin"
 msgstr ""
 
-#: ../src/display/canvas-axonomgrid.cpp:330 ../src/display/canvas-grid.cpp:688
+#: ../src/display/canvas-axonomgrid.cpp:330 ../src/display/canvas-grid.cpp:685
 msgid "O_rigin Y:"
 msgstr ""
 
-#: ../src/display/canvas-axonomgrid.cpp:330 ../src/display/canvas-grid.cpp:688
-#: ../src/ui/dialog/inkscape-preferences.cpp:778
-#: ../src/ui/dialog/inkscape-preferences.cpp:803
+#: ../src/display/canvas-axonomgrid.cpp:330 ../src/display/canvas-grid.cpp:685
+#: ../src/ui/dialog/inkscape-preferences.cpp:833
+#: ../src/ui/dialog/inkscape-preferences.cpp:858
 msgid "Y coordinate of grid origin"
 msgstr ""
 
-#: ../src/display/canvas-axonomgrid.cpp:333 ../src/display/canvas-grid.cpp:694
+#: ../src/display/canvas-axonomgrid.cpp:333 ../src/display/canvas-grid.cpp:691
 msgid "Spacing _Y:"
 msgstr ""
 
 #: ../src/display/canvas-axonomgrid.cpp:333
-#: ../src/ui/dialog/inkscape-preferences.cpp:806
+#: ../src/ui/dialog/inkscape-preferences.cpp:861
 msgid "Base length of z-axis"
 msgstr ""
 
 #: ../src/display/canvas-axonomgrid.cpp:336
-#: ../src/ui/dialog/inkscape-preferences.cpp:809
+#: ../src/ui/dialog/inkscape-preferences.cpp:864
 #: ../src/widgets/box3d-toolbar.cpp:301
 msgid "Angle X:"
 msgstr ""
 
 #: ../src/display/canvas-axonomgrid.cpp:336
-#: ../src/ui/dialog/inkscape-preferences.cpp:809
+#: ../src/ui/dialog/inkscape-preferences.cpp:864
 msgid "Angle of x-axis"
 msgstr ""
 
 #: ../src/display/canvas-axonomgrid.cpp:338
-#: ../src/ui/dialog/inkscape-preferences.cpp:810
+#: ../src/ui/dialog/inkscape-preferences.cpp:865
 #: ../src/widgets/box3d-toolbar.cpp:380
 msgid "Angle Z:"
 msgstr ""
 
 #: ../src/display/canvas-axonomgrid.cpp:338
-#: ../src/ui/dialog/inkscape-preferences.cpp:810
+#: ../src/ui/dialog/inkscape-preferences.cpp:865
 msgid "Angle of z-axis"
 msgstr ""
 
-#: ../src/display/canvas-axonomgrid.cpp:342 ../src/display/canvas-grid.cpp:699
+#: ../src/display/canvas-axonomgrid.cpp:342 ../src/display/canvas-grid.cpp:696
 msgid "Minor grid line _color:"
 msgstr ""
 
-#: ../src/display/canvas-axonomgrid.cpp:342 ../src/display/canvas-grid.cpp:699
-#: ../src/ui/dialog/inkscape-preferences.cpp:761
+#: ../src/display/canvas-axonomgrid.cpp:342 ../src/display/canvas-grid.cpp:696
+#: ../src/ui/dialog/inkscape-preferences.cpp:816
 msgid "Minor grid line color"
 msgstr ""
 
-#: ../src/display/canvas-axonomgrid.cpp:342 ../src/display/canvas-grid.cpp:699
+#: ../src/display/canvas-axonomgrid.cpp:342 ../src/display/canvas-grid.cpp:696
 msgid "Color of the minor grid lines"
 msgstr ""
 
-#: ../src/display/canvas-axonomgrid.cpp:347 ../src/display/canvas-grid.cpp:704
+#: ../src/display/canvas-axonomgrid.cpp:347 ../src/display/canvas-grid.cpp:701
 msgid "Ma_jor grid line color:"
 msgstr ""
 
-#: ../src/display/canvas-axonomgrid.cpp:347 ../src/display/canvas-grid.cpp:704
-#: ../src/ui/dialog/inkscape-preferences.cpp:763
+#: ../src/display/canvas-axonomgrid.cpp:347 ../src/display/canvas-grid.cpp:701
+#: ../src/ui/dialog/inkscape-preferences.cpp:818
 msgid "Major grid line color"
 msgstr ""
 
-#: ../src/display/canvas-axonomgrid.cpp:348 ../src/display/canvas-grid.cpp:705
+#: ../src/display/canvas-axonomgrid.cpp:348 ../src/display/canvas-grid.cpp:702
 msgid "Color of the major (highlighted) grid lines"
 msgstr ""
 
-#: ../src/display/canvas-axonomgrid.cpp:352 ../src/display/canvas-grid.cpp:709
+#: ../src/display/canvas-axonomgrid.cpp:352 ../src/display/canvas-grid.cpp:706
 msgid "_Major grid line every:"
 msgstr ""
 
-#: ../src/display/canvas-axonomgrid.cpp:352 ../src/display/canvas-grid.cpp:709
+#: ../src/display/canvas-axonomgrid.cpp:352 ../src/display/canvas-grid.cpp:706
 msgid "lines"
 msgstr ""
 
@@ -4553,59 +4553,59 @@ msgstr ""
 msgid "Axonometric grid"
 msgstr ""
 
-#: ../src/display/canvas-grid.cpp:242
+#: ../src/display/canvas-grid.cpp:239
 msgid "Create new grid"
 msgstr ""
 
-#: ../src/display/canvas-grid.cpp:308
+#: ../src/display/canvas-grid.cpp:305
 msgid "_Enabled"
 msgstr ""
 
-#: ../src/display/canvas-grid.cpp:309
+#: ../src/display/canvas-grid.cpp:306
 msgid ""
 "Determines whether to snap to this grid or not. Can be 'on' for invisible "
 "grids."
 msgstr ""
 
-#: ../src/display/canvas-grid.cpp:313
+#: ../src/display/canvas-grid.cpp:310
 msgid "Snap to visible _grid lines only"
 msgstr ""
 
-#: ../src/display/canvas-grid.cpp:314
+#: ../src/display/canvas-grid.cpp:311
 msgid ""
 "When zoomed out, not all grid lines will be displayed. Only the visible ones "
 "will be snapped to"
 msgstr ""
 
-#: ../src/display/canvas-grid.cpp:318
+#: ../src/display/canvas-grid.cpp:315
 msgid "_Visible"
 msgstr ""
 
-#: ../src/display/canvas-grid.cpp:319
+#: ../src/display/canvas-grid.cpp:316
 msgid ""
 "Determines whether the grid is displayed or not. Objects are still snapped "
 "to invisible grids."
 msgstr ""
 
-#: ../src/display/canvas-grid.cpp:691
+#: ../src/display/canvas-grid.cpp:688
 msgid "Spacing _X:"
 msgstr ""
 
-#: ../src/display/canvas-grid.cpp:691
-#: ../src/ui/dialog/inkscape-preferences.cpp:783
+#: ../src/display/canvas-grid.cpp:688
+#: ../src/ui/dialog/inkscape-preferences.cpp:838
 msgid "Distance between vertical grid lines"
 msgstr ""
 
-#: ../src/display/canvas-grid.cpp:694
-#: ../src/ui/dialog/inkscape-preferences.cpp:784
+#: ../src/display/canvas-grid.cpp:691
+#: ../src/ui/dialog/inkscape-preferences.cpp:839
 msgid "Distance between horizontal grid lines"
 msgstr ""
 
-#: ../src/display/canvas-grid.cpp:726
+#: ../src/display/canvas-grid.cpp:723
 msgid "_Show dots instead of lines"
 msgstr ""
 
-#: ../src/display/canvas-grid.cpp:727
+#: ../src/display/canvas-grid.cpp:724
 msgid "If set, displays dots at gridpoints instead of gridlines"
 msgstr ""
 
@@ -4755,11 +4755,11 @@ msgstr ""
 msgid "Bounding box side midpoint"
 msgstr ""
 
-#: ../src/display/snap-indicator.cpp:196 ../src/ui/tool/node.cpp:1473
+#: ../src/display/snap-indicator.cpp:196 ../src/ui/tool/node.cpp:1468
 msgid "Smooth node"
 msgstr ""
 
-#: ../src/display/snap-indicator.cpp:199 ../src/ui/tool/node.cpp:1472
+#: ../src/display/snap-indicator.cpp:199 ../src/ui/tool/node.cpp:1467
 msgid "Cusp node"
 msgstr ""
 
@@ -4815,35 +4815,35 @@ msgstr ""
 msgid " to "
 msgstr ""
 
-#: ../src/document.cpp:553
+#: ../src/document.cpp:555
 #, c-format
 msgid "New document %d"
 msgstr ""
 
-#: ../src/document.cpp:558
+#: ../src/document.cpp:560
 #, c-format
 msgid "Memory document %d"
 msgstr ""
 
-#: ../src/document.cpp:587
+#: ../src/document.cpp:589
 msgid "Memory document %1"
 msgstr ""
 
-#: ../src/document.cpp:886
+#: ../src/document.cpp:888
 #, c-format
 msgid "Unnamed document %d"
 msgstr ""
 
-#: ../src/event-log.cpp:181
+#: ../src/event-log.cpp:179
 msgid "[Unchanged]"
 msgstr ""
 
 #. Edit
-#: ../src/event-log.cpp:367 ../src/event-log.cpp:370 ../src/verbs.cpp:2595
+#: ../src/event-log.cpp:365 ../src/event-log.cpp:368 ../src/verbs.cpp:2625
 msgid "_Undo"
 msgstr ""
 
-#: ../src/event-log.cpp:377 ../src/event-log.cpp:381 ../src/verbs.cpp:2597
+#: ../src/event-log.cpp:375 ../src/event-log.cpp:379 ../src/verbs.cpp:2627
 msgid "_Redo"
 msgstr ""
 
@@ -4871,12 +4871,12 @@ msgstr ""
 msgid " (No preferences)"
 msgstr ""
 
-#: ../src/extension/effect.h:70 ../src/verbs.cpp:2367
+#: ../src/extension/effect.h:70 ../src/verbs.cpp:2397
 msgid "Extensions"
 msgstr ""
 
 #. \FIXME change this
-#. This is some filler text, needs to change before relase
+#. This is some filler text, needs to change before release
 #: ../src/extension/error-file.cpp:54
 msgid ""
 "<span weight=\"bold\" size=\"larger\">One or more extensions failed to load</"
@@ -4891,90 +4891,94 @@ msgstr ""
 msgid "Show dialog on startup"
 msgstr ""
 
-#: ../src/extension/execution-env.cpp:133
+#: ../src/extension/execution-env.cpp:134
 #, c-format
 msgid "'%s' working, please wait..."
 msgstr ""
 
 #. static int i = 0;
 #. std::cout << "Checking module[" << i++ << "]: " << name << std::endl;
-#: ../src/extension/extension.cpp:262
+#: ../src/extension/extension.cpp:259
 msgid ""
 "  This is caused by an improper .inx file for this extension.  An improper ."
 "inx file could have been caused by a faulty installation of Inkscape."
 msgstr ""
 
-#: ../src/extension/extension.cpp:272
+#: ../src/extension/extension.cpp:269
 msgid "the extension is designed for Windows only."
 msgstr ""
 
-#: ../src/extension/extension.cpp:277
+#: ../src/extension/extension.cpp:274
 msgid "an ID was not defined for it."
 msgstr ""
 
-#: ../src/extension/extension.cpp:281
+#: ../src/extension/extension.cpp:278
 msgid "there was no name defined for it."
 msgstr ""
 
-#: ../src/extension/extension.cpp:285
+#: ../src/extension/extension.cpp:282
 msgid "the XML description of it got lost."
 msgstr ""
 
-#: ../src/extension/extension.cpp:289
+#: ../src/extension/extension.cpp:286
 msgid "no implementation was defined for the extension."
 msgstr ""
 
 #. std::cout << "Failed: " << *(_deps[i]) << std::endl;
-#: ../src/extension/extension.cpp:296
+#: ../src/extension/extension.cpp:293
 msgid "a dependency was not met."
 msgstr ""
 
-#: ../src/extension/extension.cpp:316
+#: ../src/extension/extension.cpp:313
 msgid "Extension \""
 msgstr ""
 
-#: ../src/extension/extension.cpp:316
+#: ../src/extension/extension.cpp:313
 msgid "\" failed to load because "
 msgstr ""
 
-#: ../src/extension/extension.cpp:665
+#: ../src/extension/extension.cpp:659
 #, c-format
 msgid "Could not create extension error log file '%s'"
 msgstr ""
 
-#: ../src/extension/extension.cpp:777
+#: ../src/extension/extension.cpp:769
 #: ../share/extensions/webslicer_create_rect.inx.h:2
 msgid "Name:"
 msgstr ""
 
-#: ../src/extension/extension.cpp:778
+#: ../src/extension/extension.cpp:770
 msgid "ID:"
 msgstr ""
 
-#: ../src/extension/extension.cpp:779
+#: ../src/extension/extension.cpp:771
 msgid "State:"
 msgstr ""
 
-#: ../src/extension/extension.cpp:779
+#: ../src/extension/extension.cpp:771
 msgid "Loaded"
 msgstr ""
 
-#: ../src/extension/extension.cpp:779
+#: ../src/extension/extension.cpp:771
 msgid "Unloaded"
 msgstr ""
 
-#: ../src/extension/extension.cpp:779
+#: ../src/extension/extension.cpp:771
 msgid "Deactivated"
 msgstr ""
 
-#: ../src/extension/extension.cpp:810
+#: ../src/extension/extension.cpp:802
 msgid ""
 "Currently there is no help available for this Extension.  Please look on the "
 "Inkscape website or ask on the mailing lists if you have questions regarding "
 "this extension."
 msgstr ""
 
-#: ../src/extension/implementation/script.cpp:1094
+#: ../src/extension/implementation/script.cpp:746
+msgid "The output from the extension could not be parsed."
+msgstr ""
+
+#: ../src/extension/implementation/script.cpp:1110
 msgid ""
 "Inkscape has received additional data from the script executed.  The script "
 "did not return an error, but this may indicate the results will not be as "
@@ -4992,9 +4996,9 @@ msgstr ""
 #: ../src/ui/dialog/lpe-powerstroke-properties.cpp:61
 #: ../src/ui/dialog/object-attributes.cpp:65
 #: ../src/ui/dialog/object-attributes.cpp:74
-#: ../src/ui/widget/page-sizer.cpp:232
-#: ../src/widgets/calligraphy-toolbar.cpp:430
-#: ../src/widgets/eraser-toolbar.cpp:187 ../src/widgets/spray-toolbar.cpp:297
+#: ../src/ui/widget/page-sizer.cpp:234
+#: ../src/widgets/calligraphy-toolbar.cpp:401
+#: ../src/widgets/eraser-toolbar.cpp:191 ../src/widgets/spray-toolbar.cpp:297
 #: ../src/widgets/tweak-toolbar.cpp:128 ../share/extensions/foldablebox.inx.h:2
 msgid "Width:"
 msgstr ""
@@ -5004,12 +5008,12 @@ msgstr ""
 #: ../src/extension/internal/bitmap/sample.cpp:42
 #: ../src/ui/dialog/object-attributes.cpp:66
 #: ../src/ui/dialog/object-attributes.cpp:75
-#: ../src/ui/widget/page-sizer.cpp:233 ../share/extensions/foldablebox.inx.h:3
+#: ../src/ui/widget/page-sizer.cpp:235 ../share/extensions/foldablebox.inx.h:3
 msgid "Height:"
 msgstr ""
 
 #: ../src/extension/internal/bitmap/adaptiveThreshold.cpp:43
-#: ../src/widgets/measure-toolbar.cpp:328
+#: ../src/widgets/measure-toolbar.cpp:346
 #: ../share/extensions/printing_marks.inx.h:12
 msgid "Offset:"
 msgstr ""
@@ -5067,8 +5071,8 @@ msgstr ""
 #: ../src/extension/internal/filter/color.h:1660
 #: ../src/extension/internal/filter/distort.h:69
 #: ../src/extension/internal/filter/morphology.h:60 ../src/rdf.cpp:244
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2748
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2828
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2765
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2845
 #: ../src/ui/dialog/object-attributes.cpp:46
 #: ../share/extensions/jessyInk_effects.inx.h:5
 #: ../share/extensions/jessyInk_export.inx.h:3
@@ -5120,7 +5124,7 @@ msgstr ""
 #: ../src/extension/internal/bitmap/oilPaint.cpp:39
 #: ../src/extension/internal/bitmap/sharpen.cpp:40
 #: ../src/extension/internal/bitmap/unsharpmask.cpp:43
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2800
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2817
 msgid "Radius:"
 msgstr ""
 
@@ -5258,7 +5262,7 @@ msgstr ""
 #: ../src/extension/internal/bitmap/cycleColormap.cpp:39
 #: ../src/extension/internal/bitmap/spread.cpp:39
 #: ../src/extension/internal/bitmap/unsharpmask.cpp:45
-#: ../src/widgets/spray-toolbar.cpp:411
+#: ../src/widgets/spray-toolbar.cpp:409
 msgid "Amount:"
 msgstr ""
 
@@ -5434,13 +5438,13 @@ msgstr ""
 #: ../src/extension/internal/filter/transparency.h:279
 #: ../src/ui/dialog/clonetiler.cpp:791 ../src/ui/dialog/clonetiler.cpp:922
 #: ../src/widgets/tweak-toolbar.cpp:334
-#: ../share/extensions/interp_att_g.inx.h:18
+#: ../share/extensions/interp_att_g.inx.h:20
 msgid "Opacity"
 msgstr ""
 
 #: ../src/extension/internal/bitmap/opacity.cpp:40
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2790
-#: ../src/ui/dialog/objects.cpp:1650 ../src/widgets/dropper-toolbar.cpp:83
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2807
+#: ../src/widgets/dropper-toolbar.cpp:83
 msgid "Opacity:"
 msgstr ""
 
@@ -5606,130 +5610,130 @@ msgstr ""
 msgid "Generate from Path"
 msgstr ""
 
-#: ../src/extension/internal/cairo-ps-out.cpp:327
+#: ../src/extension/internal/cairo-ps-out.cpp:330
 #: ../share/extensions/ps_input.inx.h:3
 msgid "PostScript"
 msgstr ""
 
-#: ../src/extension/internal/cairo-ps-out.cpp:329
-#: ../src/extension/internal/cairo-ps-out.cpp:371
+#: ../src/extension/internal/cairo-ps-out.cpp:332
+#: ../src/extension/internal/cairo-ps-out.cpp:374
 msgid "Restrict to PS level:"
-msgstr ""
-
-#: ../src/extension/internal/cairo-ps-out.cpp:330
-#: ../src/extension/internal/cairo-ps-out.cpp:372
-msgid "PostScript level 3"
-msgstr ""
-
-#: ../src/extension/internal/cairo-ps-out.cpp:331
-#: ../src/extension/internal/cairo-ps-out.cpp:373
-msgid "PostScript level 2"
 msgstr ""
 
 #: ../src/extension/internal/cairo-ps-out.cpp:333
 #: ../src/extension/internal/cairo-ps-out.cpp:375
-#: ../src/extension/internal/cairo-renderer-pdf-out.cpp:250
-msgid "Text output options:"
+msgid "PostScript level 3"
 msgstr ""
 
 #: ../src/extension/internal/cairo-ps-out.cpp:334
 #: ../src/extension/internal/cairo-ps-out.cpp:376
-#: ../src/extension/internal/cairo-renderer-pdf-out.cpp:251
-msgid "Embed fonts"
-msgstr ""
-
-#: ../src/extension/internal/cairo-ps-out.cpp:335
-#: ../src/extension/internal/cairo-ps-out.cpp:377
-#: ../src/extension/internal/cairo-renderer-pdf-out.cpp:252
-msgid "Convert text to paths"
+msgid "PostScript level 2"
 msgstr ""
 
 #: ../src/extension/internal/cairo-ps-out.cpp:336
 #: ../src/extension/internal/cairo-ps-out.cpp:378
 #: ../src/extension/internal/cairo-renderer-pdf-out.cpp:253
-msgid "Omit text in PDF and create LaTeX file"
+msgid "Text output options:"
+msgstr ""
+
+#: ../src/extension/internal/cairo-ps-out.cpp:337
+#: ../src/extension/internal/cairo-ps-out.cpp:379
+#: ../src/extension/internal/cairo-renderer-pdf-out.cpp:254
+msgid "Embed fonts"
 msgstr ""
 
 #: ../src/extension/internal/cairo-ps-out.cpp:338
 #: ../src/extension/internal/cairo-ps-out.cpp:380
 #: ../src/extension/internal/cairo-renderer-pdf-out.cpp:255
-msgid "Rasterize filter effects"
+msgid "Convert text to paths"
 msgstr ""
 
 #: ../src/extension/internal/cairo-ps-out.cpp:339
 #: ../src/extension/internal/cairo-ps-out.cpp:381
 #: ../src/extension/internal/cairo-renderer-pdf-out.cpp:256
-msgid "Resolution for rasterization (dpi):"
-msgstr ""
-
-#: ../src/extension/internal/cairo-ps-out.cpp:340
-#: ../src/extension/internal/cairo-ps-out.cpp:382
-msgid "Output page size"
+msgid "Omit text in PDF and create LaTeX file"
 msgstr ""
 
 #: ../src/extension/internal/cairo-ps-out.cpp:341
 #: ../src/extension/internal/cairo-ps-out.cpp:383
 #: ../src/extension/internal/cairo-renderer-pdf-out.cpp:258
-msgid "Use document's page size"
+msgid "Rasterize filter effects"
 msgstr ""
 
 #: ../src/extension/internal/cairo-ps-out.cpp:342
 #: ../src/extension/internal/cairo-ps-out.cpp:384
 #: ../src/extension/internal/cairo-renderer-pdf-out.cpp:259
-msgid "Use exported object's size"
+msgid "Resolution for rasterization (dpi):"
+msgstr ""
+
+#: ../src/extension/internal/cairo-ps-out.cpp:343
+#: ../src/extension/internal/cairo-ps-out.cpp:385
+msgid "Output page size"
 msgstr ""
 
 #: ../src/extension/internal/cairo-ps-out.cpp:344
+#: ../src/extension/internal/cairo-ps-out.cpp:386
 #: ../src/extension/internal/cairo-renderer-pdf-out.cpp:261
-msgid "Bleed/margin (mm):"
+msgid "Use document's page size"
 msgstr ""
 
 #: ../src/extension/internal/cairo-ps-out.cpp:345
 #: ../src/extension/internal/cairo-ps-out.cpp:387
 #: ../src/extension/internal/cairo-renderer-pdf-out.cpp:262
+msgid "Use exported object's size"
+msgstr ""
+
+#: ../src/extension/internal/cairo-ps-out.cpp:347
+#: ../src/extension/internal/cairo-renderer-pdf-out.cpp:264
+msgid "Bleed/margin (mm):"
+msgstr ""
+
+#: ../src/extension/internal/cairo-ps-out.cpp:348
+#: ../src/extension/internal/cairo-ps-out.cpp:390
+#: ../src/extension/internal/cairo-renderer-pdf-out.cpp:265
 msgid "Limit export to the object with ID:"
 msgstr ""
 
-#: ../src/extension/internal/cairo-ps-out.cpp:349
+#: ../src/extension/internal/cairo-ps-out.cpp:352
 #: ../share/extensions/ps_input.inx.h:2
 msgid "PostScript (*.ps)"
 msgstr ""
 
-#: ../src/extension/internal/cairo-ps-out.cpp:350
+#: ../src/extension/internal/cairo-ps-out.cpp:353
 msgid "PostScript File"
 msgstr ""
 
-#: ../src/extension/internal/cairo-ps-out.cpp:369
+#: ../src/extension/internal/cairo-ps-out.cpp:372
 #: ../share/extensions/eps_input.inx.h:3
 msgid "Encapsulated PostScript"
 msgstr ""
 
-#: ../src/extension/internal/cairo-ps-out.cpp:386
+#: ../src/extension/internal/cairo-ps-out.cpp:389
 msgid "Bleed/margin (mm)"
 msgstr ""
 
-#: ../src/extension/internal/cairo-ps-out.cpp:391
+#: ../src/extension/internal/cairo-ps-out.cpp:394
 #: ../share/extensions/eps_input.inx.h:2
 msgid "Encapsulated PostScript (*.eps)"
 msgstr ""
 
-#: ../src/extension/internal/cairo-ps-out.cpp:392
+#: ../src/extension/internal/cairo-ps-out.cpp:395
 msgid "Encapsulated PostScript File"
 msgstr ""
 
-#: ../src/extension/internal/cairo-renderer-pdf-out.cpp:244
+#: ../src/extension/internal/cairo-renderer-pdf-out.cpp:247
 msgid "Restrict to PDF version:"
 msgstr ""
 
-#: ../src/extension/internal/cairo-renderer-pdf-out.cpp:246
+#: ../src/extension/internal/cairo-renderer-pdf-out.cpp:249
 msgid "PDF 1.5"
 msgstr ""
 
-#: ../src/extension/internal/cairo-renderer-pdf-out.cpp:248
+#: ../src/extension/internal/cairo-renderer-pdf-out.cpp:251
 msgid "PDF 1.4"
 msgstr ""
 
-#: ../src/extension/internal/cairo-renderer-pdf-out.cpp:257
+#: ../src/extension/internal/cairo-renderer-pdf-out.cpp:260
 msgid "Output page size:"
 msgstr ""
 
@@ -5769,17 +5773,17 @@ msgstr ""
 #: ../src/extension/internal/vsd-input.cpp:150
 #: ../src/extension/prefdialog.cpp:74
 #: ../src/ui/dialog/calligraphic-profile-rename.cpp:50
-#: ../src/ui/dialog/export.cpp:915 ../src/ui/dialog/export.cpp:1299
-#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:738
-#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:1052
-#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:1599
+#: ../src/ui/dialog/export.cpp:912 ../src/ui/dialog/export.cpp:1296
+#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:728
+#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:1042
+#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:1602
 #: ../src/ui/dialog/guides.cpp:161 ../src/ui/dialog/layer-properties.cpp:42
 #: ../src/ui/dialog/livepatheffect-add.cpp:26
 #: ../src/ui/dialog/lpe-fillet-chamfer-properties.cpp:33
 #: ../src/ui/dialog/lpe-powerstroke-properties.cpp:39
-#: ../src/ui/dialog/ocaldialogs.cpp:1089 ../src/ui/interface.cpp:1406
-#: ../src/widgets/desktop-widget.cpp:1089
-#: ../src/widgets/desktop-widget.cpp:1151
+#: ../src/ui/dialog/ocaldialogs.cpp:1090 ../src/ui/interface.cpp:1368
+#: ../src/widgets/desktop-widget.cpp:1102
+#: ../src/widgets/desktop-widget.cpp:1164
 msgid "_Cancel"
 msgstr ""
 
@@ -5794,7 +5798,7 @@ msgstr ""
 #. Fill in the template
 #: ../src/extension/internal/cdr-input.cpp:220
 #: ../src/extension/internal/vsd-input.cpp:221
-#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:427
+#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:423
 msgid "No preview"
 msgstr ""
 
@@ -6004,7 +6008,7 @@ msgstr ""
 #: ../src/extension/internal/filter/transparency.h:214
 #: ../src/extension/internal/filter/transparency.h:287
 #: ../src/extension/internal/filter/transparency.h:349
-#: ../src/ui/dialog/inkscape-preferences.cpp:1774
+#: ../src/ui/dialog/inkscape-preferences.cpp:1835
 #, c-format
 msgid "Filters"
 msgstr ""
@@ -6114,7 +6118,7 @@ msgstr ""
 #: ../src/extension/internal/filter/color.h:1669
 #: ../src/extension/internal/filter/paint.h:703
 #: ../src/extension/internal/filter/transparency.h:62
-#: ../src/filter-enums.cpp:54 ../src/ui/dialog/input.cpp:367
+#: ../src/filter-enums.cpp:54 ../src/ui/dialog/input.cpp:368
 msgid "Screen"
 msgstr ""
 
@@ -6216,7 +6220,7 @@ msgstr ""
 #: ../src/extension/internal/filter/textures.h:77
 #: ../src/extension/internal/filter/transparency.h:61
 #: ../src/filter-enums.cpp:52 ../src/live_effects/lpe-copy_rotate.cpp:34
-#: ../src/ui/dialog/inkscape-preferences.cpp:684
+#: ../src/ui/dialog/inkscape-preferences.cpp:735
 msgid "Normal"
 msgstr ""
 
@@ -6255,7 +6259,7 @@ msgstr ""
 #: ../src/extension/internal/filter/transparency.h:132
 #: ../src/filter-enums.cpp:128 ../src/ui/tools/flood-tool.cpp:82
 #: ../src/ui/widget/color-icc-selector.cpp:154
-#: ../src/ui/widget/color-scales.cpp:356 ../src/ui/widget/color-scales.cpp:357
+#: ../src/ui/widget/color-scales.cpp:367 ../src/ui/widget/color-scales.cpp:368
 msgid "Red"
 msgstr ""
 
@@ -6267,7 +6271,7 @@ msgstr ""
 #: ../src/extension/internal/filter/transparency.h:133
 #: ../src/filter-enums.cpp:129 ../src/ui/tools/flood-tool.cpp:83
 #: ../src/ui/widget/color-icc-selector.cpp:155
-#: ../src/ui/widget/color-scales.cpp:359 ../src/ui/widget/color-scales.cpp:360
+#: ../src/ui/widget/color-scales.cpp:370 ../src/ui/widget/color-scales.cpp:371
 msgid "Green"
 msgstr ""
 
@@ -6279,7 +6283,7 @@ msgstr ""
 #: ../src/extension/internal/filter/transparency.h:134
 #: ../src/filter-enums.cpp:130 ../src/ui/tools/flood-tool.cpp:84
 #: ../src/ui/widget/color-icc-selector.cpp:156
-#: ../src/ui/widget/color-scales.cpp:362 ../src/ui/widget/color-scales.cpp:363
+#: ../src/ui/widget/color-scales.cpp:373 ../src/ui/widget/color-scales.cpp:374
 #: ../share/extensions/nicechart.inx.h:34
 msgid "Blue"
 msgstr ""
@@ -6302,9 +6306,9 @@ msgstr ""
 
 #: ../src/extension/internal/filter/bumps.h:98
 #: ../src/extension/internal/filter/bumps.h:329
-#: ../src/ui/tools/measure-tool.cpp:1212 ../src/ui/widget/page-sizer.cpp:233
-#: ../src/widgets/rect-toolbar.cpp:330
-#: ../share/extensions/interp_att_g.inx.h:13
+#: ../src/ui/tools/measure-tool.cpp:1226 ../src/ui/widget/page-sizer.cpp:235
+#: ../src/widgets/rect-toolbar.cpp:336
+#: ../share/extensions/interp_att_g.inx.h:15
 msgid "Height"
 msgstr ""
 
@@ -6318,15 +6322,15 @@ msgstr ""
 #: ../src/extension/internal/filter/paint.h:707
 #: ../src/ui/tools/flood-tool.cpp:87
 #: ../src/ui/widget/color-icc-selector.cpp:165
-#: ../src/ui/widget/color-scales.cpp:388 ../src/ui/widget/color-scales.cpp:389
+#: ../src/ui/widget/color-scales.cpp:403 ../src/ui/widget/color-scales.cpp:404
 #: ../src/widgets/tweak-toolbar.cpp:318
 msgid "Lightness"
 msgstr ""
 
 #: ../src/extension/internal/filter/bumps.h:100
 #: ../src/extension/internal/filter/bumps.h:331
-#: ../src/live_effects/lpe-measure-line.cpp:56
-#: ../src/widgets/measure-toolbar.cpp:302
+#: ../src/live_effects/lpe-measure-segments.cpp:61
+#: ../src/widgets/measure-toolbar.cpp:320
 msgid "Precision"
 msgstr ""
 
@@ -6343,7 +6347,7 @@ msgid "Distant"
 msgstr ""
 
 #: ../src/extension/internal/filter/bumps.h:106
-#: ../src/ui/dialog/inkscape-preferences.cpp:456
+#: ../src/ui/dialog/inkscape-preferences.cpp:499
 msgid "Point"
 msgstr ""
 
@@ -6357,13 +6361,13 @@ msgstr ""
 
 #: ../src/extension/internal/filter/bumps.h:110
 #: ../src/extension/internal/filter/bumps.h:332
-#: ../src/ui/dialog/filter-effects-dialog.cpp:1172
+#: ../src/ui/dialog/filter-effects-dialog.cpp:1178
 msgid "Azimuth"
 msgstr ""
 
 #: ../src/extension/internal/filter/bumps.h:111
 #: ../src/extension/internal/filter/bumps.h:333
-#: ../src/ui/dialog/filter-effects-dialog.cpp:1173
+#: ../src/ui/dialog/filter-effects-dialog.cpp:1179
 msgid "Elevation"
 msgstr ""
 
@@ -6432,7 +6436,7 @@ msgstr ""
 
 #: ../src/extension/internal/filter/bumps.h:322
 #: ../src/extension/internal/filter/transparency.h:57
-#: ../src/filter-enums.cpp:30 ../src/sp-image.cpp:506
+#: ../src/filter-enums.cpp:30 ../src/sp-image.cpp:491
 msgid "Image"
 msgstr ""
 
@@ -6514,11 +6518,12 @@ msgstr ""
 #: ../src/extension/internal/filter/color.h:157
 #: ../src/extension/internal/filter/color.h:332
 #: ../src/extension/internal/filter/paint.h:87 ../src/filter-enums.cpp:66
-#: ../src/ui/dialog/inkscape-preferences.cpp:976
+#: ../src/ui/dialog/inkscape-preferences.cpp:1031
 #: ../src/ui/tools/flood-tool.cpp:86
 #: ../src/ui/widget/color-icc-selector.cpp:161
 #: ../src/ui/widget/color-icc-selector.cpp:166
-#: ../src/ui/widget/color-scales.cpp:385 ../src/ui/widget/color-scales.cpp:386
+#: ../src/ui/widget/color-scales.cpp:399 ../src/ui/widget/color-scales.cpp:400
+#: ../src/ui/widget/color-scales.cpp:435 ../src/ui/widget/color-scales.cpp:436
 #: ../src/widgets/tweak-toolbar.cpp:302
 msgid "Saturation"
 msgstr ""
@@ -6625,19 +6630,19 @@ msgstr ""
 
 #: ../src/extension/internal/filter/color.h:503
 #: ../src/extension/internal/filter/paint.h:498 ../src/filter-enums.cpp:111
-#: ../src/ui/dialog/filter-effects-dialog.cpp:1028
+#: ../src/ui/dialog/filter-effects-dialog.cpp:1034
 msgid "Table"
 msgstr ""
 
 #: ../src/extension/internal/filter/color.h:504
 #: ../src/extension/internal/filter/paint.h:499 ../src/filter-enums.cpp:112
-#: ../src/ui/dialog/filter-effects-dialog.cpp:1031
+#: ../src/ui/dialog/filter-effects-dialog.cpp:1037
 msgid "Discrete"
 msgstr ""
 
 #: ../src/extension/internal/filter/color.h:505 ../src/filter-enums.cpp:113
 #: ../src/live_effects/lpe-interpolate_points.cpp:24
-#: ../src/live_effects/lpe-powerstroke.cpp:122
+#: ../src/live_effects/lpe-powerstroke.cpp:125
 msgid "Linear"
 msgstr ""
 
@@ -6696,21 +6701,21 @@ msgstr ""
 #: ../src/extension/internal/filter/color.h:715
 #: ../src/ui/widget/color-icc-selector.cpp:168
 #: ../src/ui/widget/color-icc-selector.cpp:173
-#: ../src/ui/widget/color-scales.cpp:410 ../src/ui/widget/color-scales.cpp:411
+#: ../src/ui/widget/color-scales.cpp:465 ../src/ui/widget/color-scales.cpp:466
 msgid "Cyan"
 msgstr ""
 
 #: ../src/extension/internal/filter/color.h:716
 #: ../src/ui/widget/color-icc-selector.cpp:169
 #: ../src/ui/widget/color-icc-selector.cpp:174
-#: ../src/ui/widget/color-scales.cpp:413 ../src/ui/widget/color-scales.cpp:414
+#: ../src/ui/widget/color-scales.cpp:468 ../src/ui/widget/color-scales.cpp:469
 msgid "Magenta"
 msgstr ""
 
 #: ../src/extension/internal/filter/color.h:717
 #: ../src/ui/widget/color-icc-selector.cpp:170
 #: ../src/ui/widget/color-icc-selector.cpp:175
-#: ../src/ui/widget/color-scales.cpp:416 ../src/ui/widget/color-scales.cpp:417
+#: ../src/ui/widget/color-scales.cpp:471 ../src/ui/widget/color-scales.cpp:472
 msgid "Yellow"
 msgstr ""
 
@@ -6736,13 +6741,13 @@ msgstr ""
 
 #: ../src/extension/internal/filter/color.h:819
 #: ../src/ui/widget/color-icc-selector.cpp:171
-#: ../src/ui/widget/color-scales.cpp:419 ../src/ui/widget/color-scales.cpp:420
-#: ../src/ui/widget/selected-style.cpp:279
+#: ../src/ui/widget/color-scales.cpp:474 ../src/ui/widget/color-scales.cpp:475
+#: ../src/ui/widget/selected-style.cpp:277
 msgid "Black"
 msgstr ""
 
 #: ../src/extension/internal/filter/color.h:820
-#: ../src/ui/widget/selected-style.cpp:275
+#: ../src/ui/widget/selected-style.cpp:273
 msgid "White"
 msgstr ""
 
@@ -6765,7 +6770,7 @@ msgid "Customize greyscale components"
 msgstr ""
 
 #: ../src/extension/internal/filter/color.h:980
-#: ../src/ui/widget/selected-style.cpp:271
+#: ../src/ui/widget/selected-style.cpp:269
 msgid "Invert"
 msgstr ""
 
@@ -6819,11 +6824,11 @@ msgstr ""
 
 #: ../src/extension/internal/filter/color.h:1119
 #: ../src/extension/internal/filter/paint.h:356 ../src/filter-enums.cpp:33
-#: ../src/live_effects/effect.cpp:140
+#: ../src/live_effects/effect.cpp:145
 #: ../src/live_effects/lpe-transform_2pts.cpp:38
-#: ../src/ui/dialog/filter-effects-dialog.cpp:1025
-#: ../src/widgets/gradient-toolbar.cpp:1160
-#: ../src/widgets/measure-toolbar.cpp:328
+#: ../src/ui/dialog/filter-effects-dialog.cpp:1031
+#: ../src/widgets/gradient-toolbar.cpp:1049
+#: ../src/widgets/measure-toolbar.cpp:346
 msgid "Offset"
 msgstr ""
 
@@ -6853,9 +6858,9 @@ msgstr ""
 #: ../src/extension/internal/filter/color.h:1382
 #: ../src/extension/internal/filter/color.h:1385
 #: ../src/extension/internal/filter/color.h:1388
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2804
-#: ../src/ui/dialog/input.cpp:1442 ../src/ui/dialog/layers.cpp:919
-#: ../src/ui/widget/page-sizer.cpp:230
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2821
+#: ../src/ui/dialog/input.cpp:1443 ../src/ui/dialog/layers.cpp:927
+#: ../src/ui/widget/page-sizer.cpp:232
 msgid "X"
 msgstr ""
 
@@ -6867,8 +6872,8 @@ msgstr ""
 #: ../src/extension/internal/filter/color.h:1383
 #: ../src/extension/internal/filter/color.h:1386
 #: ../src/extension/internal/filter/color.h:1389
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2808
-#: ../src/ui/dialog/input.cpp:1442 ../src/ui/widget/page-sizer.cpp:231
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2825
+#: ../src/ui/dialog/input.cpp:1443 ../src/ui/widget/page-sizer.cpp:233
 msgid "Y"
 msgstr ""
 
@@ -6998,7 +7003,7 @@ msgstr ""
 
 #: ../src/extension/internal/filter/distort.h:77
 #: ../src/extension/internal/filter/textures.h:75
-#: ../src/ui/widget/selected-style.cpp:123
+#: ../src/ui/widget/selected-style.cpp:122
 #: ../src/ui/widget/style-swatch.cpp:116
 msgid "Stroke:"
 msgstr ""
@@ -7074,7 +7079,7 @@ msgid "Blur and displace edges of shapes and pictures"
 msgstr ""
 
 #: ../src/extension/internal/filter/distort.h:190
-#: ../src/live_effects/effect.cpp:114
+#: ../src/live_effects/effect.cpp:117
 msgid "Roughen"
 msgstr ""
 
@@ -7146,16 +7151,16 @@ msgid "Open"
 msgstr ""
 
 #: ../src/extension/internal/filter/morphology.h:65
-#: ../src/ui/tools/measure-tool.cpp:1218 ../src/ui/widget/page-sizer.cpp:232
-#: ../src/widgets/rect-toolbar.cpp:313 ../src/widgets/spray-toolbar.cpp:297
+#: ../src/ui/tools/measure-tool.cpp:1232 ../src/ui/widget/page-sizer.cpp:234
+#: ../src/widgets/rect-toolbar.cpp:319 ../src/widgets/spray-toolbar.cpp:297
 #: ../src/widgets/tweak-toolbar.cpp:128
-#: ../share/extensions/interp_att_g.inx.h:12
+#: ../share/extensions/interp_att_g.inx.h:14
 msgid "Width"
 msgstr ""
 
 #: ../src/extension/internal/filter/morphology.h:69
 #: ../src/extension/internal/filter/morphology.h:190
-#: ../src/ui/dialog/export.cpp:155
+#: ../src/ui/dialog/export.cpp:151
 msgid "Antialiasing"
 msgstr ""
 
@@ -7373,7 +7378,7 @@ msgid "Clean-up"
 msgstr ""
 
 #: ../src/extension/internal/filter/paint.h:238
-#: ../src/ui/tools/measure-tool.cpp:1189 ../share/extensions/measure.inx.h:17
+#: ../src/ui/tools/measure-tool.cpp:1204 ../share/extensions/measure.inx.h:17
 msgid "Length"
 msgstr ""
 
@@ -7383,7 +7388,7 @@ msgstr ""
 
 #: ../src/extension/internal/filter/paint.h:331
 #: ../src/ui/dialog/align-and-distribute.cpp:1060
-#: ../src/widgets/desktop-widget.cpp:1988
+#: ../src/widgets/desktop-widget.cpp:2001
 msgid "Drawing"
 msgstr ""
 
@@ -7392,7 +7397,7 @@ msgstr ""
 #: ../src/extension/internal/filter/paint.h:496
 #: ../src/extension/internal/filter/paint.h:590
 #: ../src/extension/internal/filter/paint.h:976
-#: ../src/live_effects/effect.cpp:108 ../src/splivarot.cpp:2366
+#: ../src/live_effects/effect.cpp:111 ../src/splivarot.cpp:2370
 msgid "Simplify"
 msgstr ""
 
@@ -7464,12 +7469,13 @@ msgstr ""
 
 #: ../src/extension/internal/filter/paint.h:591
 #: ../src/live_effects/lpe-jointype.cpp:52
+#: ../src/live_effects/lpe-measure-segments.cpp:67
 msgid "Line width"
 msgstr ""
 
 #: ../src/extension/internal/filter/paint.h:593
 #: ../src/extension/internal/filter/paint.h:861
-#: ../src/ui/widget/filter-effect-chooser.cpp:21
+#: ../src/ui/widget/filter-effect-chooser.cpp:23
 msgid "Blend mode:"
 msgstr ""
 
@@ -7669,15 +7675,14 @@ msgid "Source:"
 msgstr ""
 
 #: ../src/extension/internal/filter/transparency.h:56
-#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:1540
+#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:1543
 msgid "Background"
 msgstr ""
 
 #: ../src/extension/internal/filter/transparency.h:59
 #: ../src/live_effects/lpe-fillet-chamfer.cpp:40
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2745
-#: ../src/ui/dialog/input.cpp:920 ../src/widgets/eraser-toolbar.cpp:165
-#: ../src/widgets/pencil-toolbar.cpp:138 ../src/widgets/spray-toolbar.cpp:389
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2762
+#: ../src/ui/dialog/input.cpp:921 ../src/widgets/pencil-toolbar.cpp:159
 #: ../src/widgets/tweak-toolbar.cpp:254 ../share/extensions/extrude.inx.h:2
 #: ../share/extensions/triangle.inx.h:8
 msgid "Mode:"
@@ -7724,93 +7729,93 @@ msgstr ""
 msgid "Repaint anything visible monochrome"
 msgstr ""
 
-#: ../src/extension/internal/gdkpixbuf-input.cpp:193
+#: ../src/extension/internal/gdkpixbuf-input.cpp:189
 #, c-format
 msgid "%s bitmap image import"
 msgstr ""
 
-#: ../src/extension/internal/gdkpixbuf-input.cpp:200
+#: ../src/extension/internal/gdkpixbuf-input.cpp:196
 #, c-format
 msgid "Image Import Type:"
 msgstr ""
 
-#: ../src/extension/internal/gdkpixbuf-input.cpp:200
+#: ../src/extension/internal/gdkpixbuf-input.cpp:196
 #, c-format
 msgid ""
 "Embed results in stand-alone, larger SVG files. Link references a file "
 "outside this SVG document and all files must be moved together."
 msgstr ""
 
-#: ../src/extension/internal/gdkpixbuf-input.cpp:201
-#: ../src/ui/dialog/inkscape-preferences.cpp:1491
+#: ../src/extension/internal/gdkpixbuf-input.cpp:197
+#: ../src/ui/dialog/inkscape-preferences.cpp:1552
 #, c-format
 msgid "Embed"
 msgstr ""
 
-#: ../src/extension/internal/gdkpixbuf-input.cpp:202 ../src/sp-anchor.cpp:141
-#: ../src/ui/dialog/inkscape-preferences.cpp:1491
+#: ../src/extension/internal/gdkpixbuf-input.cpp:198 ../src/sp-anchor.cpp:141
+#: ../src/ui/dialog/inkscape-preferences.cpp:1552
 #, c-format
 msgid "Link"
 msgstr ""
 
-#: ../src/extension/internal/gdkpixbuf-input.cpp:205
+#: ../src/extension/internal/gdkpixbuf-input.cpp:201
 #, c-format
 msgid "Image DPI:"
 msgstr ""
 
-#: ../src/extension/internal/gdkpixbuf-input.cpp:205
+#: ../src/extension/internal/gdkpixbuf-input.cpp:201
 #, c-format
 msgid ""
 "Take information from file or use default bitmap import resolution as "
 "defined in the preferences."
 msgstr ""
 
-#: ../src/extension/internal/gdkpixbuf-input.cpp:206
+#: ../src/extension/internal/gdkpixbuf-input.cpp:202
 #, c-format
 msgid "From file"
 msgstr ""
 
-#: ../src/extension/internal/gdkpixbuf-input.cpp:207
+#: ../src/extension/internal/gdkpixbuf-input.cpp:203
 #, c-format
 msgid "Default import resolution"
 msgstr ""
 
-#: ../src/extension/internal/gdkpixbuf-input.cpp:210
+#: ../src/extension/internal/gdkpixbuf-input.cpp:206
 #, c-format
 msgid "Image Rendering Mode:"
 msgstr ""
 
-#: ../src/extension/internal/gdkpixbuf-input.cpp:210
+#: ../src/extension/internal/gdkpixbuf-input.cpp:206
 #, c-format
 msgid ""
 "When an image is upscaled, apply smoothing or keep blocky (pixelated). (Will "
 "not work in all browsers.)"
 msgstr ""
 
-#: ../src/extension/internal/gdkpixbuf-input.cpp:211
-#: ../src/ui/dialog/inkscape-preferences.cpp:1498
+#: ../src/extension/internal/gdkpixbuf-input.cpp:207
+#: ../src/ui/dialog/inkscape-preferences.cpp:1559
 #, c-format
 msgid "None (auto)"
 msgstr ""
 
-#: ../src/extension/internal/gdkpixbuf-input.cpp:212
-#: ../src/ui/dialog/inkscape-preferences.cpp:1498
+#: ../src/extension/internal/gdkpixbuf-input.cpp:208
+#: ../src/ui/dialog/inkscape-preferences.cpp:1559
 #, c-format
 msgid "Smooth (optimizeQuality)"
 msgstr ""
 
-#: ../src/extension/internal/gdkpixbuf-input.cpp:213
-#: ../src/ui/dialog/inkscape-preferences.cpp:1498
+#: ../src/extension/internal/gdkpixbuf-input.cpp:209
+#: ../src/ui/dialog/inkscape-preferences.cpp:1559
 #, c-format
 msgid "Blocky (optimizeSpeed)"
 msgstr ""
 
-#: ../src/extension/internal/gdkpixbuf-input.cpp:216
+#: ../src/extension/internal/gdkpixbuf-input.cpp:212
 #, c-format
 msgid "Hide the dialog next time and always apply the same actions."
 msgstr ""
 
-#: ../src/extension/internal/gdkpixbuf-input.cpp:216
+#: ../src/extension/internal/gdkpixbuf-input.cpp:212
 #, c-format
 msgid "Don't ask again"
 msgstr ""
@@ -7827,7 +7832,7 @@ msgstr ""
 msgid "Gradients used in GIMP"
 msgstr ""
 
-#: ../src/extension/internal/grid.cpp:199 ../src/ui/widget/panel.cpp:112
+#: ../src/extension/internal/grid.cpp:199 ../src/ui/dialog/swatches.cpp:708
 msgid "Grid"
 msgstr ""
 
@@ -7852,7 +7857,7 @@ msgid "Vertical Offset:"
 msgstr ""
 
 #: ../src/extension/internal/grid.cpp:209
-#: ../src/ui/dialog/inkscape-preferences.cpp:1512
+#: ../src/ui/dialog/inkscape-preferences.cpp:1573
 #: ../share/extensions/draw_from_triangle.inx.h:58
 #: ../share/extensions/eqtexsvg.inx.h:4 ../share/extensions/foldablebox.inx.h:9
 #: ../share/extensions/frame.inx.h:2 ../share/extensions/funcplot.inx.h:38
@@ -7883,8 +7888,8 @@ msgstr ""
 
 #: ../src/extension/internal/grid.cpp:210
 #: ../src/ui/dialog/document-properties.cpp:147
-#: ../src/ui/dialog/inkscape-preferences.cpp:818
-#: ../src/widgets/toolbox.cpp:1389
+#: ../src/ui/dialog/inkscape-preferences.cpp:873
+#: ../src/widgets/toolbox.cpp:1392
 msgid "Grids"
 msgstr ""
 
@@ -7920,15 +7925,15 @@ msgstr ""
 msgid "LaTeX Print"
 msgstr ""
 
-#: ../src/extension/internal/odf.cpp:2138
+#: ../src/extension/internal/odf.cpp:2135
 msgid "OpenDocument Drawing Output"
 msgstr ""
 
-#: ../src/extension/internal/odf.cpp:2143
+#: ../src/extension/internal/odf.cpp:2140
 msgid "OpenDocument drawing (*.odg)"
 msgstr ""
 
-#: ../src/extension/internal/odf.cpp:2144
+#: ../src/extension/internal/odf.cpp:2141
 msgid "OpenDocument drawing file"
 msgstr ""
 
@@ -8042,27 +8047,27 @@ msgctxt "PDF input precision"
 msgid "very fine"
 msgstr ""
 
-#: ../src/extension/internal/pdfinput/pdf-input.cpp:943
+#: ../src/extension/internal/pdfinput/pdf-input.cpp:949
 msgid "PDF Input"
 msgstr ""
 
-#: ../src/extension/internal/pdfinput/pdf-input.cpp:948
+#: ../src/extension/internal/pdfinput/pdf-input.cpp:954
 msgid "Portable Document Format (*.pdf)"
 msgstr ""
 
-#: ../src/extension/internal/pdfinput/pdf-input.cpp:949
+#: ../src/extension/internal/pdfinput/pdf-input.cpp:955
 msgid "Portable Document Format"
 msgstr ""
 
-#: ../src/extension/internal/pdfinput/pdf-input.cpp:956
+#: ../src/extension/internal/pdfinput/pdf-input.cpp:962
 msgid "AI Input"
 msgstr ""
 
-#: ../src/extension/internal/pdfinput/pdf-input.cpp:961
+#: ../src/extension/internal/pdfinput/pdf-input.cpp:967
 msgid "Adobe Illustrator 9.0 and above (*.ai)"
 msgstr ""
 
-#: ../src/extension/internal/pdfinput/pdf-input.cpp:962
+#: ../src/extension/internal/pdfinput/pdf-input.cpp:968
 msgid "Open files saved in Adobe Illustrator 9.0 and newer versions"
 msgstr ""
 
@@ -8078,39 +8083,39 @@ msgstr ""
 msgid "PovRay Raytracer File"
 msgstr ""
 
-#: ../src/extension/internal/svg.cpp:122
+#: ../src/extension/internal/svg.cpp:121
 msgid "SVG Input"
 msgstr ""
 
-#: ../src/extension/internal/svg.cpp:127
+#: ../src/extension/internal/svg.cpp:126
 msgid "Scalable Vector Graphic (*.svg)"
 msgstr ""
 
-#: ../src/extension/internal/svg.cpp:128
+#: ../src/extension/internal/svg.cpp:127
 msgid "Inkscape native file format and W3C standard"
 msgstr ""
 
-#: ../src/extension/internal/svg.cpp:136
+#: ../src/extension/internal/svg.cpp:135
 msgid "SVG Output Inkscape"
 msgstr ""
 
-#: ../src/extension/internal/svg.cpp:141
+#: ../src/extension/internal/svg.cpp:140
 msgid "Inkscape SVG (*.svg)"
 msgstr ""
 
-#: ../src/extension/internal/svg.cpp:142
+#: ../src/extension/internal/svg.cpp:141
 msgid "SVG format with Inkscape extensions"
 msgstr ""
 
-#: ../src/extension/internal/svg.cpp:150 ../share/extensions/scour.inx.h:19
+#: ../src/extension/internal/svg.cpp:149 ../share/extensions/scour.inx.h:19
 msgid "SVG Output"
 msgstr ""
 
-#: ../src/extension/internal/svg.cpp:155
+#: ../src/extension/internal/svg.cpp:154
 msgid "Plain SVG (*.svg)"
 msgstr ""
 
-#: ../src/extension/internal/svg.cpp:156
+#: ../src/extension/internal/svg.cpp:155
 msgid "Scalable Vector Graphics format as defined by the W3C"
 msgstr ""
 
@@ -8227,10 +8232,8 @@ msgstr ""
 msgid "Vector graphics format used by Corel WordPerfect"
 msgstr ""
 
-#: ../src/extension/prefdialog.cpp:74 ../src/ui/dialog/aboutbox.cpp:102
-#: ../src/ui/dialog/knot-properties.cpp:44 ../src/ui/dialog/panel-dialog.h:168
-#: ../src/ui/dialog/panel-dialog.h:217 ../src/ui/dialog/text-edit.cpp:64
-#: ../src/verbs.cpp:2588
+#: ../src/extension/prefdialog.cpp:74 ../src/ui/dialog/knot-properties.cpp:44
+#: ../src/ui/dialog/text-edit.cpp:64 ../src/verbs.cpp:2618
 msgid "_Close"
 msgstr ""
 
@@ -8239,11 +8242,11 @@ msgstr ""
 msgid "_Apply"
 msgstr ""
 
-#: ../src/extension/prefdialog.cpp:249
+#: ../src/extension/prefdialog.cpp:253
 msgid "Live preview"
 msgstr ""
 
-#: ../src/extension/prefdialog.cpp:249
+#: ../src/extension/prefdialog.cpp:253
 msgid "Is the effect previewed live on canvas?"
 msgstr ""
 
@@ -8255,43 +8258,43 @@ msgstr ""
 msgid "Convert legacy Inkscape file"
 msgstr ""
 
-#: ../src/file-update.cpp:325
+#: ../src/file-update.cpp:326
 msgid ""
 "was created in an older version of Inkscape (90 DPI) and we need to make it "
 "compatible with newer versions (96 DPI). Tell us about this file:\n"
 msgstr ""
 
-#: ../src/file-update.cpp:333
+#: ../src/file-update.cpp:334
 msgid ""
 "This file contains digital artwork for screen display. <b>(Choose if "
 "unsure.)</b>"
 msgstr ""
 
-#: ../src/file-update.cpp:336
+#: ../src/file-update.cpp:337
 msgid "This file is intended for physical output, such as paper or 3D prints."
 msgstr ""
 
-#: ../src/file-update.cpp:338
+#: ../src/file-update.cpp:339
 msgid ""
 "The appearance of elements such as clips, masks, filters, and clones\n"
 "is most important. <b>(Choose if unsure.)</b>"
 msgstr ""
 
-#: ../src/file-update.cpp:342
+#: ../src/file-update.cpp:343
 msgid ""
 "The accuracy of the physical unit size and position values of objects\n"
 "in the file is most important. (Experimental.)"
 msgstr ""
 
-#: ../src/file-update.cpp:344
+#: ../src/file-update.cpp:345
 msgid "Create a backup file in same directory."
 msgstr ""
 
-#: ../src/file-update.cpp:345
+#: ../src/file-update.cpp:346
 msgid "More details..."
 msgstr ""
 
-#: ../src/file-update.cpp:348
+#: ../src/file-update.cpp:349
 msgid ""
 "<small>We've updated Inkscape to follow the CSS standard of 96 DPI for "
 "better browser compatibility; we used to use 90 DPI. Digital artwork for "
@@ -8311,133 +8314,150 @@ msgid ""
 "printing.)\n"
 "\n"
 "More information about this change are available in the <a href='https://"
-"inkscape.org/en/learn/faq#todo-todo-todo'>Inkscape FAQ</a></small>"
+"inkscape.org/en/learn/faq#dpi_change'>Inkscape FAQ</a></small>"
 msgstr ""
 
-#: ../src/file-update.cpp:391
+#: ../src/file-update.cpp:392
 msgid "OK"
 msgstr ""
 
 #. Look for SPNamedView and SPDefs loop
 #. desktop->getDocument()->ensureUpToDate();  // Does not update box3d!
-#: ../src/file-update.cpp:613
+#: ../src/file-update.cpp:614
 msgid "Update Document"
 msgstr ""
 
-#: ../src/file.cpp:165
+#: ../src/file.cpp:161
 msgid "default.svg"
 msgstr ""
 
-#: ../src/file.cpp:281 ../src/main-cmdlinexact.cpp:174
+#: ../src/file.cpp:282 ../src/main-cmdlinexact.cpp:174
 msgid "Broken links have been changed to point to existing files."
 msgstr ""
 
-#: ../src/file.cpp:292 ../src/file.cpp:1347
+#: ../src/file.cpp:293 ../src/file.cpp:1287
 #, c-format
 msgid "Failed to load the requested file %s"
 msgstr ""
 
-#: ../src/file.cpp:318
+#: ../src/file.cpp:319
 msgid "Document not saved yet.  Cannot revert."
 msgstr ""
 
-#: ../src/file.cpp:324
+#: ../src/file.cpp:325
 msgid "Changes will be lost! Are you sure you want to reload document %1?"
 msgstr ""
 
-#: ../src/file.cpp:350
+#: ../src/file.cpp:351
 msgid "Document reverted."
 msgstr ""
 
-#: ../src/file.cpp:352
+#: ../src/file.cpp:353
 msgid "Document not reverted."
 msgstr ""
 
-#: ../src/file.cpp:502
+#: ../src/file.cpp:503
 msgid "Select file to open"
 msgstr ""
 
-#: ../src/file.cpp:584
+#: ../src/file.cpp:585
 msgid "Clean up document"
 msgstr ""
 
-#: ../src/file.cpp:591
+#: ../src/file.cpp:592
 #, c-format
 msgid "Removed <b>%i</b> unused definition in &lt;defs&gt;."
 msgid_plural "Removed <b>%i</b> unused definitions in &lt;defs&gt;."
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/file.cpp:596
+#: ../src/file.cpp:597
 msgid "No unused definitions in &lt;defs&gt;."
 msgstr ""
 
-#: ../src/file.cpp:630
+#: ../src/file.cpp:631
 #, c-format
 msgid ""
 "No Inkscape extension found to save document (%s).  This may have been "
 "caused by an unknown filename extension."
 msgstr ""
 
-#: ../src/file.cpp:631 ../src/file.cpp:641 ../src/file.cpp:650
-#: ../src/file.cpp:657 ../src/file.cpp:663
+#: ../src/file.cpp:632 ../src/file.cpp:642 ../src/file.cpp:651
+#: ../src/file.cpp:658 ../src/file.cpp:663 ../src/file.cpp:675
+#: ../src/file.cpp:685
 msgid "Document not saved."
 msgstr ""
 
-#: ../src/file.cpp:640
+#: ../src/file.cpp:641
 #, c-format
 msgid ""
 "File %s is write protected. Please remove write protection and try again."
 msgstr ""
 
-#: ../src/file.cpp:649
+#: ../src/file.cpp:650 ../src/file.cpp:684
 #, c-format
 msgid "File %s could not be saved."
 msgstr ""
 
-#: ../src/file.cpp:682 ../src/file.cpp:684
+#: ../src/file.cpp:662
+#, c-format
+msgid ""
+"File could not be saved:\n"
+"No object with ID '%s' found."
+msgstr ""
+
+#: ../src/file.cpp:672
+#, c-format
+msgid ""
+"File %s could not be saved.\n"
+"\n"
+"The following additional information was returned by the output extension:\n"
+"'%s'"
+msgstr ""
+
+#: ../src/file.cpp:707 ../src/file.cpp:709
 msgid "Document saved."
 msgstr ""
 
 #. We are saving for the first time; create a unique default filename
-#: ../src/file.cpp:827 ../src/file.cpp:1506
+#: ../src/file.cpp:767 ../src/file.cpp:1446
 msgid "drawing"
 msgstr ""
 
-#: ../src/file.cpp:832
+#: ../src/file.cpp:772
 msgid "drawing-%1"
 msgstr ""
 
-#: ../src/file.cpp:849
+#: ../src/file.cpp:789
 msgid "Select file to save a copy to"
 msgstr ""
 
-#: ../src/file.cpp:851
+#: ../src/file.cpp:791
 msgid "Select file to save to"
 msgstr ""
 
-#: ../src/file.cpp:956 ../src/file.cpp:958
+#: ../src/file.cpp:896 ../src/file.cpp:898
 msgid "No changes need to be saved."
 msgstr ""
 
-#: ../src/file.cpp:977
+#: ../src/file.cpp:917
 msgid "Saving document..."
 msgstr ""
 
-#: ../src/file.cpp:1344 ../src/ui/dialog/inkscape-preferences.cpp:1485
-#: ../src/ui/dialog/ocaldialogs.cpp:1091
+#: ../src/file.cpp:1284 ../src/ui/dialog/inkscape-preferences.cpp:1546
+#: ../src/ui/dialog/ocaldialogs.cpp:1092
 msgid "Import"
 msgstr ""
 
-#: ../src/file.cpp:1394
+#: ../src/file.cpp:1334
 msgid "Select file to import"
 msgstr ""
 
-#: ../src/file.cpp:1527
+#: ../src/file.cpp:1467
 msgid "Select file to export to"
 msgstr ""
 
-#: ../src/file.cpp:1780
+#: ../src/file.cpp:1720
 msgid "Import Clip Art"
 msgstr ""
 
@@ -8533,7 +8553,8 @@ msgstr ""
 #: ../src/filter-enums.cpp:65 ../src/ui/tools/flood-tool.cpp:85
 #: ../src/ui/widget/color-icc-selector.cpp:160
 #: ../src/ui/widget/color-icc-selector.cpp:164
-#: ../src/ui/widget/color-scales.cpp:382 ../src/ui/widget/color-scales.cpp:383
+#: ../src/ui/widget/color-scales.cpp:394 ../src/ui/widget/color-scales.cpp:395
+#: ../src/ui/widget/color-scales.cpp:430 ../src/ui/widget/color-scales.cpp:431
 #: ../src/widgets/tweak-toolbar.cpp:286
 msgid "Hue"
 msgstr ""
@@ -8573,7 +8594,7 @@ msgstr ""
 msgid "Copy"
 msgstr ""
 
-#: ../src/filter-enums.cpp:97 ../src/ui/dialog/filedialogimpl-gtkmm.cpp:1560
+#: ../src/filter-enums.cpp:97 ../src/ui/dialog/filedialogimpl-gtkmm.cpp:1563
 msgid "Destination"
 msgstr ""
 
@@ -8602,7 +8623,7 @@ msgid "Arithmetic"
 msgstr ""
 
 #: ../src/filter-enums.cpp:120 ../src/selection-chemistry.cpp:544
-#: ../src/ui/dialog/objects.cpp:1919
+#: ../src/ui/dialog/objects.cpp:1881
 msgid "Duplicate"
 msgstr ""
 
@@ -8639,15 +8660,15 @@ msgstr ""
 msgid "Spot Light"
 msgstr ""
 
-#: ../src/gradient-chemistry.cpp:1613
+#: ../src/gradient-chemistry.cpp:1606
 msgid "Invert gradient colors"
 msgstr ""
 
-#: ../src/gradient-chemistry.cpp:1640
+#: ../src/gradient-chemistry.cpp:1633
 msgid "Reverse gradient"
 msgstr ""
 
-#: ../src/gradient-chemistry.cpp:1654 ../src/widgets/gradient-selector.cpp:207
+#: ../src/gradient-chemistry.cpp:1647 ../src/widgets/gradient-selector.cpp:207
 msgid "Delete swatch"
 msgstr ""
 
@@ -8718,7 +8739,7 @@ msgstr ""
 msgid "Move gradient handle"
 msgstr ""
 
-#: ../src/gradient-drag.cpp:1182 ../src/widgets/gradient-vector.cpp:798
+#: ../src/gradient-drag.cpp:1182 ../src/widgets/gradient-vector.cpp:777
 msgid "Delete gradient stop"
 msgstr ""
 
@@ -8771,52 +8792,52 @@ msgstr ""
 msgid "Move gradient mid stop(s)"
 msgstr ""
 
-#: ../src/gradient-drag.cpp:3104
+#: ../src/gradient-drag.cpp:3102
 msgid "Delete gradient stop(s)"
 msgstr ""
 
-#: ../src/inkscape.cpp:224
+#: ../src/inkscape.cpp:226
 msgid "Autosave failed! Cannot open directory %1."
 msgstr ""
 
-#: ../src/inkscape.cpp:240
+#: ../src/inkscape.cpp:242
 msgid "Autosaving documents..."
 msgstr ""
 
-#: ../src/inkscape.cpp:308
+#: ../src/inkscape.cpp:310
 msgid "Autosave failed! Could not find inkscape extension to save document."
 msgstr ""
 
-#: ../src/inkscape.cpp:311 ../src/inkscape.cpp:318
+#: ../src/inkscape.cpp:313 ../src/inkscape.cpp:320
 #, c-format
 msgid "Autosave failed! File %s could not be saved."
 msgstr ""
 
-#: ../src/inkscape.cpp:333
+#: ../src/inkscape.cpp:335
 msgid "Autosave complete."
 msgstr ""
 
-#: ../src/inkscape.cpp:647
+#: ../src/inkscape.cpp:667 ../src/ui/dialog/symbols.cpp:648
 msgid "Untitled document"
 msgstr ""
 
 #. Show nice dialog box
-#: ../src/inkscape.cpp:679
+#: ../src/inkscape.cpp:697
 msgid "Inkscape encountered an internal error and will close now.\n"
 msgstr ""
 
-#: ../src/inkscape.cpp:680
+#: ../src/inkscape.cpp:698
 msgid ""
 "Automatic backups of unsaved documents were done to the following "
 "locations:\n"
 msgstr ""
 
-#: ../src/inkscape.cpp:681
+#: ../src/inkscape.cpp:699
 msgid "Automatic backup of the following documents failed:\n"
 msgstr ""
 
-#. wether to launch in fullscreen mode
-#. wether to search folders for SVG files recursively
+#. whether to launch in fullscreen mode
+#. whether to search folders for SVG files recursively
 #. time (in seconds) after which the next image of the slideshow is automatically loaded
 #. scale factor for images
 #. (currently only applied to the first image - others are resized to window dimensions)
@@ -8884,286 +8905,311 @@ msgstr ""
 msgid "Node or handle drag canceled."
 msgstr ""
 
-#: ../src/knotholder.cpp:180
+#: ../src/knotholder.cpp:187
 msgid "Change handle"
 msgstr ""
 
-#: ../src/knotholder.cpp:317
+#: ../src/knotholder.cpp:324
 msgid "Move handle"
 msgstr ""
 
 #. TRANSLATORS: This refers to the pattern that's inside the object
-#: ../src/knotholder.cpp:336 ../src/knotholder.cpp:358
+#: ../src/knotholder.cpp:343 ../src/knotholder.cpp:365
 msgid "<b>Move</b> the pattern fill inside the object"
 msgstr ""
 
-#: ../src/knotholder.cpp:340 ../src/knotholder.cpp:362
+#: ../src/knotholder.cpp:347 ../src/knotholder.cpp:369
 msgid "<b>Scale</b> the pattern fill; uniformly if with <b>Ctrl</b>"
 msgstr ""
 
-#: ../src/knotholder.cpp:344 ../src/knotholder.cpp:366
+#: ../src/knotholder.cpp:351 ../src/knotholder.cpp:373
 msgid "<b>Rotate</b> the pattern fill; with <b>Ctrl</b> to snap angle"
 msgstr ""
 
-#: ../src/libnrtype/FontFactory.cpp:652
+#: ../src/libnrtype/FontFactory.cpp:797
 msgid "Ignoring font without family that will crash Pango"
 msgstr ""
 
 #. {constant defined in effect-enum.h, N_("name of your effect"), "name of your effect in SVG"}
 #. 0.46
-#: ../src/live_effects/effect.cpp:90
+#: ../src/live_effects/effect.cpp:93
 msgid "Bend"
 msgstr ""
 
-#: ../src/live_effects/effect.cpp:91
+#: ../src/live_effects/effect.cpp:94
 msgid "Gears"
 msgstr ""
 
-#: ../src/live_effects/effect.cpp:92
+#: ../src/live_effects/effect.cpp:95
 msgid "Pattern Along Path"
 msgstr ""
 
 #. for historic reasons, this effect is called skeletal(strokes) in Inkscape:SVG
-#: ../src/live_effects/effect.cpp:93
+#: ../src/live_effects/effect.cpp:96
 msgid "Stitch Sub-Paths"
 msgstr ""
 
 #. 0.47
-#: ../src/live_effects/effect.cpp:95
+#: ../src/live_effects/effect.cpp:98
 msgid "VonKoch"
 msgstr ""
 
-#: ../src/live_effects/effect.cpp:96
+#: ../src/live_effects/effect.cpp:99
 msgid "Knot"
 msgstr ""
 
-#: ../src/live_effects/effect.cpp:97
+#: ../src/live_effects/effect.cpp:100
 msgid "Construct grid"
 msgstr ""
 
-#: ../src/live_effects/effect.cpp:98
+#: ../src/live_effects/effect.cpp:101
 msgid "Spiro spline"
 msgstr ""
 
-#: ../src/live_effects/effect.cpp:99
+#: ../src/live_effects/effect.cpp:102
 msgid "Envelope Deformation"
 msgstr ""
 
-#: ../src/live_effects/effect.cpp:100
+#: ../src/live_effects/effect.cpp:103
 msgid "Interpolate Sub-Paths"
 msgstr ""
 
-#: ../src/live_effects/effect.cpp:101
+#: ../src/live_effects/effect.cpp:104
 msgid "Hatches (rough)"
 msgstr ""
 
-#: ../src/live_effects/effect.cpp:102
+#: ../src/live_effects/effect.cpp:105
 msgid "Sketch"
 msgstr ""
 
-#: ../src/live_effects/effect.cpp:103
+#: ../src/live_effects/effect.cpp:106
 msgid "Ruler"
 msgstr ""
 
 #. 0.91
-#: ../src/live_effects/effect.cpp:105
+#: ../src/live_effects/effect.cpp:108
 msgid "Power stroke"
 msgstr ""
 
-#: ../src/live_effects/effect.cpp:106
+#: ../src/live_effects/effect.cpp:109 ../src/selection-chemistry.cpp:2933
 msgid "Clone original"
 msgstr ""
 
-#: ../src/live_effects/effect.cpp:109
+#: ../src/live_effects/effect.cpp:112
 msgid "Lattice Deformation 2"
 msgstr ""
 
-#: ../src/live_effects/effect.cpp:110
+#: ../src/live_effects/effect.cpp:113
 msgid "Perspective/Envelope"
 msgstr ""
 
 #. TODO:Wrong name with "-"
-#: ../src/live_effects/effect.cpp:111
+#: ../src/live_effects/effect.cpp:114
 msgid "Interpolate points"
 msgstr ""
 
-#: ../src/live_effects/effect.cpp:112
+#: ../src/live_effects/effect.cpp:115
 msgid "Transform by 2 points"
 msgstr ""
 
-#: ../src/live_effects/effect.cpp:113
-#: ../src/live_effects/lpe-show_handles.cpp:27
-#: ../src/widgets/mesh-toolbar.cpp:505
+#: ../src/live_effects/effect.cpp:116
+#: ../src/live_effects/lpe-show_handles.cpp:28
+#: ../src/widgets/mesh-toolbar.cpp:514
 msgid "Show handles"
 msgstr ""
 
-#: ../src/live_effects/effect.cpp:115 ../src/widgets/pencil-toolbar.cpp:115
+#: ../src/live_effects/effect.cpp:118 ../src/widgets/pencil-toolbar.cpp:137
 msgid "BSpline"
 msgstr ""
 
-#: ../src/live_effects/effect.cpp:116
+#: ../src/live_effects/effect.cpp:119
 msgid "Join type"
 msgstr ""
 
-#: ../src/live_effects/effect.cpp:117
+#: ../src/live_effects/effect.cpp:120
 msgid "Taper stroke"
 msgstr ""
 
-#: ../src/live_effects/effect.cpp:118
+#: ../src/live_effects/effect.cpp:121
 msgid "Mirror symmetry"
 msgstr ""
 
-#: ../src/live_effects/effect.cpp:119
+#: ../src/live_effects/effect.cpp:122
 msgid "Rotate copies"
 msgstr ""
 
 #. Ponyscape -> Inkscape 0.92
-#: ../src/live_effects/effect.cpp:121
+#: ../src/live_effects/effect.cpp:124
 msgid "Attach path"
 msgstr ""
 
-#: ../src/live_effects/effect.cpp:122
+#: ../src/live_effects/effect.cpp:125
 msgid "Fill between strokes"
 msgstr ""
 
-#: ../src/live_effects/effect.cpp:123 ../src/selection-chemistry.cpp:2963
+#: ../src/live_effects/effect.cpp:126 ../src/selection-chemistry.cpp:2931
 msgid "Fill between many"
 msgstr ""
 
-#: ../src/live_effects/effect.cpp:124
+#: ../src/live_effects/effect.cpp:127
 msgid "Ellipse by 5 points"
 msgstr ""
 
-#: ../src/live_effects/effect.cpp:125
+#: ../src/live_effects/effect.cpp:128
 msgid "Bounding Box"
 msgstr ""
 
 #. 9.93
-#: ../src/live_effects/effect.cpp:127
-msgid "Measure Line"
+#: ../src/live_effects/effect.cpp:130
+msgid "Measure Segments"
 msgstr ""
 
-#: ../src/live_effects/effect.cpp:128
+#: ../src/live_effects/effect.cpp:131
 msgid "Fillet/Chamfer"
 msgstr ""
 
-#: ../src/live_effects/effect.cpp:129
+#: ../src/live_effects/effect.cpp:132
 msgid "Boolean operation"
 msgstr ""
 
-#: ../src/live_effects/effect.cpp:130
-msgid "Embrodery stitch"
-msgstr ""
-
-#: ../src/live_effects/effect.cpp:132
-msgid "doEffect stack test"
-msgstr ""
-
 #: ../src/live_effects/effect.cpp:133
-msgid "Angle bisector"
+msgid "Embroidery stitch"
 msgstr ""
 
 #: ../src/live_effects/effect.cpp:134
-msgid "Circle (by center and radius)"
+msgid "Power clip"
 msgstr ""
 
 #: ../src/live_effects/effect.cpp:135
-msgid "Circle by 3 points"
+msgid "Power mask"
 msgstr ""
 
-#: ../src/live_effects/effect.cpp:136
-msgid "Dynamic stroke"
-msgstr ""
-
-#: ../src/live_effects/effect.cpp:137 ../share/extensions/extrude.inx.h:1
-msgid "Extrude"
+#: ../src/live_effects/effect.cpp:137
+msgid "doEffect stack test"
 msgstr ""
 
 #: ../src/live_effects/effect.cpp:138
-msgid "Lattice Deformation"
+msgid "Angle bisector"
 msgstr ""
 
 #: ../src/live_effects/effect.cpp:139
-msgid "Line Segment"
+msgid "Circle (by center and radius)"
+msgstr ""
+
+#: ../src/live_effects/effect.cpp:140
+msgid "Circle by 3 points"
 msgstr ""
 
 #: ../src/live_effects/effect.cpp:141
-#: ../src/live_effects/lpe-measure-line.cpp:46
-msgid "Parallel"
+msgid "Dynamic stroke"
 msgstr ""
 
-#: ../src/live_effects/effect.cpp:142
-msgid "Path length"
+#: ../src/live_effects/effect.cpp:142 ../share/extensions/extrude.inx.h:1
+msgid "Extrude"
 msgstr ""
 
 #: ../src/live_effects/effect.cpp:143
-msgid "Perpendicular bisector"
+msgid "Lattice Deformation"
 msgstr ""
 
 #: ../src/live_effects/effect.cpp:144
-msgid "Perspective path"
-msgstr ""
-
-#: ../src/live_effects/effect.cpp:145
-msgid "Recursive skeleton"
+msgid "Line Segment"
 msgstr ""
 
 #: ../src/live_effects/effect.cpp:146
-msgid "Tangent to curve"
+#: ../src/live_effects/lpe-measure-segments.cpp:51
+msgid "Parallel"
 msgstr ""
 
 #: ../src/live_effects/effect.cpp:147
+msgid "Path length"
+msgstr ""
+
+#: ../src/live_effects/effect.cpp:148
+msgid "Perpendicular bisector"
+msgstr ""
+
+#: ../src/live_effects/effect.cpp:149
+msgid "Perspective path"
+msgstr ""
+
+#: ../src/live_effects/effect.cpp:150
+msgid "Recursive skeleton"
+msgstr ""
+
+#: ../src/live_effects/effect.cpp:151
+msgid "Tangent to curve"
+msgstr ""
+
+#: ../src/live_effects/effect.cpp:152
 msgid "Text label"
 msgstr ""
 
-#: ../src/live_effects/effect.cpp:366
+#: ../src/live_effects/effect.cpp:377
 msgid "Is visible?"
 msgstr ""
 
-#: ../src/live_effects/effect.cpp:366
+#: ../src/live_effects/effect.cpp:377
 msgid ""
 "If unchecked, the effect remains applied to the object but is temporarily "
 "disabled on canvas"
 msgstr ""
 
-#: ../src/live_effects/effect.cpp:395
+#: ../src/live_effects/effect.cpp:406
 msgid "No effect"
 msgstr ""
 
-#: ../src/live_effects/effect.cpp:583
+#: ../src/live_effects/effect.cpp:594
 #, c-format
 msgid "Please specify a parameter path for the LPE '%s' with %d mouse clicks"
 msgstr ""
 
-#: ../src/live_effects/effect.cpp:819
-msgid ". Change custom values for this parameter"
+#: ../src/live_effects/effect.cpp:837 ../src/live_effects/effect.cpp:908
+msgid "<b>Default value:</b> "
 msgstr ""
 
-#: ../src/live_effects/effect.cpp:828 ../src/live_effects/effect.cpp:870
+#: ../src/live_effects/effect.cpp:838 ../src/live_effects/effect.cpp:895
+msgid "<b>Default value overridden:</b> "
+msgstr ""
+
+#: ../src/live_effects/effect.cpp:840 ../src/live_effects/effect.cpp:891
 msgid "Update"
 msgstr ""
 
-#: ../src/live_effects/effect.cpp:830 ../src/live_effects/effect.cpp:880
+#: ../src/live_effects/effect.cpp:841 ../src/live_effects/effect.cpp:894
+msgid "<b>Default value:</b> <s>"
+msgstr ""
+
+#: ../src/live_effects/effect.cpp:843 ../src/live_effects/effect.cpp:905
 #: ../src/ui/dialog/xml-tree.cpp:76
 msgid "Set"
 msgstr ""
 
+#: ../src/live_effects/effect.cpp:844 ../src/live_effects/effect.cpp:909
+msgid "<b>Default value overridden:</b> None\n"
+msgstr ""
+
+#: ../src/live_effects/effect.cpp:846 ../src/live_effects/effect.cpp:896
+#: ../src/live_effects/effect.cpp:910
+msgid "<b>Current parameter value:</b> "
+msgstr ""
+
 #. image-rendering
-#: ../src/live_effects/effect.cpp:839
+#: ../src/live_effects/effect.cpp:856
 #: ../share/extensions/image_attributes.inx.h:19
 msgid "Unset"
 msgstr ""
 
-#: ../src/live_effects/effect.cpp:852
+#: ../src/live_effects/effect.cpp:870
 msgid "</b>: Set default parameters"
 msgstr ""
 
-#: ../src/live_effects/effect.cpp:952
+#: ../src/live_effects/effect.cpp:981
 #, c-format
 msgid "Editing parameter <b>%s</b>."
 msgstr ""
 
-#: ../src/live_effects/effect.cpp:957
+#: ../src/live_effects/effect.cpp:986
 msgid "None of the applied path effect's parameters can be edited on-canvas."
 msgstr ""
 
@@ -9228,43 +9274,48 @@ msgstr ""
 msgid "End path curve end:"
 msgstr ""
 
-#: ../src/live_effects/lpe-bendpath.cpp:54
+#: ../src/live_effects/lpe-bendpath.cpp:59
 msgid "Bend path:"
 msgstr ""
 
-#: ../src/live_effects/lpe-bendpath.cpp:54
+#: ../src/live_effects/lpe-bendpath.cpp:59
 msgid "Path along which to bend the original path"
 msgstr ""
 
-#: ../src/live_effects/lpe-bendpath.cpp:56
-#: ../src/live_effects/lpe-patternalongpath.cpp:68
-#: ../src/ui/dialog/export.cpp:257 ../src/ui/dialog/transformation.cpp:67
+#: ../src/live_effects/lpe-bendpath.cpp:61
+#: ../src/live_effects/lpe-patternalongpath.cpp:72
+#: ../src/ui/dialog/export.cpp:253 ../src/ui/dialog/transformation.cpp:67
 #: ../src/ui/widget/page-sizer.cpp:220
 msgid "_Width:"
 msgstr ""
 
-#: ../src/live_effects/lpe-bendpath.cpp:56
+#: ../src/live_effects/lpe-bendpath.cpp:61
 msgid "Width of the path"
 msgstr ""
 
-#: ../src/live_effects/lpe-bendpath.cpp:57
+#: ../src/live_effects/lpe-bendpath.cpp:62
 msgid "W_idth in units of length"
 msgstr ""
 
-#: ../src/live_effects/lpe-bendpath.cpp:57
+#: ../src/live_effects/lpe-bendpath.cpp:62
 msgid "Scale the width of the path in units of its length"
 msgstr ""
 
-#: ../src/live_effects/lpe-bendpath.cpp:58
+#: ../src/live_effects/lpe-bendpath.cpp:63
 msgid "_Original path is vertical"
 msgstr ""
 
-#: ../src/live_effects/lpe-bendpath.cpp:58
+#: ../src/live_effects/lpe-bendpath.cpp:63
 msgid "Rotates the original 90 degrees, before bending it along the bend path"
 msgstr ""
 
-#: ../src/live_effects/lpe-bendpath.cpp:163
-#: ../src/live_effects/lpe-patternalongpath.cpp:283
+#: ../src/live_effects/lpe-bendpath.cpp:64
+#: ../src/live_effects/lpe-patternalongpath.cpp:89
+msgid "Hide width knot"
+msgstr ""
+
+#: ../src/live_effects/lpe-bendpath.cpp:190
+#: ../src/live_effects/lpe-patternalongpath.cpp:298
 msgid "Change the width"
 msgstr ""
 
@@ -9370,7 +9421,7 @@ msgid "Fill type (winding mode) for operand path"
 msgstr ""
 
 #: ../src/live_effects/lpe-bounding-box.cpp:20
-#: ../src/live_effects/lpe-fill-between-many.cpp:22
+#: ../src/live_effects/lpe-fill-between-many.cpp:33
 #: ../src/live_effects/lpe-fill-between-strokes.cpp:20
 msgid "Linked path:"
 msgstr ""
@@ -9446,74 +9497,45 @@ msgid "Change to 0 weight"
 msgstr ""
 
 #: ../src/live_effects/lpe-bspline.cpp:160
-#: ../src/live_effects/parameter/parameter.cpp:187
+#: ../src/live_effects/parameter/parameter.cpp:194
 msgid "Change scalar parameter"
 msgstr ""
 
-#: ../src/live_effects/lpe-clone-original.cpp:23
-msgid "Linked Item:"
-msgstr ""
-
-#: ../src/live_effects/lpe-clone-original.cpp:23
-msgid "Item from which to take the original data"
-msgstr ""
-
-#: ../src/live_effects/lpe-clone-original.cpp:24
-#: ../src/widgets/measure-toolbar.cpp:315
-msgid "Scale %"
-msgstr ""
-
-#: ../src/live_effects/lpe-clone-original.cpp:24
-msgid "Scale item %"
-msgstr ""
-
-#: ../src/live_effects/lpe-clone-original.cpp:25
-msgid "Preserve position"
-msgstr ""
-
 #: ../src/live_effects/lpe-clone-original.cpp:26
-msgid "Inverse clone"
-msgstr ""
-
-#: ../src/live_effects/lpe-clone-original.cpp:26
-msgid "Use LPE item as origin"
+msgid "No shape"
 msgstr ""
 
 #: ../src/live_effects/lpe-clone-original.cpp:27
-msgid "Clone shape -d-"
+#: ../src/live_effects/lpe-fill-between-many.cpp:25
+msgid "Without LPE's"
 msgstr ""
 
 #: ../src/live_effects/lpe-clone-original.cpp:28
-msgid "Clone transforms"
+#: ../src/live_effects/lpe-fill-between-many.cpp:26
+msgid "With Spiro or BSpline"
 msgstr ""
 
 #: ../src/live_effects/lpe-clone-original.cpp:29
-msgid "Clone fill"
+#: ../src/live_effects/lpe-fill-between-many.cpp:27
+msgid "With LPE's"
 msgstr ""
 
-#: ../src/live_effects/lpe-clone-original.cpp:30
-msgid "Clone stroke"
+#: ../src/live_effects/lpe-clone-original.cpp:35
+msgid "Linked Item:"
 msgstr ""
 
-#: ../src/live_effects/lpe-clone-original.cpp:31
-msgid "Clone paint order"
+#: ../src/live_effects/lpe-clone-original.cpp:35
+msgid "Item from which to take the original data"
 msgstr ""
 
-#: ../src/live_effects/lpe-clone-original.cpp:32
-msgid "Clone opacity"
+#: ../src/live_effects/lpe-clone-original.cpp:36
+msgid "Shape linked"
 msgstr ""
 
-#: ../src/live_effects/lpe-clone-original.cpp:33
-msgid "Clone filter"
-msgstr ""
-
-#: ../src/live_effects/lpe-clone-original.cpp:322
-#: ../src/live_effects/lpe-clone-original.cpp:337
-msgid "Show attributes override"
-msgstr ""
-
-#: ../src/live_effects/lpe-clone-original.cpp:335
-msgid "Hide attributes override"
+#: ../src/live_effects/lpe-clone-original.cpp:39
+#: ../src/live_effects/lpe-fill-between-many.cpp:36
+#: ../src/live_effects/lpe-fill-between-strokes.cpp:24
+msgid "Allow transforms"
 msgstr ""
 
 #: ../src/live_effects/lpe-constructgrid.cpp:24
@@ -9742,7 +9764,7 @@ msgid "traveling salesman 4-opt (seconds)"
 msgstr ""
 
 #: ../src/live_effects/lpe-embrodery-stitch.cpp:37
-msgid "traveling salesman 5-opt (miutes)"
+msgid "traveling salesman 5-opt (minutes)"
 msgstr ""
 
 #: ../src/live_effects/lpe-embrodery-stitch.cpp:44
@@ -9859,7 +9881,7 @@ msgid "Left path along which to bend the original path"
 msgstr ""
 
 #: ../src/live_effects/lpe-envelope.cpp:23
-msgid "_Enable left & right paths"
+msgid "_Enable left &amp; right paths"
 msgstr ""
 
 #: ../src/live_effects/lpe-envelope.cpp:23
@@ -9867,7 +9889,7 @@ msgid "Enable the left and right deformation paths"
 msgstr ""
 
 #: ../src/live_effects/lpe-envelope.cpp:24
-msgid "_Enable top & bottom paths"
+msgid "_Enable top &amp; bottom paths"
 msgstr ""
 
 #: ../src/live_effects/lpe-envelope.cpp:24
@@ -9882,32 +9904,35 @@ msgstr ""
 msgid "Defines the direction and magnitude of the extrusion"
 msgstr ""
 
-#: ../src/live_effects/lpe-fill-between-many.cpp:22
+#: ../src/live_effects/lpe-fill-between-many.cpp:33
 msgid "Paths from which to take the original path data"
 msgstr ""
 
-#: ../src/live_effects/lpe-fill-between-many.cpp:23
+#: ../src/live_effects/lpe-fill-between-many.cpp:34
+msgid "LPE's on linked:"
+msgstr ""
+
+#: ../src/live_effects/lpe-fill-between-many.cpp:34
+msgid "LPE's on linked"
+msgstr ""
+
+#: ../src/live_effects/lpe-fill-between-many.cpp:35
 #: ../src/live_effects/lpe-fill-between-strokes.cpp:23
 msgid "Fuse coincident points"
 msgstr ""
 
-#: ../src/live_effects/lpe-fill-between-many.cpp:24
-#: ../src/live_effects/lpe-fill-between-strokes.cpp:24
-msgid "Allow transforms"
-msgstr ""
-
-#: ../src/live_effects/lpe-fill-between-many.cpp:25
+#: ../src/live_effects/lpe-fill-between-many.cpp:37
 #: ../src/live_effects/lpe-fill-between-strokes.cpp:25
 msgid "Join subpaths"
 msgstr ""
 
-#: ../src/live_effects/lpe-fill-between-many.cpp:26
+#: ../src/live_effects/lpe-fill-between-many.cpp:38
 #: ../src/live_effects/lpe-fill-between-strokes.cpp:26
-#: ../src/ui/dialog/ocaldialogs.cpp:1090
+#: ../src/ui/dialog/ocaldialogs.cpp:1091
 msgid "Close"
 msgstr ""
 
-#: ../src/live_effects/lpe-fill-between-many.cpp:26
+#: ../src/live_effects/lpe-fill-between-many.cpp:38
 #: ../src/live_effects/lpe-fill-between-strokes.cpp:26
 msgid "Close path"
 msgstr ""
@@ -9929,7 +9954,7 @@ msgid "Reverses the second path order"
 msgstr ""
 
 #: ../src/live_effects/lpe-fillet-chamfer.cpp:27
-#: ../src/widgets/text-toolbar.cpp:1905
+#: ../src/widgets/text-toolbar.cpp:2207
 #: ../share/extensions/render_barcode_qrcode.inx.h:5
 msgid "Auto"
 msgstr ""
@@ -9943,8 +9968,8 @@ msgid "Force bezier"
 msgstr ""
 
 #: ../src/live_effects/lpe-fillet-chamfer.cpp:35
-#: ../src/live_effects/lpe-measure-line.cpp:52
-#: ../src/live_effects/lpe-ruler.cpp:39 ../src/widgets/gimp/ruler.cpp:194
+#: ../src/live_effects/lpe-measure-segments.cpp:57
+#: ../src/live_effects/lpe-ruler.cpp:39 ../src/widgets/gimp/ruler.cpp:197
 msgid "Unit"
 msgstr ""
 
@@ -10005,22 +10030,22 @@ msgstr ""
 msgid "Helper path size with direction to node"
 msgstr ""
 
-#: ../src/live_effects/lpe-fillet-chamfer.cpp:228
+#: ../src/live_effects/lpe-fillet-chamfer.cpp:226
 #: ../src/ui/dialog/lpe-fillet-chamfer-properties.cpp:63
 msgid "Fillet"
 msgstr ""
 
-#: ../src/live_effects/lpe-fillet-chamfer.cpp:233
+#: ../src/live_effects/lpe-fillet-chamfer.cpp:231
 #: ../src/ui/dialog/lpe-fillet-chamfer-properties.cpp:65
 msgid "Inverse fillet"
 msgstr ""
 
-#: ../src/live_effects/lpe-fillet-chamfer.cpp:239
+#: ../src/live_effects/lpe-fillet-chamfer.cpp:237
 #: ../src/ui/dialog/lpe-fillet-chamfer-properties.cpp:67
 msgid "Chamfer"
 msgstr ""
 
-#: ../src/live_effects/lpe-fillet-chamfer.cpp:244
+#: ../src/live_effects/lpe-fillet-chamfer.cpp:242
 #: ../src/ui/dialog/lpe-fillet-chamfer-properties.cpp:69
 msgid "Inverse chamfer"
 msgstr ""
@@ -10079,53 +10104,53 @@ msgid ""
 msgstr ""
 
 #: ../src/live_effects/lpe-interpolate_points.cpp:25
-#: ../src/live_effects/lpe-powerstroke.cpp:123
+#: ../src/live_effects/lpe-powerstroke.cpp:126
 msgid "CubicBezierFit"
 msgstr ""
 
 #: ../src/live_effects/lpe-interpolate_points.cpp:26
-#: ../src/live_effects/lpe-powerstroke.cpp:124
+#: ../src/live_effects/lpe-powerstroke.cpp:127
 msgid "CubicBezierJohan"
 msgstr ""
 
 #: ../src/live_effects/lpe-interpolate_points.cpp:27
-#: ../src/live_effects/lpe-powerstroke.cpp:125
+#: ../src/live_effects/lpe-powerstroke.cpp:128
 msgid "SpiroInterpolator"
 msgstr ""
 
 #: ../src/live_effects/lpe-interpolate_points.cpp:28
-#: ../src/live_effects/lpe-powerstroke.cpp:126
+#: ../src/live_effects/lpe-powerstroke.cpp:129
 msgid "Centripetal Catmull-Rom"
 msgstr ""
 
 #: ../src/live_effects/lpe-interpolate_points.cpp:36
-#: ../src/live_effects/lpe-powerstroke.cpp:168
+#: ../src/live_effects/lpe-powerstroke.cpp:171
 msgid "Interpolator type:"
 msgstr ""
 
 #: ../src/live_effects/lpe-interpolate_points.cpp:37
-#: ../src/live_effects/lpe-powerstroke.cpp:168
+#: ../src/live_effects/lpe-powerstroke.cpp:171
 msgid ""
 "Determines which kind of interpolator will be used to interpolate between "
 "stroke width along the path"
 msgstr ""
 
 #: ../src/live_effects/lpe-jointype.cpp:29
-#: ../src/live_effects/lpe-powerstroke.cpp:155
+#: ../src/live_effects/lpe-powerstroke.cpp:158
 #: ../src/live_effects/lpe-taperstroke.cpp:57
 msgid "Beveled"
 msgstr ""
 
 #: ../src/live_effects/lpe-jointype.cpp:30
 #: ../src/live_effects/lpe-jointype.cpp:41
-#: ../src/live_effects/lpe-powerstroke.cpp:156
+#: ../src/live_effects/lpe-powerstroke.cpp:159
 #: ../src/live_effects/lpe-taperstroke.cpp:58
-#: ../src/widgets/star-toolbar.cpp:532
+#: ../src/widgets/star-toolbar.cpp:544
 msgid "Rounded"
 msgstr ""
 
 #: ../src/live_effects/lpe-jointype.cpp:31
-#: ../src/live_effects/lpe-powerstroke.cpp:159
+#: ../src/live_effects/lpe-powerstroke.cpp:162
 #: ../src/live_effects/lpe-taperstroke.cpp:59
 msgid "Miter"
 msgstr ""
@@ -10136,7 +10161,7 @@ msgstr ""
 
 #. {LINEJOIN_EXTRP_MITER,  N_("Extrapolated"),      "extrapolated"}, // disabled because doesn't work well
 #: ../src/live_effects/lpe-jointype.cpp:33
-#: ../src/live_effects/lpe-powerstroke.cpp:158
+#: ../src/live_effects/lpe-powerstroke.cpp:161
 msgid "Extrapolated arc"
 msgstr ""
 
@@ -10153,17 +10178,17 @@ msgid "Extrapolated arc Alt3"
 msgstr ""
 
 #: ../src/live_effects/lpe-jointype.cpp:40
-#: ../src/live_effects/lpe-powerstroke.cpp:138
+#: ../src/live_effects/lpe-powerstroke.cpp:141
 msgid "Butt"
 msgstr ""
 
 #: ../src/live_effects/lpe-jointype.cpp:42
-#: ../src/live_effects/lpe-powerstroke.cpp:139
+#: ../src/live_effects/lpe-powerstroke.cpp:142
 msgid "Square"
 msgstr ""
 
 #: ../src/live_effects/lpe-jointype.cpp:43
-#: ../src/live_effects/lpe-powerstroke.cpp:141
+#: ../src/live_effects/lpe-powerstroke.cpp:144
 msgid "Peak"
 msgstr ""
 
@@ -10183,20 +10208,20 @@ msgstr ""
 #. TRANSLATORS: The line join style specifies the shape to be used at the
 #. corners of paths. It can be "miter", "round" or "bevel".
 #: ../src/live_effects/lpe-jointype.cpp:54
-#: ../src/live_effects/lpe-powerstroke.cpp:171
+#: ../src/live_effects/lpe-powerstroke.cpp:175
 #: ../src/widgets/stroke-style.cpp:262
 msgid "Join:"
 msgstr ""
 
 #: ../src/live_effects/lpe-jointype.cpp:54
-#: ../src/live_effects/lpe-powerstroke.cpp:171
+#: ../src/live_effects/lpe-powerstroke.cpp:175
 msgid "Determines the shape of the path's corners"
 msgstr ""
 
 #. start_lean(_("Start path lean"), _("Start path lean"), "start_lean", &wr, this, 0.),
 #. end_lean(_("End path lean"), _("End path lean"), "end_lean", &wr, this, 0.),
 #: ../src/live_effects/lpe-jointype.cpp:57
-#: ../src/live_effects/lpe-powerstroke.cpp:172
+#: ../src/live_effects/lpe-powerstroke.cpp:176
 #: ../src/live_effects/lpe-taperstroke.cpp:72
 msgid "Miter limit:"
 msgstr ""
@@ -10262,12 +10287,12 @@ msgstr ""
 msgid "Crossings signs"
 msgstr ""
 
-#: ../src/live_effects/lpe-knot.cpp:622
+#: ../src/live_effects/lpe-knot.cpp:618
 msgid "Drag to select a crossing, click to flip it"
 msgstr ""
 
 #. / @todo Is this the right verb?
-#: ../src/live_effects/lpe-knot.cpp:660
+#: ../src/live_effects/lpe-knot.cpp:656
 msgid "Change knot crossing"
 msgstr ""
 
@@ -10282,395 +10307,390 @@ msgid "Mirror movements in vertical"
 msgstr ""
 
 #: ../src/live_effects/lpe-lattice2.cpp:38
+msgid "Use only perimeter"
+msgstr ""
+
+#: ../src/live_effects/lpe-lattice2.cpp:39
 msgid "Update while moving knots (maybe slow)"
 msgstr ""
 
-#: ../src/live_effects/lpe-lattice2.cpp:39
+#: ../src/live_effects/lpe-lattice2.cpp:40
 msgid "Control 0:"
 msgstr ""
 
-#: ../src/live_effects/lpe-lattice2.cpp:39
+#: ../src/live_effects/lpe-lattice2.cpp:40
 msgid "Control 0 - <b>Ctrl+Alt+Click</b>: reset, <b>Ctrl</b>: move along axes"
 msgstr ""
 
-#: ../src/live_effects/lpe-lattice2.cpp:40
+#: ../src/live_effects/lpe-lattice2.cpp:41
 msgid "Control 1:"
 msgstr ""
 
-#: ../src/live_effects/lpe-lattice2.cpp:40
+#: ../src/live_effects/lpe-lattice2.cpp:41
 msgid "Control 1 - <b>Ctrl+Alt+Click</b>: reset, <b>Ctrl</b>: move along axes"
 msgstr ""
 
-#: ../src/live_effects/lpe-lattice2.cpp:41
+#: ../src/live_effects/lpe-lattice2.cpp:42
 msgid "Control 2:"
 msgstr ""
 
-#: ../src/live_effects/lpe-lattice2.cpp:41
+#: ../src/live_effects/lpe-lattice2.cpp:42
 msgid "Control 2 - <b>Ctrl+Alt+Click</b>: reset, <b>Ctrl</b>: move along axes"
 msgstr ""
 
-#: ../src/live_effects/lpe-lattice2.cpp:42
+#: ../src/live_effects/lpe-lattice2.cpp:43
 msgid "Control 3:"
 msgstr ""
 
-#: ../src/live_effects/lpe-lattice2.cpp:42
+#: ../src/live_effects/lpe-lattice2.cpp:43
 msgid "Control 3 - <b>Ctrl+Alt+Click</b>: reset, <b>Ctrl</b>: move along axes"
 msgstr ""
 
-#: ../src/live_effects/lpe-lattice2.cpp:43
+#: ../src/live_effects/lpe-lattice2.cpp:44
 msgid "Control 4:"
 msgstr ""
 
-#: ../src/live_effects/lpe-lattice2.cpp:43
+#: ../src/live_effects/lpe-lattice2.cpp:44
 msgid "Control 4 - <b>Ctrl+Alt+Click</b>: reset, <b>Ctrl</b>: move along axes"
 msgstr ""
 
-#: ../src/live_effects/lpe-lattice2.cpp:44
+#: ../src/live_effects/lpe-lattice2.cpp:45
 msgid "Control 5:"
 msgstr ""
 
-#: ../src/live_effects/lpe-lattice2.cpp:44
+#: ../src/live_effects/lpe-lattice2.cpp:45
 msgid "Control 5 - <b>Ctrl+Alt+Click</b>: reset, <b>Ctrl</b>: move along axes"
 msgstr ""
 
-#: ../src/live_effects/lpe-lattice2.cpp:45
+#: ../src/live_effects/lpe-lattice2.cpp:46
 msgid "Control 6:"
 msgstr ""
 
-#: ../src/live_effects/lpe-lattice2.cpp:45
+#: ../src/live_effects/lpe-lattice2.cpp:46
 msgid "Control 6 - <b>Ctrl+Alt+Click</b>: reset, <b>Ctrl</b>: move along axes"
 msgstr ""
 
-#: ../src/live_effects/lpe-lattice2.cpp:46
+#: ../src/live_effects/lpe-lattice2.cpp:47
 msgid "Control 7:"
 msgstr ""
 
-#: ../src/live_effects/lpe-lattice2.cpp:46
+#: ../src/live_effects/lpe-lattice2.cpp:47
 msgid "Control 7 - <b>Ctrl+Alt+Click</b>: reset, <b>Ctrl</b>: move along axes"
 msgstr ""
 
-#: ../src/live_effects/lpe-lattice2.cpp:47
+#: ../src/live_effects/lpe-lattice2.cpp:48
 msgid "Control 8x9:"
 msgstr ""
 
-#: ../src/live_effects/lpe-lattice2.cpp:47
+#: ../src/live_effects/lpe-lattice2.cpp:48
 msgid ""
 "Control 8x9 - <b>Ctrl+Alt+Click</b>: reset, <b>Ctrl</b>: move along axes"
 msgstr ""
 
-#: ../src/live_effects/lpe-lattice2.cpp:48
+#: ../src/live_effects/lpe-lattice2.cpp:49
 msgid "Control 10x11:"
 msgstr ""
 
-#: ../src/live_effects/lpe-lattice2.cpp:48
+#: ../src/live_effects/lpe-lattice2.cpp:49
 msgid ""
 "Control 10x11 - <b>Ctrl+Alt+Click</b>: reset, <b>Ctrl</b>: move along axes"
 msgstr ""
 
-#: ../src/live_effects/lpe-lattice2.cpp:49
+#: ../src/live_effects/lpe-lattice2.cpp:50
 msgid "Control 12:"
 msgstr ""
 
-#: ../src/live_effects/lpe-lattice2.cpp:49
+#: ../src/live_effects/lpe-lattice2.cpp:50
 msgid "Control 12 - <b>Ctrl+Alt+Click</b>: reset, <b>Ctrl</b>: move along axes"
 msgstr ""
 
-#: ../src/live_effects/lpe-lattice2.cpp:50
+#: ../src/live_effects/lpe-lattice2.cpp:51
 msgid "Control 13:"
 msgstr ""
 
-#: ../src/live_effects/lpe-lattice2.cpp:50
+#: ../src/live_effects/lpe-lattice2.cpp:51
 msgid "Control 13 - <b>Ctrl+Alt+Click</b>: reset, <b>Ctrl</b>: move along axes"
 msgstr ""
 
-#: ../src/live_effects/lpe-lattice2.cpp:51
+#: ../src/live_effects/lpe-lattice2.cpp:52
 msgid "Control 14:"
 msgstr ""
 
-#: ../src/live_effects/lpe-lattice2.cpp:51
+#: ../src/live_effects/lpe-lattice2.cpp:52
 msgid "Control 14 - <b>Ctrl+Alt+Click</b>: reset, <b>Ctrl</b>: move along axes"
 msgstr ""
 
-#: ../src/live_effects/lpe-lattice2.cpp:52
+#: ../src/live_effects/lpe-lattice2.cpp:53
 msgid "Control 15:"
 msgstr ""
 
-#: ../src/live_effects/lpe-lattice2.cpp:52
+#: ../src/live_effects/lpe-lattice2.cpp:53
 msgid "Control 15 - <b>Ctrl+Alt+Click</b>: reset, <b>Ctrl</b>: move along axes"
 msgstr ""
 
-#: ../src/live_effects/lpe-lattice2.cpp:53
+#: ../src/live_effects/lpe-lattice2.cpp:54
 msgid "Control 16:"
 msgstr ""
 
-#: ../src/live_effects/lpe-lattice2.cpp:53
+#: ../src/live_effects/lpe-lattice2.cpp:54
 msgid "Control 16 - <b>Ctrl+Alt+Click</b>: reset, <b>Ctrl</b>: move along axes"
 msgstr ""
 
-#: ../src/live_effects/lpe-lattice2.cpp:54
+#: ../src/live_effects/lpe-lattice2.cpp:55
 msgid "Control 17:"
 msgstr ""
 
-#: ../src/live_effects/lpe-lattice2.cpp:54
+#: ../src/live_effects/lpe-lattice2.cpp:55
 msgid "Control 17 - <b>Ctrl+Alt+Click</b>: reset, <b>Ctrl</b>: move along axes"
 msgstr ""
 
-#: ../src/live_effects/lpe-lattice2.cpp:55
+#: ../src/live_effects/lpe-lattice2.cpp:56
 msgid "Control 18:"
 msgstr ""
 
-#: ../src/live_effects/lpe-lattice2.cpp:55
+#: ../src/live_effects/lpe-lattice2.cpp:56
 msgid "Control 18 - <b>Ctrl+Alt+Click</b>: reset, <b>Ctrl</b>: move along axes"
 msgstr ""
 
-#: ../src/live_effects/lpe-lattice2.cpp:56
+#: ../src/live_effects/lpe-lattice2.cpp:57
 msgid "Control 19:"
 msgstr ""
 
-#: ../src/live_effects/lpe-lattice2.cpp:56
+#: ../src/live_effects/lpe-lattice2.cpp:57
 msgid "Control 19 - <b>Ctrl+Alt+Click</b>: reset, <b>Ctrl</b>: move along axes"
 msgstr ""
 
-#: ../src/live_effects/lpe-lattice2.cpp:57
+#: ../src/live_effects/lpe-lattice2.cpp:58
 msgid "Control 20x21:"
 msgstr ""
 
-#: ../src/live_effects/lpe-lattice2.cpp:57
+#: ../src/live_effects/lpe-lattice2.cpp:58
 msgid ""
 "Control 20x21 - <b>Ctrl+Alt+Click</b>: reset, <b>Ctrl</b>: move along axes"
 msgstr ""
 
-#: ../src/live_effects/lpe-lattice2.cpp:58
+#: ../src/live_effects/lpe-lattice2.cpp:59
 msgid "Control 22x23:"
 msgstr ""
 
-#: ../src/live_effects/lpe-lattice2.cpp:58
+#: ../src/live_effects/lpe-lattice2.cpp:59
 msgid ""
 "Control 22x23 - <b>Ctrl+Alt+Click</b>: reset, <b>Ctrl</b>: move along axes"
 msgstr ""
 
-#: ../src/live_effects/lpe-lattice2.cpp:59
+#: ../src/live_effects/lpe-lattice2.cpp:60
 msgid "Control 24x26:"
 msgstr ""
 
-#: ../src/live_effects/lpe-lattice2.cpp:59
+#: ../src/live_effects/lpe-lattice2.cpp:60
 msgid ""
 "Control 24x26 - <b>Ctrl+Alt+Click</b>: reset, <b>Ctrl</b>: move along axes"
 msgstr ""
 
-#: ../src/live_effects/lpe-lattice2.cpp:60
+#: ../src/live_effects/lpe-lattice2.cpp:61
 msgid "Control 25x27:"
 msgstr ""
 
-#: ../src/live_effects/lpe-lattice2.cpp:60
+#: ../src/live_effects/lpe-lattice2.cpp:61
 msgid ""
 "Control 25x27 - <b>Ctrl+Alt+Click</b>: reset, <b>Ctrl</b>: move along axes"
 msgstr ""
 
-#: ../src/live_effects/lpe-lattice2.cpp:61
+#: ../src/live_effects/lpe-lattice2.cpp:62
 msgid "Control 28x30:"
 msgstr ""
 
-#: ../src/live_effects/lpe-lattice2.cpp:61
+#: ../src/live_effects/lpe-lattice2.cpp:62
 msgid ""
 "Control 28x30 - <b>Ctrl+Alt+Click</b>: reset, <b>Ctrl</b>: move along axes"
 msgstr ""
 
-#: ../src/live_effects/lpe-lattice2.cpp:62
+#: ../src/live_effects/lpe-lattice2.cpp:63
 msgid "Control 29x31:"
 msgstr ""
 
-#: ../src/live_effects/lpe-lattice2.cpp:62
+#: ../src/live_effects/lpe-lattice2.cpp:63
 msgid ""
 "Control 29x31 - <b>Ctrl+Alt+Click</b>: reset, <b>Ctrl</b>: move along axes"
 msgstr ""
 
-#: ../src/live_effects/lpe-lattice2.cpp:63
+#: ../src/live_effects/lpe-lattice2.cpp:64
 msgid "Control 32x33x34x35:"
 msgstr ""
 
-#: ../src/live_effects/lpe-lattice2.cpp:63
+#: ../src/live_effects/lpe-lattice2.cpp:64
 msgid ""
 "Control 32x33x34x35 - <b>Ctrl+Alt+Click</b>: reset, <b>Ctrl</b>: move along "
 "axes"
 msgstr ""
 
-#: ../src/live_effects/lpe-lattice2.cpp:228
+#: ../src/live_effects/lpe-lattice2.cpp:230
 msgid "Reset grid"
 msgstr ""
 
-#: ../src/live_effects/lpe-lattice2.cpp:260
-#: ../src/live_effects/lpe-lattice2.cpp:275
+#: ../src/live_effects/lpe-lattice2.cpp:266
+#: ../src/live_effects/lpe-lattice2.cpp:281
 msgid "Show Points"
 msgstr ""
 
-#: ../src/live_effects/lpe-lattice2.cpp:273
+#: ../src/live_effects/lpe-lattice2.cpp:279
 msgid "Hide Points"
 msgstr ""
 
-#: ../src/live_effects/lpe-measure-line.cpp:44
-#: ../src/widgets/text-toolbar.cpp:1862
+#: ../src/live_effects/lpe-measure-segments.cpp:49
+#: ../src/widgets/text-toolbar.cpp:2164
 msgid "Horizontal"
 msgstr ""
 
-#: ../src/live_effects/lpe-measure-line.cpp:45
+#: ../src/live_effects/lpe-measure-segments.cpp:50
 msgid "Vertical"
 msgstr ""
 
-#: ../src/live_effects/lpe-measure-line.cpp:53
-msgid "Font"
-msgstr ""
-
-#: ../src/live_effects/lpe-measure-line.cpp:53
-msgid "Font Selector"
-msgstr ""
-
-#: ../src/live_effects/lpe-measure-line.cpp:54
-#: ../src/widgets/gimp/ruler.cpp:184
+#: ../src/live_effects/lpe-measure-segments.cpp:58
+#: ../src/widgets/gimp/ruler.cpp:187
 #: ../share/extensions/gcodetools_graffiti.inx.h:9
 #: ../share/extensions/gcodetools_orientation_points.inx.h:2
 msgid "Orientation"
 msgstr ""
 
-#: ../src/live_effects/lpe-measure-line.cpp:54
+#: ../src/live_effects/lpe-measure-segments.cpp:58
 msgid "Orientation method"
 msgstr ""
 
-#: ../src/live_effects/lpe-measure-line.cpp:55
-msgid "Curve on origin"
+#: ../src/live_effects/lpe-measure-segments.cpp:59
+msgid "Color and opacity"
 msgstr ""
 
-#: ../src/live_effects/lpe-measure-line.cpp:55
-msgid "Curve on origin, set 0 to start/end"
+#: ../src/live_effects/lpe-measure-segments.cpp:59
+msgid "Set color and opacity of the measurements"
 msgstr ""
 
-#: ../src/live_effects/lpe-measure-line.cpp:57
-#: ../src/widgets/gimp/ruler.cpp:222
+#: ../src/live_effects/lpe-measure-segments.cpp:60
+msgid "Font"
+msgstr ""
+
+#: ../src/live_effects/lpe-measure-segments.cpp:60
+msgid "Font Selector"
+msgstr ""
+
+#: ../src/live_effects/lpe-measure-segments.cpp:62
+msgid "Fix overlaps °"
+msgstr ""
+
+#: ../src/live_effects/lpe-measure-segments.cpp:62
+msgid "Min angle where overlaps are fixed, 180° no fix"
+msgstr ""
+
+#: ../src/live_effects/lpe-measure-segments.cpp:63
+#: ../src/widgets/gimp/ruler.cpp:225
 msgid "Position"
 msgstr ""
 
-#: ../src/live_effects/lpe-measure-line.cpp:58
+#: ../src/live_effects/lpe-measure-segments.cpp:64
 msgid "Text top/bottom"
 msgstr ""
 
-#: ../src/live_effects/lpe-measure-line.cpp:59
-msgid "Text right/left"
-msgstr ""
-
-#: ../src/live_effects/lpe-measure-line.cpp:60
+#: ../src/live_effects/lpe-measure-segments.cpp:65
 msgid "Helpline distance"
 msgstr ""
 
-#: ../src/live_effects/lpe-measure-line.cpp:61
+#: ../src/live_effects/lpe-measure-segments.cpp:66
 msgid "Helpline overlap"
 msgstr ""
 
-#: ../src/live_effects/lpe-measure-line.cpp:62
-#: ../src/selection-chemistry.cpp:2262 ../src/seltrans.cpp:475
-#: ../src/ui/dialog/transformation.cpp:758 ../src/ui/widget/page-sizer.cpp:406
-#: ../share/extensions/interp_att_g.inx.h:14
+#: ../src/live_effects/lpe-measure-segments.cpp:67
+msgid "Line width. DIM line group standard are 0.25 or 0.35"
+msgstr ""
+
+#: ../src/live_effects/lpe-measure-segments.cpp:68
+#: ../src/selection-chemistry.cpp:2256 ../src/seltrans.cpp:475
+#: ../src/ui/dialog/transformation.cpp:758 ../src/ui/widget/page-sizer.cpp:420
+#: ../share/extensions/interp_att_g.inx.h:16
 msgid "Scale"
 msgstr ""
 
-#: ../src/live_effects/lpe-measure-line.cpp:62
+#: ../src/live_effects/lpe-measure-segments.cpp:68
 msgid "Scaling factor"
 msgstr ""
 
-#: ../src/live_effects/lpe-measure-line.cpp:63
+#: ../src/live_effects/lpe-measure-segments.cpp:70
 msgid "Format"
 msgstr ""
 
-#: ../src/live_effects/lpe-measure-line.cpp:63
+#: ../src/live_effects/lpe-measure-segments.cpp:70
 msgid "Format the number ex:{measure} {unit}, return to save"
 msgstr ""
 
-#: ../src/live_effects/lpe-measure-line.cpp:65
+#: ../src/live_effects/lpe-measure-segments.cpp:71
+msgid "Blacklist"
+msgstr ""
+
+#: ../src/live_effects/lpe-measure-segments.cpp:71
+msgid ""
+"Optional segment index that exclude measure, comma limited, you can add more "
+"LPE like this to fill the holes"
+msgstr ""
+
+#: ../src/live_effects/lpe-measure-segments.cpp:72
+msgid "Inverse blacklist"
+msgstr ""
+
+#: ../src/live_effects/lpe-measure-segments.cpp:72
+msgid "Blacklist as whitelist"
+msgstr ""
+
+#: ../src/live_effects/lpe-measure-segments.cpp:73
 msgid "Arrows outside"
 msgstr ""
 
-#: ../src/live_effects/lpe-measure-line.cpp:66
+#: ../src/live_effects/lpe-measure-segments.cpp:74
 msgid "Flip side"
 msgstr ""
 
-#: ../src/live_effects/lpe-measure-line.cpp:67
+#: ../src/live_effects/lpe-measure-segments.cpp:75
 msgid "Scale sensitive"
 msgstr ""
 
-#: ../src/live_effects/lpe-measure-line.cpp:67
+#: ../src/live_effects/lpe-measure-segments.cpp:75
 msgid "Costrained scale sensitive to transformed containers"
 msgstr ""
 
-#: ../src/live_effects/lpe-measure-line.cpp:68
+#: ../src/live_effects/lpe-measure-segments.cpp:76
 msgid "Local Number Format"
 msgstr ""
 
-#: ../src/live_effects/lpe-measure-line.cpp:68
+#: ../src/live_effects/lpe-measure-segments.cpp:76
 msgid "Local number format"
 msgstr ""
 
-#: ../src/live_effects/lpe-measure-line.cpp:69
-msgid "Line Group 0.5"
+#: ../src/live_effects/lpe-measure-segments.cpp:77
+msgid "Rotate Annotation"
 msgstr ""
 
-#: ../src/live_effects/lpe-measure-line.cpp:69
-msgid "Line Group 0.5, from 0.7"
-msgstr ""
-
-#: ../src/live_effects/lpe-measure-line.cpp:70
-msgid "Rotate Anotation"
-msgstr ""
-
-#: ../src/live_effects/lpe-measure-line.cpp:71
+#: ../src/live_effects/lpe-measure-segments.cpp:78
 msgid "Hide if label over"
 msgstr ""
 
-#: ../src/live_effects/lpe-measure-line.cpp:71
+#: ../src/live_effects/lpe-measure-segments.cpp:78
 msgid "Hide DIN line if label over"
 msgstr ""
 
-#: ../src/live_effects/lpe-measure-line.cpp:72
-msgid "CSS DIN line"
+#: ../src/live_effects/lpe-measure-segments.cpp:79
+msgid "Info Box"
 msgstr ""
 
-#: ../src/live_effects/lpe-measure-line.cpp:72
-msgid "Override CSS to DIN line, return to save, empty to reset to DIM"
+#: ../src/live_effects/lpe-measure-segments.cpp:79
+msgid "Important messages"
 msgstr ""
 
-#: ../src/live_effects/lpe-measure-line.cpp:73
-msgid "CSS helpers"
+#: ../src/live_effects/lpe-measure-segments.cpp:79
+msgid ""
+"Use <b>\"Style Dialog\"</b> to more styling. Each measure element has extra "
+"selectors. Use !important to override defaults..."
 msgstr ""
 
-#: ../src/live_effects/lpe-measure-line.cpp:73
-msgid "Override CSS to helper lines, return to save, empty to reset to DIM"
-msgstr ""
-
-#: ../src/live_effects/lpe-measure-line.cpp:74
-msgid "CSS anotation"
-msgstr ""
-
-#: ../src/live_effects/lpe-measure-line.cpp:74
-msgid "Override CSS to anotation text, return to save, empty to reset to DIM"
-msgstr ""
-
-#: ../src/live_effects/lpe-measure-line.cpp:75
-msgid "CSS arrows"
-msgstr ""
-
-#: ../src/live_effects/lpe-measure-line.cpp:75
-msgid "Override CSS to arrows, return to save, empty to reset DIM"
-msgstr ""
-
-#: ../src/live_effects/lpe-measure-line.cpp:332
+#: ../src/live_effects/lpe-measure-segments.cpp:324
 msgid "Non Uniform Scale"
-msgstr ""
-
-#: ../src/live_effects/lpe-measure-line.cpp:726
-#: ../src/live_effects/lpe-measure-line.cpp:741
-msgid "Show DIM CSS style override"
-msgstr ""
-
-#: ../src/live_effects/lpe-measure-line.cpp:739
-msgid "Hide DIM CSS style override"
 msgstr ""
 
 #: ../src/live_effects/lpe-mirror_symmetry.cpp:42
@@ -10693,8 +10713,10 @@ msgstr ""
 msgid "Y from middle knot"
 msgstr ""
 
+#. Name
 #: ../src/live_effects/lpe-mirror_symmetry.cpp:53
-#: ../src/widgets/spray-toolbar.cpp:388 ../src/widgets/tweak-toolbar.cpp:253
+#: ../src/widgets/eraser-toolbar.cpp:170 ../src/widgets/spray-toolbar.cpp:389
+#: ../src/widgets/tweak-toolbar.cpp:253
 msgid "Mode"
 msgstr ""
 
@@ -10750,96 +10772,96 @@ msgstr ""
 msgid "Adjust center of mirroring"
 msgstr ""
 
-#: ../src/live_effects/lpe-patternalongpath.cpp:57
+#: ../src/live_effects/lpe-patternalongpath.cpp:61
 #: ../share/extensions/pathalongpath.inx.h:10
 msgid "Single"
 msgstr ""
 
-#: ../src/live_effects/lpe-patternalongpath.cpp:58
+#: ../src/live_effects/lpe-patternalongpath.cpp:62
 #: ../share/extensions/pathalongpath.inx.h:11
 msgid "Single, stretched"
 msgstr ""
 
-#: ../src/live_effects/lpe-patternalongpath.cpp:59
+#: ../src/live_effects/lpe-patternalongpath.cpp:63
 #: ../share/extensions/pathalongpath.inx.h:12
 msgid "Repeated"
 msgstr ""
 
-#: ../src/live_effects/lpe-patternalongpath.cpp:60
+#: ../src/live_effects/lpe-patternalongpath.cpp:64
 #: ../share/extensions/pathalongpath.inx.h:13
 msgid "Repeated, stretched"
 msgstr ""
 
-#: ../src/live_effects/lpe-patternalongpath.cpp:66
+#: ../src/live_effects/lpe-patternalongpath.cpp:70
 msgid "Pattern source:"
 msgstr ""
 
-#: ../src/live_effects/lpe-patternalongpath.cpp:66
+#: ../src/live_effects/lpe-patternalongpath.cpp:70
 msgid "Path to put along the skeleton path"
 msgstr ""
 
-#: ../src/live_effects/lpe-patternalongpath.cpp:68
+#: ../src/live_effects/lpe-patternalongpath.cpp:72
 msgid "Width of the pattern"
 msgstr ""
 
-#: ../src/live_effects/lpe-patternalongpath.cpp:69
+#: ../src/live_effects/lpe-patternalongpath.cpp:73
 msgid "Pattern copies:"
 msgstr ""
 
-#: ../src/live_effects/lpe-patternalongpath.cpp:69
+#: ../src/live_effects/lpe-patternalongpath.cpp:73
 msgid "How many pattern copies to place along the skeleton path"
 msgstr ""
 
-#: ../src/live_effects/lpe-patternalongpath.cpp:71
+#: ../src/live_effects/lpe-patternalongpath.cpp:75
 msgid "Wid_th in units of length"
 msgstr ""
 
-#: ../src/live_effects/lpe-patternalongpath.cpp:72
+#: ../src/live_effects/lpe-patternalongpath.cpp:76
 msgid "Scale the width of the pattern in units of its length"
 msgstr ""
 
-#: ../src/live_effects/lpe-patternalongpath.cpp:74
+#: ../src/live_effects/lpe-patternalongpath.cpp:78
 msgid "Spa_cing:"
 msgstr ""
 
-#: ../src/live_effects/lpe-patternalongpath.cpp:76
+#: ../src/live_effects/lpe-patternalongpath.cpp:80
 #, no-c-format
 msgid ""
 "Space between copies of the pattern. Negative values allowed, but are "
 "limited to -90% of pattern width."
 msgstr ""
 
-#: ../src/live_effects/lpe-patternalongpath.cpp:78
+#: ../src/live_effects/lpe-patternalongpath.cpp:82
 msgid "No_rmal offset:"
 msgstr ""
 
-#: ../src/live_effects/lpe-patternalongpath.cpp:79
+#: ../src/live_effects/lpe-patternalongpath.cpp:83
 msgid "Tan_gential offset:"
 msgstr ""
 
-#: ../src/live_effects/lpe-patternalongpath.cpp:80
+#: ../src/live_effects/lpe-patternalongpath.cpp:84
 msgid "Offsets in _unit of pattern size"
 msgstr ""
 
-#: ../src/live_effects/lpe-patternalongpath.cpp:81
+#: ../src/live_effects/lpe-patternalongpath.cpp:85
 msgid ""
 "Spacing, tangential and normal offset are expressed as a ratio of width/"
 "height"
 msgstr ""
 
-#: ../src/live_effects/lpe-patternalongpath.cpp:83
+#: ../src/live_effects/lpe-patternalongpath.cpp:87
 msgid "Pattern is _vertical"
 msgstr ""
 
-#: ../src/live_effects/lpe-patternalongpath.cpp:83
+#: ../src/live_effects/lpe-patternalongpath.cpp:87
 msgid "Rotate pattern 90 deg before applying"
 msgstr ""
 
-#: ../src/live_effects/lpe-patternalongpath.cpp:85
+#: ../src/live_effects/lpe-patternalongpath.cpp:90
 msgid "_Fuse nearby ends:"
 msgstr ""
 
-#: ../src/live_effects/lpe-patternalongpath.cpp:85
+#: ../src/live_effects/lpe-patternalongpath.cpp:90
 msgid "Fuse ends closer than this number. 0 means don't fuse."
 msgstr ""
 
@@ -10906,66 +10928,115 @@ msgstr ""
 msgid "_Clear"
 msgstr ""
 
-#: ../src/live_effects/lpe-powerstroke.cpp:121
+#: ../src/live_effects/lpe-powerstroke.cpp:124
 msgid "CubicBezierSmooth"
 msgstr ""
 
-#: ../src/live_effects/lpe-powerstroke.cpp:140
+#: ../src/live_effects/lpe-powerstroke.cpp:143
 #: ../share/extensions/gcodetools_prepare_path_for_plasma.inx.h:13
 msgid "Round"
 msgstr ""
 
-#: ../src/live_effects/lpe-powerstroke.cpp:142
+#: ../src/live_effects/lpe-powerstroke.cpp:145
 msgid "Zero width"
 msgstr ""
 
-#: ../src/live_effects/lpe-powerstroke.cpp:160
-#: ../src/widgets/pencil-toolbar.cpp:109
+#: ../src/live_effects/lpe-powerstroke.cpp:163
+#: ../src/widgets/pencil-toolbar.cpp:131
 msgid "Spiro"
 msgstr ""
 
-#: ../src/live_effects/lpe-powerstroke.cpp:166
+#: ../src/live_effects/lpe-powerstroke.cpp:169
 msgid "Offset points"
 msgstr ""
 
-#: ../src/live_effects/lpe-powerstroke.cpp:167
+#: ../src/live_effects/lpe-powerstroke.cpp:170
 msgid "Sort points"
 msgstr ""
 
-#: ../src/live_effects/lpe-powerstroke.cpp:167
+#: ../src/live_effects/lpe-powerstroke.cpp:170
 msgid "Sort offset points according to their time value along the curve"
 msgstr ""
 
-#: ../src/live_effects/lpe-powerstroke.cpp:169
+#: ../src/live_effects/lpe-powerstroke.cpp:172
 #: ../share/extensions/fractalize.inx.h:3
 msgid "Smoothness:"
 msgstr ""
 
-#: ../src/live_effects/lpe-powerstroke.cpp:169
+#: ../src/live_effects/lpe-powerstroke.cpp:172
 msgid ""
 "Sets the smoothness for the CubicBezierJohan interpolator; 0 = linear "
 "interpolation, 1 = smooth"
 msgstr ""
 
-#: ../src/live_effects/lpe-powerstroke.cpp:170
+#: ../src/live_effects/lpe-powerstroke.cpp:173
+msgid "Width scale:"
+msgstr ""
+
+#: ../src/live_effects/lpe-powerstroke.cpp:173
+msgid "Width scale all points"
+msgstr ""
+
+#: ../src/live_effects/lpe-powerstroke.cpp:174
 msgid "Start cap:"
 msgstr ""
 
-#: ../src/live_effects/lpe-powerstroke.cpp:170
+#: ../src/live_effects/lpe-powerstroke.cpp:174
 msgid "Determines the shape of the path's start"
 msgstr ""
 
-#: ../src/live_effects/lpe-powerstroke.cpp:172
+#: ../src/live_effects/lpe-powerstroke.cpp:176
 #: ../src/widgets/stroke-style.cpp:302
 msgid "Maximum length of the miter (in units of stroke width)"
 msgstr ""
 
-#: ../src/live_effects/lpe-powerstroke.cpp:173
+#: ../src/live_effects/lpe-powerstroke.cpp:177
 msgid "End cap:"
 msgstr ""
 
-#: ../src/live_effects/lpe-powerstroke.cpp:173
+#: ../src/live_effects/lpe-powerstroke.cpp:177
 msgid "Determines the shape of the path's end"
+msgstr ""
+
+#: ../src/live_effects/lpe-powerclip.cpp:27
+msgid "Hide clip"
+msgstr ""
+
+#: ../src/live_effects/lpe-powerclip.cpp:30
+msgid "Inverse clip"
+msgstr ""
+
+#: ../src/live_effects/lpe-powerclip.cpp:31
+msgid "Flatten clip"
+msgstr ""
+
+#: ../src/live_effects/lpe-powerclip.cpp:31
+msgid "Flatten clip, see fill rule once convert to paths"
+msgstr ""
+
+#: ../src/live_effects/lpe-powerclip.cpp:278
+msgid "Convert clips to paths, undoable"
+msgstr ""
+
+#: ../src/live_effects/lpe-powermask.cpp:31
+msgid "Invert mask"
+msgstr ""
+
+#. wrap(_("Wrap mask data"), _("Wrap mask data allowing previous filters"), "wrap", &wr, this, false),
+#: ../src/live_effects/lpe-powermask.cpp:33
+msgid "Hide mask"
+msgstr ""
+
+#: ../src/live_effects/lpe-powermask.cpp:34
+msgid "Add background to mask"
+msgstr ""
+
+#: ../src/live_effects/lpe-powermask.cpp:35
+msgid "Background color and opacity"
+msgstr ""
+
+#: ../src/live_effects/lpe-powermask.cpp:35
+msgid "Set color and opacity of the background"
 msgstr ""
 
 #: ../src/live_effects/lpe-rough-hatches.cpp:218
@@ -11259,13 +11330,13 @@ msgstr ""
 
 #: ../src/live_effects/lpe-ruler.cpp:30
 #: ../src/live_effects/lpe-transform_2pts.cpp:35
-#: ../src/ui/tools/measure-tool.cpp:749 ../src/widgets/arc-toolbar.cpp:334
+#: ../src/ui/tools/measure-tool.cpp:755 ../src/widgets/arc-toolbar.cpp:497
 msgid "Start"
 msgstr ""
 
 #: ../src/live_effects/lpe-ruler.cpp:31
 #: ../src/live_effects/lpe-transform_2pts.cpp:36
-#: ../src/ui/tools/measure-tool.cpp:750 ../src/widgets/arc-toolbar.cpp:347
+#: ../src/ui/tools/measure-tool.cpp:756 ../src/widgets/arc-toolbar.cpp:510
 msgid "End"
 msgstr ""
 
@@ -11278,7 +11349,7 @@ msgid "Distance between successive ruler marks"
 msgstr ""
 
 #: ../src/live_effects/lpe-ruler.cpp:39 ../share/extensions/foldablebox.inx.h:7
-#: ../share/extensions/interp_att_g.inx.h:9
+#: ../share/extensions/interp_att_g.inx.h:11
 #: ../share/extensions/layout_nup.inx.h:3
 #: ../share/extensions/printing_marks.inx.h:11
 msgid "Unit:"
@@ -11340,23 +11411,27 @@ msgstr ""
 msgid "Choose whether to draw marks at the beginning and end of the path"
 msgstr ""
 
-#: ../src/live_effects/lpe-show_handles.cpp:26
+#: ../src/live_effects/lpe-show_handles.cpp:27
 msgid "Show nodes"
 msgstr ""
 
-#: ../src/live_effects/lpe-show_handles.cpp:28
+#: ../src/live_effects/lpe-show_handles.cpp:29
 msgid "Show path"
 msgstr ""
 
-#: ../src/live_effects/lpe-show_handles.cpp:29
+#: ../src/live_effects/lpe-show_handles.cpp:30
 msgid "Show center of node"
 msgstr ""
 
-#: ../src/live_effects/lpe-show_handles.cpp:30
+#: ../src/live_effects/lpe-show_handles.cpp:31
+msgid "Show original"
+msgstr ""
+
+#: ../src/live_effects/lpe-show_handles.cpp:32
 msgid "Scale nodes and handles"
 msgstr ""
 
-#: ../src/live_effects/lpe-show_handles.cpp:53
+#: ../src/live_effects/lpe-show_handles.cpp:56
 msgid ""
 "The \"show handles\" path effect will remove any custom style on the object "
 "you are applying it to. If this is not what you want, click Cancel."
@@ -11483,7 +11558,7 @@ msgid "How many construction lines (tangents) to draw"
 msgstr ""
 
 #: ../src/live_effects/lpe-sketch.cpp:51
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2784
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2801
 #: ../share/extensions/render_alphabetsoup.inx.h:3
 msgid "Scale:"
 msgstr ""
@@ -11656,11 +11731,11 @@ msgid "Change index of knot"
 msgstr ""
 
 #: ../src/live_effects/lpe-transform_2pts.cpp:356
-#: ../src/ui/dialog/inkscape-preferences.cpp:1591
+#: ../src/ui/dialog/inkscape-preferences.cpp:1652
 #: ../src/ui/dialog/pixelartdialog.cpp:289
-#: ../src/ui/dialog/svg-fonts-dialog.cpp:793
+#: ../src/ui/dialog/svg-fonts-dialog.cpp:805
 #: ../src/ui/dialog/tracedialog.cpp:811
-#: ../src/ui/widget/preferences-widget.cpp:655
+#: ../src/ui/widget/preferences-widget.cpp:657
 msgid "Reset"
 msgstr ""
 
@@ -11718,117 +11793,164 @@ msgstr ""
 msgid "Disable effect if the output is too complex"
 msgstr ""
 
-#: ../src/live_effects/parameter/bool.cpp:79
+#: ../src/live_effects/parameter/bool.cpp:86
 msgid "Change bool parameter"
+msgstr ""
+
+#: ../src/live_effects/parameter/colorpicker.cpp:125
+msgid "Change color button parameter"
 msgstr ""
 
 #: ../src/live_effects/parameter/enum.h:49
 msgid "Change enumeration parameter"
 msgstr ""
 
-#: ../src/live_effects/parameter/fontbutton.cpp:70
+#: ../src/live_effects/parameter/fontbutton.cpp:78
 msgid "Change font button parameter"
 msgstr ""
 
-#: ../src/live_effects/parameter/item.cpp:123
+#: ../src/live_effects/parameter/item.cpp:133
 msgid "Link to item on clipboard"
 msgstr ""
 
-#: ../src/live_effects/parameter/item.cpp:236
+#: ../src/live_effects/parameter/item.cpp:255
 msgid "Link item parameter to path"
 msgstr ""
 
-#: ../src/live_effects/parameter/originalitem.cpp:66
-msgid "Link to item"
+#: ../src/live_effects/parameter/originalitemarray.cpp:75
+msgid "Active"
 msgstr ""
 
-#: ../src/live_effects/parameter/originalitem.cpp:79
-#: ../src/live_effects/parameter/originalpath.cpp:80
-msgid "Select original"
-msgstr ""
-
-#: ../src/live_effects/parameter/originalpath.cpp:67
-#: ../src/live_effects/parameter/originalpatharray.cpp:155
-msgid "Link to path"
-msgstr ""
-
-#: ../src/live_effects/parameter/originalpatharray.cpp:81
-#: ../src/ui/dialog/inkscape-preferences.cpp:1546
-#: ../src/ui/widget/page-sizer.cpp:268 ../src/widgets/gradient-selector.cpp:140
+#: ../src/live_effects/parameter/originalitemarray.cpp:82
+#: ../src/live_effects/parameter/originalpatharray.cpp:103
+#: ../src/ui/dialog/inkscape-preferences.cpp:1607
+#: ../src/ui/widget/page-sizer.cpp:269 ../src/widgets/gradient-selector.cpp:140
 #: ../src/widgets/sp-xmlview-attr-list.cpp:45
 msgid "Name"
 msgstr ""
 
-#: ../src/live_effects/parameter/originalpatharray.cpp:89
-#: ../src/widgets/gradient-toolbar.cpp:1206
-msgid "Reverse"
+#: ../src/live_effects/parameter/originalitemarray.cpp:122
+msgid "Link item parameter to item"
 msgstr ""
 
-#: ../src/live_effects/parameter/originalpatharray.cpp:129
-#: ../src/live_effects/parameter/originalpatharray.cpp:318
-#: ../src/live_effects/parameter/path.cpp:539
-msgid "Link path parameter to path"
+#: ../src/live_effects/parameter/originalitemarray.cpp:148
+#: ../src/live_effects/parameter/originalitem.cpp:66
+msgid "Link to item"
 msgstr ""
 
-#: ../src/live_effects/parameter/originalpatharray.cpp:168
-msgid "Remove Path"
+#: ../src/live_effects/parameter/originalitemarray.cpp:161
+msgid "Remove Item"
 msgstr ""
 
-#: ../src/live_effects/parameter/originalpatharray.cpp:181
-#: ../src/ui/dialog/objects.cpp:1880
+#: ../src/live_effects/parameter/originalitemarray.cpp:174
+#: ../src/live_effects/parameter/originalpatharray.cpp:213
+#: ../src/ui/dialog/objects.cpp:1842
 msgid "Move Down"
 msgstr ""
 
-#: ../src/live_effects/parameter/originalpatharray.cpp:194
-#: ../src/ui/dialog/objects.cpp:1888
+#: ../src/live_effects/parameter/originalitemarray.cpp:187
+#: ../src/live_effects/parameter/originalpatharray.cpp:226
+#: ../src/ui/dialog/objects.cpp:1850
 msgid "Move Up"
 msgstr ""
 
-#: ../src/live_effects/parameter/originalpatharray.cpp:234
+#: ../src/live_effects/parameter/originalitemarray.cpp:227
+msgid "Move item up"
+msgstr ""
+
+#: ../src/live_effects/parameter/originalitemarray.cpp:257
+msgid "Move item down"
+msgstr ""
+
+#: ../src/live_effects/parameter/originalitemarray.cpp:275
+msgid "Remove item"
+msgstr ""
+
+#: ../src/live_effects/parameter/originalitemarray.cpp:315
+msgid "Link itemarray parameter to item"
+msgstr ""
+
+#: ../src/live_effects/parameter/originalitem.cpp:79
+#: ../src/live_effects/parameter/originalpath.cpp:81
+msgid "Select original"
+msgstr ""
+
+#: ../src/live_effects/parameter/originalpath.cpp:68
+#: ../src/live_effects/parameter/originalpatharray.cpp:187
+msgid "Link to path"
+msgstr ""
+
+#: ../src/live_effects/parameter/originalpatharray.cpp:88
+#: ../src/widgets/gradient-toolbar.cpp:1095
+msgid "Reverse"
+msgstr ""
+
+#: ../src/live_effects/parameter/originalpatharray.cpp:96
+msgid "Visible"
+msgstr ""
+
+#: ../src/live_effects/parameter/originalpatharray.cpp:146
+#: ../src/live_effects/parameter/path.cpp:556
+msgid "Link path parameter to path"
+msgstr ""
+
+#: ../src/live_effects/parameter/originalpatharray.cpp:161
+msgid "Toggle path parameter to path"
+msgstr ""
+
+#: ../src/live_effects/parameter/originalpatharray.cpp:200
+msgid "Remove Path"
+msgstr ""
+
+#: ../src/live_effects/parameter/originalpatharray.cpp:266
 msgid "Move path up"
 msgstr ""
 
-#: ../src/live_effects/parameter/originalpatharray.cpp:264
+#: ../src/live_effects/parameter/originalpatharray.cpp:296
 msgid "Move path down"
 msgstr ""
 
-#: ../src/live_effects/parameter/originalpatharray.cpp:282
+#: ../src/live_effects/parameter/originalpatharray.cpp:314
 msgid "Remove path"
 msgstr ""
 
-#: ../src/live_effects/parameter/path.cpp:201
+#: ../src/live_effects/parameter/originalpatharray.cpp:353
+msgid "Link patharray parameter to path"
+msgstr ""
+
+#: ../src/live_effects/parameter/path.cpp:211
 msgid "Edit on-canvas"
 msgstr ""
 
-#: ../src/live_effects/parameter/path.cpp:214
+#: ../src/live_effects/parameter/path.cpp:224
 msgid "Copy path"
 msgstr ""
 
-#: ../src/live_effects/parameter/path.cpp:227
+#: ../src/live_effects/parameter/path.cpp:237
 msgid "Paste path"
 msgstr ""
 
-#: ../src/live_effects/parameter/path.cpp:239
+#: ../src/live_effects/parameter/path.cpp:249
 msgid "Link to path on clipboard"
 msgstr ""
 
-#: ../src/live_effects/parameter/path.cpp:507
+#: ../src/live_effects/parameter/path.cpp:524
 msgid "Paste path parameter"
 msgstr ""
 
-#: ../src/live_effects/parameter/point.cpp:139
+#: ../src/live_effects/parameter/point.cpp:165
 msgid "Change point parameter"
 msgstr ""
 
-#: ../src/live_effects/parameter/powerstrokepointarray.cpp:239
-#: ../src/live_effects/parameter/powerstrokepointarray.cpp:256
+#: ../src/live_effects/parameter/powerstrokepointarray.cpp:267
+#: ../src/live_effects/parameter/powerstrokepointarray.cpp:284
 msgid ""
 "<b>Stroke width control point</b>: drag to alter the stroke width. <b>Ctrl"
 "+click</b> adds a control point, <b>Ctrl+Alt+click</b> deletes it, <b>Shift"
 "+click</b> launches width dialog."
 msgstr ""
 
-#: ../src/live_effects/parameter/random.cpp:149
+#: ../src/live_effects/parameter/random.cpp:158
 msgid "Change random parameter"
 msgstr ""
 
@@ -11880,20 +12002,20 @@ msgid ""
 "dialog, <b>Ctrl+Alt+Click</b> resets"
 msgstr ""
 
-#: ../src/live_effects/parameter/text.cpp:126
+#: ../src/live_effects/parameter/text.cpp:143
 msgid "Change text parameter"
 msgstr ""
 
-#: ../src/live_effects/parameter/togglebutton.cpp:123
+#: ../src/live_effects/parameter/togglebutton.cpp:130
 msgid "Change togglebutton parameter"
 msgstr ""
 
-#: ../src/live_effects/parameter/transformedpoint.cpp:117
-#: ../src/live_effects/parameter/vector.cpp:117
+#: ../src/live_effects/parameter/transformedpoint.cpp:126
+#: ../src/live_effects/parameter/vector.cpp:126
 msgid "Change vector parameter"
 msgstr ""
 
-#: ../src/live_effects/parameter/unit.cpp:87
+#: ../src/live_effects/parameter/unit.cpp:93
 msgid "Change unit parameter"
 msgstr ""
 
@@ -11907,293 +12029,297 @@ msgstr ""
 msgid "Unable to find node ID: '%s'\n"
 msgstr ""
 
-#: ../src/main.cpp:301
+#: ../src/main.cpp:303
 msgid "Print the Inkscape version number"
 msgstr ""
 
-#: ../src/main.cpp:306
+#: ../src/main.cpp:308
 msgid "Do not use X server (only process files from console)"
 msgstr ""
 
-#: ../src/main.cpp:311
+#: ../src/main.cpp:313
 msgid "Try to use X server (even if $DISPLAY is not set)"
 msgstr ""
 
-#: ../src/main.cpp:316
+#: ../src/main.cpp:318
 msgid "Open specified document(s) (option string may be excluded)"
 msgstr ""
 
-#: ../src/main.cpp:317 ../src/main.cpp:327 ../src/main.cpp:332
-#: ../src/main.cpp:404 ../src/main.cpp:408 ../src/main.cpp:413
-#: ../src/main.cpp:418 ../src/main.cpp:429 ../src/main.cpp:445
-#: ../src/main.cpp:450
+#: ../src/main.cpp:319 ../src/main.cpp:329 ../src/main.cpp:334
+#: ../src/main.cpp:406 ../src/main.cpp:410 ../src/main.cpp:415
+#: ../src/main.cpp:420 ../src/main.cpp:431 ../src/main.cpp:447
+#: ../src/main.cpp:452
 msgid "FILENAME"
 msgstr ""
 
-#: ../src/main.cpp:321
+#: ../src/main.cpp:323
 msgid "xverbs command"
 msgstr ""
 
-#: ../src/main.cpp:322
+#: ../src/main.cpp:324
 msgid "XVERBS_FILENAME"
 msgstr ""
 
-#: ../src/main.cpp:326
+#: ../src/main.cpp:328
 msgid "Print document(s) to specified output file (use '| program' for pipe)"
 msgstr ""
 
-#: ../src/main.cpp:331
+#: ../src/main.cpp:333
 msgid "Export document to a PNG file"
 msgstr ""
 
-#: ../src/main.cpp:336
+#: ../src/main.cpp:338
 msgid ""
 "Resolution for exporting to bitmap and for rasterization of filters in PS/"
 "EPS/PDF (default 96)"
 msgstr ""
 
-#: ../src/main.cpp:337 ../src/ui/widget/rendering-options.cpp:37
+#: ../src/main.cpp:339 ../src/ui/widget/rendering-options.cpp:37
 msgid "DPI"
 msgstr ""
 
-#: ../src/main.cpp:341
+#: ../src/main.cpp:343
 msgid ""
 "Exported area in SVG user units (default is the page; 0,0 is lower-left "
 "corner)"
 msgstr ""
 
-#: ../src/main.cpp:342
+#: ../src/main.cpp:344
 msgid "x0:y0:x1:y1"
 msgstr ""
 
-#: ../src/main.cpp:346
+#: ../src/main.cpp:348
 msgid "Exported area is the entire drawing (not page)"
 msgstr ""
 
-#: ../src/main.cpp:351
+#: ../src/main.cpp:353
 msgid "Exported area is the entire page"
 msgstr ""
 
-#: ../src/main.cpp:356
-msgid "Only for PS/EPS/PDF, sets margin in mm around exported area (default 0)"
+#: ../src/main.cpp:358
+msgid ""
+"Sets margin around exported area (default 0) in units of page size for SVG "
+"and mm for PS/EPS/PDF"
 msgstr ""
 
-#: ../src/main.cpp:357 ../src/main.cpp:399
+#: ../src/main.cpp:359 ../src/main.cpp:401
 msgid "VALUE"
 msgstr ""
 
-#: ../src/main.cpp:361
+#: ../src/main.cpp:363
 msgid ""
 "Snap the bitmap export area outwards to the nearest integer values (in SVG "
 "user units)"
 msgstr ""
 
-#: ../src/main.cpp:366
+#: ../src/main.cpp:368
 msgid "The width of exported bitmap in pixels (overrides export-dpi)"
 msgstr ""
 
-#: ../src/main.cpp:367
+#: ../src/main.cpp:369
 msgid "WIDTH"
 msgstr ""
 
-#: ../src/main.cpp:371
+#: ../src/main.cpp:373
 msgid "The height of exported bitmap in pixels (overrides export-dpi)"
 msgstr ""
 
-#: ../src/main.cpp:372
+#: ../src/main.cpp:374
 msgid "HEIGHT"
 msgstr ""
 
-#: ../src/main.cpp:376
+#: ../src/main.cpp:378
 msgid "The ID of the object to export"
 msgstr ""
 
-#: ../src/main.cpp:377 ../src/main.cpp:494
-#: ../src/ui/dialog/inkscape-preferences.cpp:1549
+#: ../src/main.cpp:379 ../src/main.cpp:496
+#: ../src/ui/dialog/inkscape-preferences.cpp:1610
 msgid "ID"
 msgstr ""
 
 #. TRANSLATORS: this means: "Only export the object whose id is given in --export-id".
 #. See "man inkscape" for details.
-#: ../src/main.cpp:383
+#: ../src/main.cpp:385
 msgid ""
 "Export just the object with export-id, hide all others (only with export-id)"
 msgstr ""
 
-#: ../src/main.cpp:388
+#: ../src/main.cpp:390
 msgid "Use stored filename and DPI hints when exporting (only with export-id)"
 msgstr ""
 
-#: ../src/main.cpp:393
+#: ../src/main.cpp:395
 msgid "Background color of exported bitmap (any SVG-supported color string)"
 msgstr ""
 
-#: ../src/main.cpp:394
+#: ../src/main.cpp:396
 msgid "COLOR"
 msgstr ""
 
-#: ../src/main.cpp:398
+#: ../src/main.cpp:400
 msgid "Background opacity of exported bitmap (either 0.0 to 1.0, or 1 to 255)"
 msgstr ""
 
-#: ../src/main.cpp:403
+#: ../src/main.cpp:405
 msgid "Export document to an inkscape SVG file (similar to save as.)"
 msgstr ""
 
-#: ../src/main.cpp:407
+#: ../src/main.cpp:409
 msgid "Export document to plain SVG file (no sodipodi or inkscape namespaces)"
 msgstr ""
 
-#: ../src/main.cpp:412
+#: ../src/main.cpp:414
 msgid "Export document to a PS file"
 msgstr ""
 
-#: ../src/main.cpp:417
+#: ../src/main.cpp:419
 msgid "Export document to an EPS file"
 msgstr ""
 
-#: ../src/main.cpp:422
+#: ../src/main.cpp:424
 msgid ""
 "Choose the PostScript Level used to export. Possible choices are 2 and 3 "
 "(the default)"
 msgstr ""
 
-#: ../src/main.cpp:424
+#: ../src/main.cpp:426
 msgid "PS Level"
 msgstr ""
 
-#: ../src/main.cpp:428
+#: ../src/main.cpp:430
 msgid "Export document to a PDF file"
 msgstr ""
 
 #. TRANSLATORS: "--export-pdf-version" is an Inkscape command line option; see "inkscape --help"
-#: ../src/main.cpp:434
+#: ../src/main.cpp:436
 msgid ""
 "Export PDF to given version. (hint: make sure to input a version found in "
 "the PDF export dialog, e.g. \"1.4\" which is PDF-a conformant)"
 msgstr ""
 
-#: ../src/main.cpp:435
+#: ../src/main.cpp:437
 msgid "PDF_VERSION"
 msgstr ""
 
-#: ../src/main.cpp:439
+#: ../src/main.cpp:441
 msgid ""
 "Export PDF/PS/EPS without text. Besides the PDF/PS/EPS, a LaTeX file is "
 "exported, putting the text on top of the PDF/PS/EPS file. Include the result "
 "in LaTeX like: \\input{latexfile.tex}"
 msgstr ""
 
-#: ../src/main.cpp:444
+#: ../src/main.cpp:446
 msgid "Export document to an Enhanced Metafile (EMF) File"
 msgstr ""
 
-#: ../src/main.cpp:449
+#: ../src/main.cpp:451
 msgid "Export document to a Windows Metafile (WMF) File"
 msgstr ""
 
-#: ../src/main.cpp:454
+#: ../src/main.cpp:456
 msgid "Convert text object to paths on export (PS, EPS, PDF, SVG)"
 msgstr ""
 
-#: ../src/main.cpp:459
+#: ../src/main.cpp:461
 msgid ""
 "Render filtered objects without filters, instead of rasterizing (PS, EPS, "
 "PDF)"
 msgstr ""
 
 #. TRANSLATORS: "--query-id" is an Inkscape command line option; see "inkscape --help"
-#: ../src/main.cpp:465
+#: ../src/main.cpp:467
 msgid ""
 "Query the X coordinate of the drawing or, if specified, of the object with --"
 "query-id"
 msgstr ""
 
 #. TRANSLATORS: "--query-id" is an Inkscape command line option; see "inkscape --help"
-#: ../src/main.cpp:471
+#: ../src/main.cpp:473
 msgid ""
 "Query the Y coordinate of the drawing or, if specified, of the object with --"
 "query-id"
 msgstr ""
 
 #. TRANSLATORS: "--query-id" is an Inkscape command line option; see "inkscape --help"
-#: ../src/main.cpp:477
+#: ../src/main.cpp:479
 msgid ""
 "Query the width of the drawing or, if specified, of the object with --query-"
 "id"
 msgstr ""
 
 #. TRANSLATORS: "--query-id" is an Inkscape command line option; see "inkscape --help"
-#: ../src/main.cpp:483
+#: ../src/main.cpp:485
 msgid ""
 "Query the height of the drawing or, if specified, of the object with --query-"
 "id"
 msgstr ""
 
-#: ../src/main.cpp:488
+#: ../src/main.cpp:490
 msgid "List id,x,y,w,h for all objects"
 msgstr ""
 
-#: ../src/main.cpp:493
+#: ../src/main.cpp:495
 msgid "The ID of the object whose dimensions are queried"
 msgstr ""
 
 #. TRANSLATORS: this option makes Inkscape print the name (path) of the extension directory
-#: ../src/main.cpp:499
+#: ../src/main.cpp:501
 msgid "Print out the extension directory and exit"
 msgstr ""
 
-#: ../src/main.cpp:504
+#: ../src/main.cpp:506
 msgid "Remove unused definitions from the defs section(s) of the document"
 msgstr ""
 
-#: ../src/main.cpp:510
+#: ../src/main.cpp:512
 msgid "Enter a listening loop for D-Bus messages in console mode"
 msgstr ""
 
-#: ../src/main.cpp:515
+#: ../src/main.cpp:517
 msgid ""
 "Specify the D-Bus bus name to listen for messages on (default is org."
 "inkscape)"
 msgstr ""
 
-#: ../src/main.cpp:516
+#: ../src/main.cpp:518
 msgid "BUS-NAME"
 msgstr ""
 
-#: ../src/main.cpp:521
+#: ../src/main.cpp:523
 msgid "List the IDs of all the verbs in Inkscape"
 msgstr ""
 
-#: ../src/main.cpp:526
+#: ../src/main.cpp:528
 msgid "Verb to call when Inkscape opens."
 msgstr ""
 
-#: ../src/main.cpp:527
+#: ../src/main.cpp:529
 msgid "VERB-ID"
 msgstr ""
 
-#: ../src/main.cpp:531
+#: ../src/main.cpp:533
 msgid "Object ID to select when Inkscape opens."
 msgstr ""
 
-#: ../src/main.cpp:532
+#: ../src/main.cpp:534
 msgid "OBJECT-ID"
 msgstr ""
 
-#: ../src/main.cpp:536
+#: ../src/main.cpp:538
 msgid "Start Inkscape in interactive shell mode."
 msgstr ""
 
-#: ../src/main.cpp:541
+#: ../src/main.cpp:543
 msgid "Do not fix legacy (pre-0.92) files' text baseline spacing on opening."
 msgstr ""
 
-#: ../src/main.cpp:546
-msgid "Method used to convert pre-.92 document dpi, if needed."
+#: ../src/main.cpp:548
+msgid ""
+"Method used to convert pre-.92 document dpi, if needed. ([none|scale-viewbox|"
+"scale-document])"
 msgstr ""
 
-#: ../src/main.cpp:865 ../src/main.cpp:1259
+#: ../src/main.cpp:837 ../src/main.cpp:1185
 msgid ""
 "[OPTIONS...] [FILE...]\n"
 "\n"
@@ -12230,43 +12356,43 @@ msgstr ""
 msgid "Breaking apart paths..."
 msgstr ""
 
-#: ../src/path-chemistry.cpp:289
+#: ../src/path-chemistry.cpp:287
 msgid "Break apart"
 msgstr ""
 
-#: ../src/path-chemistry.cpp:293
+#: ../src/path-chemistry.cpp:291
 msgid "<b>No path(s)</b> to break apart in the selection."
 msgstr ""
 
-#: ../src/path-chemistry.cpp:301
+#: ../src/path-chemistry.cpp:299
 msgid "Select <b>object(s)</b> to convert to path."
 msgstr ""
 
-#: ../src/path-chemistry.cpp:307
+#: ../src/path-chemistry.cpp:305
 msgid "Converting objects to paths..."
 msgstr ""
 
-#: ../src/path-chemistry.cpp:327
+#: ../src/path-chemistry.cpp:328
 msgid "Object to path"
 msgstr ""
 
-#: ../src/path-chemistry.cpp:330
+#: ../src/path-chemistry.cpp:331
 msgid "<b>No objects</b> to convert to path in the selection."
 msgstr ""
 
-#: ../src/path-chemistry.cpp:614
+#: ../src/path-chemistry.cpp:624
 msgid "Select <b>path(s)</b> to reverse."
 msgstr ""
 
-#: ../src/path-chemistry.cpp:622
+#: ../src/path-chemistry.cpp:632
 msgid "Reversing paths..."
 msgstr ""
 
-#: ../src/path-chemistry.cpp:660
+#: ../src/path-chemistry.cpp:670
 msgid "Reverse path"
 msgstr ""
 
-#: ../src/path-chemistry.cpp:663
+#: ../src/path-chemistry.cpp:673
 msgid "<b>No paths</b> to reverse in the selection."
 msgstr ""
 
@@ -12389,7 +12515,7 @@ msgstr ""
 
 #. Create the Title label and edit control
 #. TRANSLATORS: for info, see http://www.w3.org/TR/2000/CR-SVG-20000802/linking.html#AElementXLinkTitleAttribute
-#: ../src/rdf.cpp:235 ../src/ui/dialog/filedialogimpl-win32.cpp:1881
+#: ../src/rdf.cpp:235 ../src/ui/dialog/filedialogimpl-win32.cpp:1882
 #: ../src/ui/dialog/object-attributes.cpp:54
 msgid "Title:"
 msgstr ""
@@ -12464,7 +12590,7 @@ msgstr ""
 msgid "A related resource"
 msgstr ""
 
-#: ../src/rdf.cpp:267 ../src/ui/dialog/inkscape-preferences.cpp:1897
+#: ../src/rdf.cpp:267 ../src/ui/dialog/inkscape-preferences.cpp:1958
 msgid "Language:"
 msgstr ""
 
@@ -12540,11 +12666,11 @@ msgstr ""
 msgid "<b>Nothing</b> was deleted."
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:410 ../src/ui/dialog/swatches.cpp:270
-#: ../src/ui/tools/text-tool.cpp:959 ../src/widgets/eraser-toolbar.cpp:145
-#: ../src/widgets/gradient-toolbar.cpp:1182
-#: ../src/widgets/gradient-toolbar.cpp:1196
-#: ../src/widgets/gradient-toolbar.cpp:1210 ../src/widgets/node-toolbar.cpp:399
+#: ../src/selection-chemistry.cpp:410 ../src/ui/dialog/swatches.cpp:282
+#: ../src/ui/tools/text-tool.cpp:955 ../src/widgets/eraser-toolbar.cpp:151
+#: ../src/widgets/gradient-toolbar.cpp:1071
+#: ../src/widgets/gradient-toolbar.cpp:1085
+#: ../src/widgets/gradient-toolbar.cpp:1099 ../src/widgets/node-toolbar.cpp:399
 msgid "Delete"
 msgstr ""
 
@@ -12565,503 +12691,503 @@ msgstr ""
 msgid "Select <b>some objects</b> to group."
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:765
+#: ../src/selection-chemistry.cpp:769
 msgctxt "Verb"
 msgid "Group"
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:787
+#: ../src/selection-chemistry.cpp:785
 msgid "<b>No objects selected</b> to pop out of group."
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:796
+#: ../src/selection-chemistry.cpp:794
 msgid "Selection <b>not in a group</b>."
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:811
+#: ../src/selection-chemistry.cpp:809
 msgid "Pop selection from group"
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:875
+#: ../src/selection-chemistry.cpp:871
 msgid "Select a <b>group</b> to ungroup."
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:881
+#: ../src/selection-chemistry.cpp:877
 msgid "<b>No groups</b> to ungroup in the selection."
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:888 ../src/sp-item-group.cpp:656
-#: ../src/ui/dialog/objects.cpp:1942
+#: ../src/selection-chemistry.cpp:884 ../src/sp-item-group.cpp:651
+#: ../src/ui/dialog/objects.cpp:1904
 msgid "Ungroup"
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:975 ../src/selection-chemistry.cpp:1027
+#: ../src/selection-chemistry.cpp:971 ../src/selection-chemistry.cpp:1023
 msgid "Select <b>object(s)</b> to raise."
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:982 ../src/selection-chemistry.cpp:1033
-#: ../src/selection-chemistry.cpp:1059 ../src/selection-chemistry.cpp:1116
+#: ../src/selection-chemistry.cpp:978 ../src/selection-chemistry.cpp:1029
+#: ../src/selection-chemistry.cpp:1055 ../src/selection-chemistry.cpp:1112
 msgid ""
 "You cannot raise/lower objects from <b>different groups</b> or <b>layers</b>."
 msgstr ""
 
 #. TRANSLATORS: "Raise" means "to raise an object" in the undo history
-#: ../src/selection-chemistry.cpp:1021
+#: ../src/selection-chemistry.cpp:1017
 msgctxt "Undo action"
 msgid "Raise"
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:1047
+#: ../src/selection-chemistry.cpp:1043
 msgid "Raise to top"
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:1053
+#: ../src/selection-chemistry.cpp:1049
 msgid "Select <b>object(s)</b> to lower."
 msgstr ""
 
 #. TRANSLATORS: "Lower" means "to lower an object" in the undo history
-#: ../src/selection-chemistry.cpp:1102
+#: ../src/selection-chemistry.cpp:1098
 msgctxt "Undo action"
 msgid "Lower"
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:1110
+#: ../src/selection-chemistry.cpp:1106
 msgid "Select <b>object(s)</b> to lower to bottom."
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:1140
+#: ../src/selection-chemistry.cpp:1136
 msgid "Lower to bottom"
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:1146
+#: ../src/selection-chemistry.cpp:1142
 msgid "Select <b>object(s)</b> to stack up."
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:1157
+#: ../src/selection-chemistry.cpp:1153
 msgid "We hit top."
 msgstr ""
 
 #. TRANSLATORS: undo history: "stack up" means to raise an object of its ordinal position by 1
-#: ../src/selection-chemistry.cpp:1165
+#: ../src/selection-chemistry.cpp:1161
 msgctxt "Undo action"
 msgid "stack up"
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:1170
+#: ../src/selection-chemistry.cpp:1166
 msgid "Select <b>object(s)</b> to stack down."
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:1181
+#: ../src/selection-chemistry.cpp:1177
 msgid "We hit bottom."
 msgstr ""
 
 #. TRANSLATORS: undo history: "stack down" means to lower an object of its ordinal position by 1
-#: ../src/selection-chemistry.cpp:1189
+#: ../src/selection-chemistry.cpp:1185
 msgctxt "Undo action"
 msgid "stack down"
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:1199
+#: ../src/selection-chemistry.cpp:1195
 msgid "Nothing to undo."
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:1210
+#: ../src/selection-chemistry.cpp:1206
 msgid "Nothing to redo."
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:1282
+#: ../src/selection-chemistry.cpp:1278
 msgid "Paste"
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:1290
+#: ../src/selection-chemistry.cpp:1286
 msgid "Paste style"
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:1299
+#: ../src/selection-chemistry.cpp:1295
 msgid "Paste live path effect"
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:1319
+#: ../src/selection-chemistry.cpp:1315
 msgid "Select <b>object(s)</b> to remove live path effects from."
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:1332
+#: ../src/selection-chemistry.cpp:1328
 msgid "Remove live path effect"
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:1341
+#: ../src/selection-chemistry.cpp:1337
 msgid "Select <b>object(s)</b> to remove filters from."
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:1351
-#: ../src/ui/dialog/filter-effects-dialog.cpp:1674
+#: ../src/selection-chemistry.cpp:1347
+#: ../src/ui/dialog/filter-effects-dialog.cpp:1685
 msgid "Remove filter"
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:1360
+#: ../src/selection-chemistry.cpp:1356
 msgid "Paste size"
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:1369
+#: ../src/selection-chemistry.cpp:1365
 msgid "Paste size separately"
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:1399
+#: ../src/selection-chemistry.cpp:1395
 msgid "Select <b>object(s)</b> to move to the layer above."
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:1425
+#: ../src/selection-chemistry.cpp:1421
 msgid "Raise to next layer"
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:1432
+#: ../src/selection-chemistry.cpp:1428
 msgid "No more layers above."
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:1445
+#: ../src/selection-chemistry.cpp:1441
 msgid "Select <b>object(s)</b> to move to the layer below."
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:1471
+#: ../src/selection-chemistry.cpp:1467
 msgid "Lower to previous layer"
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:1478
+#: ../src/selection-chemistry.cpp:1474
 msgid "No more layers below."
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:1491
+#: ../src/selection-chemistry.cpp:1487
 msgid "Select <b>object(s)</b> to move."
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:1509 ../src/verbs.cpp:2819
+#: ../src/selection-chemistry.cpp:1505 ../src/verbs.cpp:2849
 msgid "Move selection to layer"
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:1601 ../src/seltrans.cpp:385
+#: ../src/selection-chemistry.cpp:1597 ../src/seltrans.cpp:385
 msgid "Cannot transform an embedded SVG."
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:1767
+#: ../src/selection-chemistry.cpp:1763
 msgid "Remove transform"
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:1866
+#: ../src/selection-chemistry.cpp:1862
 msgid "Rotate 90° CCW"
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:1866
+#: ../src/selection-chemistry.cpp:1862
 msgid "Rotate 90° CW"
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:1885 ../src/seltrans.cpp:478
+#: ../src/selection-chemistry.cpp:1881 ../src/seltrans.cpp:478
 #: ../src/ui/dialog/transformation.cpp:784
 msgid "Rotate"
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:2233
+#: ../src/selection-chemistry.cpp:2227
 msgid "Rotate by pixels"
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:2286
+#: ../src/selection-chemistry.cpp:2280
 msgid "Scale by whole factor"
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:2300
+#: ../src/selection-chemistry.cpp:2294
 msgid "Move vertically"
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:2303
+#: ../src/selection-chemistry.cpp:2297
 msgid "Move horizontally"
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:2306 ../src/selection-chemistry.cpp:2331
+#: ../src/selection-chemistry.cpp:2300 ../src/selection-chemistry.cpp:2325
 #: ../src/seltrans.cpp:472 ../src/ui/dialog/transformation.cpp:695
 msgid "Move"
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:2325
+#: ../src/selection-chemistry.cpp:2319
 msgid "Move vertically by pixels"
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:2328
+#: ../src/selection-chemistry.cpp:2322
 msgid "Move horizontally by pixels"
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:2532
+#: ../src/selection-chemistry.cpp:2530
 msgid "The selection has no applied path effect."
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:2620 ../src/ui/dialog/clonetiler.cpp:2060
+#: ../src/selection-chemistry.cpp:2588 ../src/ui/dialog/clonetiler.cpp:2060
 msgid "Select an <b>object</b> to clone."
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:2655
+#: ../src/selection-chemistry.cpp:2623
 msgctxt "Action"
 msgid "Clone"
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:2664
+#: ../src/selection-chemistry.cpp:2632
 msgid "Select <b>clones</b> to relink."
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:2672
+#: ../src/selection-chemistry.cpp:2640
 msgid "Copy an <b>object</b> to clipboard to relink clones to."
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:2694
+#: ../src/selection-chemistry.cpp:2662
 msgid "<b>No clones to relink</b> in the selection."
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:2697
+#: ../src/selection-chemistry.cpp:2665
 msgid "Relink clone"
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:2706 ../src/selection-chemistry.cpp:2792
+#: ../src/selection-chemistry.cpp:2674 ../src/selection-chemistry.cpp:2760
 msgid "Select <b>clones</b> to unlink."
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:2779 ../src/selection-chemistry.cpp:2810
+#: ../src/selection-chemistry.cpp:2747 ../src/selection-chemistry.cpp:2778
 msgid "<b>No clones to unlink</b> in the selection."
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:2784
+#: ../src/selection-chemistry.cpp:2752
 msgid "Unlink clone"
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:2814
+#: ../src/selection-chemistry.cpp:2782
 msgid "Unlink clone recursively"
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:2824
+#: ../src/selection-chemistry.cpp:2792
 msgid ""
 "Select a <b>clone</b> to go to its original. Select a <b>linked offset</b> "
 "to go to its source. Select a <b>text on path</b> to go to the path. Select "
 "a <b>flowed text</b> to go to its frame."
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:2877
+#: ../src/selection-chemistry.cpp:2833
 msgid ""
 "<b>Cannot find</b> the object to select (orphaned clone, offset, textpath, "
 "flowed text?)"
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:2884
+#: ../src/selection-chemistry.cpp:2840
 msgid ""
 "The object you're trying to select is <b>not visible</b> (it is in &lt;"
 "defs&gt;)"
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:2970
+#: ../src/selection-chemistry.cpp:2938
 msgid "Select path(s) to fill."
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:2987
+#: ../src/selection-chemistry.cpp:2955
 msgid "Select <b>object(s)</b> to convert to marker."
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:3059
+#: ../src/selection-chemistry.cpp:3027
 msgid "Objects to marker"
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:3082
+#: ../src/selection-chemistry.cpp:3050
 msgid "Select <b>object(s)</b> to convert to guides."
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:3103
+#: ../src/selection-chemistry.cpp:3071
 msgid "Objects to guides"
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:3135
+#: ../src/selection-chemistry.cpp:3102
 msgid "Select <b>objects</b> to convert to symbol."
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:3239
+#: ../src/selection-chemistry.cpp:3245
 msgid "Group to symbol"
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:3253
+#: ../src/selection-chemistry.cpp:3258
 msgid "Select a <b>symbol</b> to extract objects from."
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:3263
+#: ../src/selection-chemistry.cpp:3268
 msgid "Select only one <b>symbol</b> in Symbol dialog to convert to group."
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:3319
+#: ../src/selection-chemistry.cpp:3329
 msgid "Group from symbol"
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:3334
+#: ../src/selection-chemistry.cpp:3344
 msgid "Select <b>object(s)</b> to convert to pattern."
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:3430
+#: ../src/selection-chemistry.cpp:3440
 msgid "Objects to pattern"
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:3442
+#: ../src/selection-chemistry.cpp:3452
 msgid "Select an <b>object with pattern fill</b> to extract objects from."
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:3502
+#: ../src/selection-chemistry.cpp:3512
 msgid "<b>No pattern fills</b> in the selection."
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:3505
+#: ../src/selection-chemistry.cpp:3515
 msgid "Pattern to objects"
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:3587
+#: ../src/selection-chemistry.cpp:3597
 msgid "Select <b>object(s)</b> to make a bitmap copy."
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:3591
+#: ../src/selection-chemistry.cpp:3601
 msgid "Rendering bitmap..."
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:3778
+#: ../src/selection-chemistry.cpp:3788
 msgid "Create bitmap"
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:3800 ../src/selection-chemistry.cpp:3910
+#: ../src/selection-chemistry.cpp:3810 ../src/selection-chemistry.cpp:3919
 msgid "Select <b>object(s)</b> to create clippath or mask from."
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:3886 ../src/ui/dialog/objects.cpp:1948
+#: ../src/selection-chemistry.cpp:3895 ../src/ui/dialog/objects.cpp:1910
 msgid "Create Clip Group"
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:3914
+#: ../src/selection-chemistry.cpp:3923
 msgid "Select mask object and <b>object(s)</b> to apply clippath or mask to."
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:4058
+#: ../src/selection-chemistry.cpp:4073
 msgid "Set clipping path"
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:4060
+#: ../src/selection-chemistry.cpp:4075
 msgid "Set mask"
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:4072
+#: ../src/selection-chemistry.cpp:4087
 msgid "Select <b>object(s)</b> to remove clippath or mask from."
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:4189
+#: ../src/selection-chemistry.cpp:4200
 msgid "Release clipping path"
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:4191
+#: ../src/selection-chemistry.cpp:4202
 msgid "Release mask"
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:4207
+#: ../src/selection-chemistry.cpp:4218
 msgid "Select <b>object(s)</b> to fit canvas to."
 msgstr ""
 
 #. Fit Page
-#: ../src/selection-chemistry.cpp:4215 ../src/verbs.cpp:3186
+#: ../src/selection-chemistry.cpp:4226 ../src/verbs.cpp:3220
 msgid "Fit Page to Selection"
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:4289 ../src/verbs.cpp:2689
+#: ../src/selection-chemistry.cpp:4300 ../src/verbs.cpp:2719
 msgid "Swap fill and stroke of an object"
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:4317 ../src/verbs.cpp:3188
+#: ../src/selection-chemistry.cpp:4328 ../src/verbs.cpp:3222
 msgid "Fit Page to Drawing"
 msgstr ""
 
-#: ../src/selection-chemistry.cpp:4338
+#: ../src/selection-chemistry.cpp:4349
 msgid "Fit Page to Selection or Drawing"
 msgstr ""
 
-#: ../src/selection-describer.cpp:129
+#: ../src/selection-describer.cpp:118
 msgid "root"
 msgstr ""
 
-#: ../src/selection-describer.cpp:131 ../src/widgets/ege-paint-def.cpp:64
+#: ../src/selection-describer.cpp:120 ../src/widgets/ege-paint-def.cpp:64
 #: ../src/widgets/ege-paint-def.cpp:88
 msgid "none"
 msgstr ""
 
-#: ../src/selection-describer.cpp:143
+#: ../src/selection-describer.cpp:132
 #, c-format
 msgid "layer <b>%s</b>"
 msgstr ""
 
-#: ../src/selection-describer.cpp:145
+#: ../src/selection-describer.cpp:134
 #, c-format
 msgid "layer <b><i>%s</i></b>"
 msgstr ""
 
-#: ../src/selection-describer.cpp:156
+#: ../src/selection-describer.cpp:145
 #, c-format
 msgid "<i>%s</i>"
 msgstr ""
 
-#: ../src/selection-describer.cpp:166
+#: ../src/selection-describer.cpp:155
 #, c-format
 msgid " in %s"
 msgstr ""
 
-#: ../src/selection-describer.cpp:168
+#: ../src/selection-describer.cpp:157
 msgid " hidden in definitions"
 msgstr ""
 
-#: ../src/selection-describer.cpp:170
+#: ../src/selection-describer.cpp:159
 #, c-format
 msgid " in group %s (%s)"
 msgstr ""
 
-#: ../src/selection-describer.cpp:172
+#: ../src/selection-describer.cpp:161
 #, c-format
 msgid " in unnamed group (%s)"
 msgstr ""
 
-#: ../src/selection-describer.cpp:174
+#: ../src/selection-describer.cpp:163
 #, c-format
 msgid " in <b>%i</b> parent (%s)"
 msgid_plural " in <b>%i</b> parents (%s)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/selection-describer.cpp:177
+#: ../src/selection-describer.cpp:166
 #, c-format
 msgid " in <b>%i</b> layer"
 msgid_plural " in <b>%i</b> layers"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/selection-describer.cpp:189
+#: ../src/selection-describer.cpp:178
 msgid "Convert symbol to group to edit"
 msgstr ""
 
-#: ../src/selection-describer.cpp:193
+#: ../src/selection-describer.cpp:182
 msgid "Remove from symbols tray to edit symbol"
 msgstr ""
 
-#: ../src/selection-describer.cpp:199
+#: ../src/selection-describer.cpp:188
 msgid "Use <b>Shift+D</b> to look up original"
 msgstr ""
 
-#: ../src/selection-describer.cpp:205
+#: ../src/selection-describer.cpp:194
 msgid "Use <b>Shift+D</b> to look up path"
 msgstr ""
 
-#: ../src/selection-describer.cpp:211
+#: ../src/selection-describer.cpp:200
 msgid "Use <b>Shift+D</b> to look up frame"
 msgstr ""
 
-#: ../src/selection-describer.cpp:227
+#: ../src/selection-describer.cpp:216
 #, c-format
 msgid "<b>%1$i</b> objects selected of type %2$s"
 msgid_plural "<b>%1$i</b> objects selected of types %2$s"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/selection-describer.cpp:237
+#: ../src/selection-describer.cpp:226
 #, c-format
 msgid "; <i>%d filtered object</i> "
 msgid_plural "; <i>%d filtered objects</i> "
@@ -13114,39 +13240,39 @@ msgstr ""
 msgid "Reset center"
 msgstr ""
 
-#: ../src/seltrans.cpp:958 ../src/seltrans.cpp:1062
+#: ../src/seltrans.cpp:960 ../src/seltrans.cpp:1064
 #, c-format
 msgid "<b>Scale</b>: %0.2f%% x %0.2f%%; with <b>Ctrl</b> to lock ratio"
 msgstr ""
 
 #. TRANSLATORS: don't modify the first ";"
 #. (it will NOT be displayed as ";" - only the second one will be)
-#: ../src/seltrans.cpp:1199
+#: ../src/seltrans.cpp:1201
 #, c-format
 msgid "<b>Skew</b>: %0.2f&#176;; with <b>Ctrl</b> to snap angle"
 msgstr ""
 
 #. TRANSLATORS: don't modify the first ";"
 #. (it will NOT be displayed as ";" - only the second one will be)
-#: ../src/seltrans.cpp:1275
+#: ../src/seltrans.cpp:1277
 #, c-format
 msgid "<b>Rotate</b>: %0.2f&#176;; with <b>Ctrl</b> to snap angle"
 msgstr ""
 
-#: ../src/seltrans.cpp:1312
+#: ../src/seltrans.cpp:1314
 #, c-format
 msgid "Move <b>center</b> to %s, %s"
 msgstr ""
 
-#: ../src/seltrans.cpp:1458
+#: ../src/seltrans.cpp:1459
 #, c-format
 msgid ""
 "<b>Move</b> by %s, %s; with <b>Ctrl</b> to restrict to horizontal/vertical; "
 "with <b>Shift</b> to disable snapping"
 msgstr ""
 
-#: ../src/shortcuts.cpp:397 ../src/ui/dialog/export.cpp:1296
-#: ../src/ui/dialog/export.cpp:1330
+#: ../src/shortcuts.cpp:397 ../src/ui/dialog/export.cpp:1293
+#: ../src/ui/dialog/export.cpp:1323
 msgid "Select a filename for exporting"
 msgstr ""
 
@@ -13167,31 +13293,31 @@ msgstr ""
 msgid "without URI"
 msgstr ""
 
-#: ../src/sp-ellipse.cpp:385 ../src/widgets/arc-toolbar.cpp:364
+#: ../src/sp-ellipse.cpp:387 ../src/widgets/arc-toolbar.cpp:529
 msgid "Slice"
 msgstr ""
 
-#: ../src/sp-ellipse.cpp:388 ../src/widgets/arc-toolbar.cpp:378
+#: ../src/sp-ellipse.cpp:390 ../src/widgets/arc-toolbar.cpp:541
 msgid "Chord"
 msgstr ""
 
-#: ../src/sp-ellipse.cpp:391
+#: ../src/sp-ellipse.cpp:393
 msgid "Arc"
 msgstr ""
 
 #. Ellipse
-#: ../src/sp-ellipse.cpp:395 ../src/sp-ellipse.cpp:402
-#: ../src/ui/dialog/inkscape-preferences.cpp:407
-#: ../src/widgets/pencil-toolbar.cpp:176
+#: ../src/sp-ellipse.cpp:397 ../src/sp-ellipse.cpp:404
+#: ../src/ui/dialog/inkscape-preferences.cpp:447
+#: ../src/widgets/pencil-toolbar.cpp:221
 msgid "Ellipse"
 msgstr ""
 
-#: ../src/sp-ellipse.cpp:399
+#: ../src/sp-ellipse.cpp:401
 msgid "Circle"
 msgstr ""
 
 #. TRANSLATORS: "Flow region" is an area where text is allowed to flow
-#: ../src/sp-flowregion.cpp:178
+#: ../src/sp-flowregion.cpp:169
 msgid "Flow Region"
 msgstr ""
 
@@ -13199,35 +13325,35 @@ msgstr ""
 #. * flow excluded region.  flowRegionExclude in SVG 1.2: see
 #. * http://www.w3.org/TR/2004/WD-SVG12-20041027/flow.html#flowRegion-elem and
 #. * http://www.w3.org/TR/2004/WD-SVG12-20041027/flow.html#flowRegionExclude-elem.
-#: ../src/sp-flowregion.cpp:331
+#: ../src/sp-flowregion.cpp:313
 msgid "Flow Excluded Region"
 msgstr ""
 
-#: ../src/sp-flowtext.cpp:279
+#: ../src/sp-flowtext.cpp:273
 msgid "Flowed Text"
 msgstr ""
 
-#: ../src/sp-flowtext.cpp:281
+#: ../src/sp-flowtext.cpp:275
 msgid "Linked Flowed Text"
 msgstr ""
 
-#: ../src/sp-flowtext.cpp:287 ../src/sp-text.cpp:368
-#: ../src/ui/tools/text-tool.cpp:1602
+#: ../src/sp-flowtext.cpp:281 ../src/sp-text.cpp:339
+#: ../src/ui/tools/text-tool.cpp:1598
 msgid " [truncated]"
 msgstr ""
 
-#: ../src/sp-flowtext.cpp:289
+#: ../src/sp-flowtext.cpp:283
 #, c-format
 msgid "(%d character%s)"
 msgid_plural "(%d characters%s)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/sp-guide.cpp:258
+#: ../src/sp-guide.cpp:257
 msgid "Create Guides Around the Page"
 msgstr ""
 
-#: ../src/sp-guide.cpp:271 ../src/verbs.cpp:2681
+#: ../src/sp-guide.cpp:270 ../src/verbs.cpp:2711
 msgid "Delete All Guides"
 msgstr ""
 
@@ -13257,35 +13383,35 @@ msgstr ""
 msgid "at %d degrees, through (%s,%s)"
 msgstr ""
 
-#: ../src/sp-image.cpp:514
+#: ../src/sp-image.cpp:499
 msgid "embedded"
 msgstr ""
 
-#: ../src/sp-image.cpp:522
+#: ../src/sp-image.cpp:507
 #, c-format
 msgid "[bad reference]: %s"
 msgstr ""
 
-#: ../src/sp-image.cpp:523
+#: ../src/sp-image.cpp:508
 #, c-format
 msgid "%d &#215; %d: %s"
 msgstr ""
 
-#: ../src/sp-item-group.cpp:312 ../src/ui/dialog/objects.cpp:1941
+#: ../src/sp-item-group.cpp:309 ../src/ui/dialog/objects.cpp:1903
 msgid "Group"
 msgstr ""
 
-#: ../src/sp-item-group.cpp:318 ../src/sp-switch.cpp:69
+#: ../src/sp-item-group.cpp:315 ../src/sp-switch.cpp:69
 #, c-format
 msgid "of <b>%d</b> object"
 msgstr ""
 
-#: ../src/sp-item-group.cpp:318 ../src/sp-switch.cpp:69
+#: ../src/sp-item-group.cpp:315 ../src/sp-switch.cpp:69
 #, c-format
 msgid "of <b>%d</b> objects"
 msgstr ""
 
-#: ../src/sp-item.cpp:1032 ../src/verbs.cpp:208
+#: ../src/sp-item.cpp:1032 ../src/verbs.cpp:211
 msgid "Object"
 msgstr ""
 
@@ -13313,7 +13439,7 @@ msgstr ""
 msgid "Line"
 msgstr ""
 
-#: ../src/sp-lpe-item.cpp:296 ../src/sp-lpe-item.cpp:765
+#: ../src/sp-lpe-item.cpp:296 ../src/sp-lpe-item.cpp:802
 msgid "An exception occurred during execution of the Path Effect."
 msgstr ""
 
@@ -13367,12 +13493,12 @@ msgid "<b>Polyline</b>"
 msgstr ""
 
 #. Rectangle
-#: ../src/sp-rect.cpp:194 ../src/ui/dialog/inkscape-preferences.cpp:397
+#: ../src/sp-rect.cpp:194 ../src/ui/dialog/inkscape-preferences.cpp:437
 msgid "Rectangle"
 msgstr ""
 
 #. Spiral
-#: ../src/sp-spiral.cpp:218 ../src/ui/dialog/inkscape-preferences.cpp:415
+#: ../src/sp-spiral.cpp:218 ../src/ui/dialog/inkscape-preferences.cpp:455
 #: ../share/extensions/gcodetools_area.inx.h:16
 msgid "Spiral"
 msgstr ""
@@ -13385,24 +13511,24 @@ msgid "with %3f turns"
 msgstr ""
 
 #. Star
-#: ../src/sp-star.cpp:245 ../src/ui/dialog/inkscape-preferences.cpp:411
-#: ../src/widgets/star-toolbar.cpp:467
+#: ../src/sp-star.cpp:246 ../src/ui/dialog/inkscape-preferences.cpp:451
+#: ../src/widgets/star-toolbar.cpp:479
 msgid "Star"
 msgstr ""
 
-#: ../src/sp-star.cpp:246 ../src/widgets/star-toolbar.cpp:460
+#: ../src/sp-star.cpp:247 ../src/widgets/star-toolbar.cpp:472
 msgid "Polygon"
 msgstr ""
 
 #. while there will never be less than 3 vertices, we still need to
 #. make calls to ngettext because the pluralization may be different
 #. for various numbers >=3.  The singular form is used as the index.
-#: ../src/sp-star.cpp:253
+#: ../src/sp-star.cpp:254
 #, c-format
 msgid "with %d vertex"
 msgstr ""
 
-#: ../src/sp-star.cpp:253
+#: ../src/sp-star.cpp:254
 #, c-format
 msgid "with %d vertices"
 msgstr ""
@@ -13411,7 +13537,7 @@ msgstr ""
 msgid "Conditional Group"
 msgstr ""
 
-#: ../src/sp-text.cpp:349 ../src/verbs.cpp:342
+#: ../src/sp-text.cpp:320 ../src/verbs.cpp:345
 #: ../share/extensions/lorem_ipsum.inx.h:8
 #: ../share/extensions/replace_font.inx.h:11 ../share/extensions/split.inx.h:10
 #: ../share/extensions/text_braille.inx.h:2
@@ -13426,12 +13552,12 @@ msgstr ""
 msgid "Text"
 msgstr ""
 
-#: ../src/sp-text.cpp:372
+#: ../src/sp-text.cpp:343
 #, c-format
 msgid "on path%s (%s, %s)"
 msgstr ""
 
-#: ../src/sp-text.cpp:373
+#: ../src/sp-text.cpp:344
 #, c-format
 msgid "%s (%s, %s)"
 msgstr ""
@@ -13444,38 +13570,38 @@ msgstr ""
 msgid " from "
 msgstr ""
 
-#: ../src/sp-tref.cpp:237 ../src/sp-use.cpp:272
+#: ../src/sp-tref.cpp:237 ../src/sp-use.cpp:269
 msgid "[orphaned]"
 msgstr ""
 
-#: ../src/sp-tspan.cpp:215
+#: ../src/sp-tspan.cpp:214
 msgid "Text Span"
 msgstr ""
 
-#: ../src/sp-use.cpp:235
+#: ../src/sp-use.cpp:232
 msgid "Symbol"
 msgstr ""
 
-#: ../src/sp-use.cpp:237
+#: ../src/sp-use.cpp:234
 msgid "Clone"
 msgstr ""
 
-#: ../src/sp-use.cpp:245 ../src/sp-use.cpp:247 ../src/sp-use.cpp:249
+#: ../src/sp-use.cpp:242 ../src/sp-use.cpp:244 ../src/sp-use.cpp:246
 #, c-format
 msgid "called %s"
 msgstr ""
 
-#: ../src/sp-use.cpp:249
+#: ../src/sp-use.cpp:246
 msgid "Unnamed Symbol"
 msgstr ""
 
 #. TRANSLATORS: Used for statusbar description for long <use> chains:
 #. * "Clone of: Clone of: ... in Layer 1".
-#: ../src/sp-use.cpp:258
+#: ../src/sp-use.cpp:255
 msgid "..."
 msgstr ""
 
-#: ../src/sp-use.cpp:267
+#: ../src/sp-use.cpp:264
 #, c-format
 msgid "of: %s"
 msgstr ""
@@ -13515,70 +13641,70 @@ msgid ""
 "difference, XOR, division, or path cut."
 msgstr ""
 
-#: ../src/splivarot.cpp:1663
+#: ../src/splivarot.cpp:1667
 msgid "Select <b>stroked path(s)</b> to convert stroke to path."
 msgstr ""
 
-#: ../src/splivarot.cpp:1679
+#: ../src/splivarot.cpp:1683
 msgid "Convert stroke to path"
 msgstr ""
 
 #. TRANSLATORS: "to outline" means "to convert stroke to path"
-#: ../src/splivarot.cpp:1682
+#: ../src/splivarot.cpp:1686
 msgid "<b>No stroked paths</b> in the selection."
 msgstr ""
 
-#: ../src/splivarot.cpp:1753
+#: ../src/splivarot.cpp:1757
 msgid "Selected object is <b>not a path</b>, cannot inset/outset."
 msgstr ""
 
-#: ../src/splivarot.cpp:1844 ../src/splivarot.cpp:1911
+#: ../src/splivarot.cpp:1848 ../src/splivarot.cpp:1915
 msgid "Create linked offset"
 msgstr ""
 
-#: ../src/splivarot.cpp:1845 ../src/splivarot.cpp:1912
+#: ../src/splivarot.cpp:1849 ../src/splivarot.cpp:1916
 msgid "Create dynamic offset"
 msgstr ""
 
-#: ../src/splivarot.cpp:1937
+#: ../src/splivarot.cpp:1941
 msgid "Select <b>path(s)</b> to inset/outset."
 msgstr ""
 
-#: ../src/splivarot.cpp:2122
+#: ../src/splivarot.cpp:2126
 msgid "Outset path"
 msgstr ""
 
-#: ../src/splivarot.cpp:2122
+#: ../src/splivarot.cpp:2126
 msgid "Inset path"
 msgstr ""
 
-#: ../src/splivarot.cpp:2124
+#: ../src/splivarot.cpp:2128
 msgid "<b>No paths</b> to inset/outset in the selection."
 msgstr ""
 
-#: ../src/splivarot.cpp:2286
+#: ../src/splivarot.cpp:2290
 msgid "Simplifying paths (separately):"
 msgstr ""
 
-#: ../src/splivarot.cpp:2288
+#: ../src/splivarot.cpp:2292
 msgid "Simplifying paths:"
 msgstr ""
 
-#: ../src/splivarot.cpp:2325
+#: ../src/splivarot.cpp:2329
 #, c-format
 msgid "%s <b>%d</b> of <b>%d</b> paths simplified..."
 msgstr ""
 
-#: ../src/splivarot.cpp:2338
+#: ../src/splivarot.cpp:2342
 #, c-format
 msgid "<b>%d</b> paths simplified."
 msgstr ""
 
-#: ../src/splivarot.cpp:2352
+#: ../src/splivarot.cpp:2356
 msgid "Select <b>path(s)</b> to simplify."
 msgstr ""
 
-#: ../src/splivarot.cpp:2368
+#: ../src/splivarot.cpp:2372
 msgid "<b>No paths</b> to simplify in the selection."
 msgstr ""
 
@@ -13603,61 +13729,61 @@ msgstr ""
 msgid "The flowed text(s) must be <b>visible</b> in order to be put on a path."
 msgstr ""
 
-#: ../src/text-chemistry.cpp:181 ../src/verbs.cpp:2716
+#: ../src/text-chemistry.cpp:181 ../src/verbs.cpp:2746
 msgid "Put text on path"
 msgstr ""
 
-#: ../src/text-chemistry.cpp:193
+#: ../src/text-chemistry.cpp:192
 msgid "Select <b>a text on path</b> to remove it from path."
 msgstr ""
 
-#: ../src/text-chemistry.cpp:212
+#: ../src/text-chemistry.cpp:211
 msgid "<b>No texts-on-paths</b> in the selection."
 msgstr ""
 
-#: ../src/text-chemistry.cpp:215 ../src/verbs.cpp:2718
+#: ../src/text-chemistry.cpp:214 ../src/verbs.cpp:2748
 msgid "Remove text from path"
 msgstr ""
 
-#: ../src/text-chemistry.cpp:257 ../src/text-chemistry.cpp:277
+#: ../src/text-chemistry.cpp:256 ../src/text-chemistry.cpp:276
 msgid "Select <b>text(s)</b> to remove kerns from."
 msgstr ""
 
-#: ../src/text-chemistry.cpp:280
+#: ../src/text-chemistry.cpp:279
 msgid "Remove manual kerns"
 msgstr ""
 
-#: ../src/text-chemistry.cpp:300
+#: ../src/text-chemistry.cpp:299
 msgid ""
 "Select <b>a text</b> and one or more <b>paths or shapes</b> to flow text "
 "into frame."
 msgstr ""
 
-#: ../src/text-chemistry.cpp:369
+#: ../src/text-chemistry.cpp:368
 msgid "Flow text into shape"
 msgstr ""
 
-#: ../src/text-chemistry.cpp:391
+#: ../src/text-chemistry.cpp:390
 msgid "Select <b>a flowed text</b> to unflow it."
 msgstr ""
 
-#: ../src/text-chemistry.cpp:464
+#: ../src/text-chemistry.cpp:461
 msgid "Unflow flowed text"
 msgstr ""
 
-#: ../src/text-chemistry.cpp:476
+#: ../src/text-chemistry.cpp:473
 msgid "Select <b>flowed text(s)</b> to convert."
 msgstr ""
 
-#: ../src/text-chemistry.cpp:494
+#: ../src/text-chemistry.cpp:491
 msgid "The flowed text(s) must be <b>visible</b> in order to be converted."
 msgstr ""
 
-#: ../src/text-chemistry.cpp:521
+#: ../src/text-chemistry.cpp:518
 msgid "Convert flowed text to text"
 msgstr ""
 
-#: ../src/text-chemistry.cpp:526
+#: ../src/text-chemistry.cpp:523
 msgid "<b>No flowed text(s)</b> to convert in the selection."
 msgstr ""
 
@@ -13716,42 +13842,46 @@ msgid "Trace: Done. %ld nodes created"
 msgstr ""
 
 #. check whether something is selected
-#: ../src/ui/clipboard.cpp:258
+#: ../src/ui/clipboard.cpp:259
 msgid "Nothing was copied."
 msgstr ""
 
-#: ../src/ui/clipboard.cpp:389 ../src/ui/clipboard.cpp:604
-#: ../src/ui/clipboard.cpp:633
+#: ../src/ui/clipboard.cpp:390 ../src/ui/clipboard.cpp:605
+#: ../src/ui/clipboard.cpp:634 ../src/ui/clipboard.cpp:666
 msgid "Nothing on the clipboard."
 msgstr ""
 
-#: ../src/ui/clipboard.cpp:446
+#: ../src/ui/clipboard.cpp:447
 msgid "Select <b>object(s)</b> to paste style to."
 msgstr ""
 
-#: ../src/ui/clipboard.cpp:457 ../src/ui/clipboard.cpp:474
+#: ../src/ui/clipboard.cpp:458 ../src/ui/clipboard.cpp:475
 msgid "No style on the clipboard."
 msgstr ""
 
-#: ../src/ui/clipboard.cpp:500
+#: ../src/ui/clipboard.cpp:501
 msgid "Select <b>object(s)</b> to paste size to."
 msgstr ""
 
-#: ../src/ui/clipboard.cpp:508
+#: ../src/ui/clipboard.cpp:509
 msgid "No size on the clipboard."
 msgstr ""
 
-#: ../src/ui/clipboard.cpp:565
+#: ../src/ui/clipboard.cpp:566
 msgid "Select <b>object(s)</b> to paste live path effect to."
 msgstr ""
 
 #. no_effect:
-#: ../src/ui/clipboard.cpp:591
+#: ../src/ui/clipboard.cpp:592
 msgid "No effect on the clipboard."
 msgstr ""
 
-#: ../src/ui/clipboard.cpp:610 ../src/ui/clipboard.cpp:647
+#: ../src/ui/clipboard.cpp:611 ../src/ui/clipboard.cpp:648
 msgid "Clipboard does not contain a path."
+msgstr ""
+
+#: ../src/ui/clipboard.cpp:697
+msgid "Clipboard does not contain any."
 msgstr ""
 
 #: ../src/ui/contextmenu.cpp:58
@@ -13788,7 +13918,7 @@ msgid "_Pop selection out of group"
 msgstr ""
 
 #. Item dialog
-#: ../src/ui/contextmenu.cpp:323 ../src/verbs.cpp:3118
+#: ../src/ui/contextmenu.cpp:323 ../src/verbs.cpp:3152
 msgid "_Object Properties..."
 msgstr ""
 
@@ -13836,7 +13966,7 @@ msgid "Create _Link"
 msgstr ""
 
 #. Set mask
-#: ../src/ui/contextmenu.cpp:421 ../src/ui/dialog/objects.cpp:1956
+#: ../src/ui/contextmenu.cpp:421 ../src/ui/dialog/objects.cpp:1918
 msgid "Set Mask"
 msgstr ""
 
@@ -13861,7 +13991,7 @@ msgid "Release C_lip"
 msgstr ""
 
 #. Group
-#: ../src/ui/contextmenu.cpp:472 ../src/verbs.cpp:2708
+#: ../src/ui/contextmenu.cpp:472 ../src/verbs.cpp:2738
 msgid "_Group"
 msgstr ""
 
@@ -13870,7 +14000,7 @@ msgid "Create link"
 msgstr ""
 
 #. Ungroup
-#: ../src/ui/contextmenu.cpp:578 ../src/verbs.cpp:2710
+#: ../src/ui/contextmenu.cpp:578 ../src/verbs.cpp:2740
 msgid "_Ungroup"
 msgstr ""
 
@@ -13905,7 +14035,7 @@ msgstr ""
 
 #. Trace Bitmap
 #. TRANSLATORS: "to trace" means "to convert a bitmap to vector graphics" (to vectorize)
-#: ../src/ui/contextmenu.cpp:676 ../src/verbs.cpp:2789
+#: ../src/ui/contextmenu.cpp:676 ../src/verbs.cpp:2819
 msgid "_Trace Bitmap..."
 msgstr ""
 
@@ -13927,41 +14057,32 @@ msgstr ""
 #. Item dialog
 #. Fill and Stroke dialog
 #: ../src/ui/contextmenu.cpp:850 ../src/ui/contextmenu.cpp:870
-#: ../src/verbs.cpp:3081
+#: ../src/verbs.cpp:3115
 msgid "_Fill and Stroke..."
 msgstr ""
 
 #. Edit Text dialog
-#: ../src/ui/contextmenu.cpp:876 ../src/verbs.cpp:3100
+#: ../src/ui/contextmenu.cpp:876 ../src/verbs.cpp:3134
 msgid "_Text and Font..."
 msgstr ""
 
 #. Spellcheck dialog
-#: ../src/ui/contextmenu.cpp:882 ../src/verbs.cpp:3108
+#: ../src/ui/contextmenu.cpp:882 ../src/verbs.cpp:3142
 msgid "Check Spellin_g..."
 msgstr ""
 
-#. *
-#. * Constructor
-#.
-#: ../src/ui/dialog/aboutbox.cpp:77
-msgid "About Inkscape"
+#: ../src/ui/dialog/aboutbox.cpp:87
+msgid "Inkscape website"
 msgstr ""
 
-#: ../src/ui/dialog/aboutbox.cpp:88
-msgid "_Splash"
+#: ../src/ui/dialog/aboutbox.cpp:89
+msgid "© 2017 Inkscape Developers"
 msgstr ""
 
-#: ../src/ui/dialog/aboutbox.cpp:92
-msgid "_Authors"
-msgstr ""
-
-#: ../src/ui/dialog/aboutbox.cpp:94
-msgid "_Translators"
-msgstr ""
-
-#: ../src/ui/dialog/aboutbox.cpp:96
-msgid "_License"
+#: ../src/ui/dialog/aboutbox.cpp:90
+msgid ""
+"Open Source Scalable Vector Graphics Editor\n"
+"Draw Freely."
 msgstr ""
 
 #. TRANSLATORS: This is the filename of the `About Inkscape' picture in
@@ -13969,16 +14090,20 @@ msgstr ""
 #. the filename of its translated version, e.g. about.zh.svg for Chinese.
 #.
 #. Please don't translate the filename unless the translated picture exists.
+#. Try to get the translated version of the 'About Inkscape' file first.  If the
+#. translation fails, or if the file does not exist, then fall-back to the
+#. default untranslated "about.svg" file
+#.
 #. FIXME? INKSCAPE_SCREENSDIR and "about.svg" are in UTF-8, not the
 #. native filename encoding... and the filename passed to sp_document_new
 #. should be in UTF-*8..
-#: ../src/ui/dialog/aboutbox.cpp:188
+#: ../src/ui/dialog/aboutbox.cpp:111
 msgid "about.svg"
 msgstr ""
 
 #. TRANSLATORS: Put here your name (and other national contributors')
 #. one per line in the form of: name surname (email). Use \n for newline.
-#: ../src/ui/dialog/aboutbox.cpp:458
+#: ../src/ui/dialog/aboutbox.cpp:179
 msgid "translator-credits"
 msgstr ""
 
@@ -14014,7 +14139,7 @@ msgstr ""
 
 #: ../src/ui/dialog/align-and-distribute.cpp:488
 #: ../src/ui/dialog/align-and-distribute.cpp:918
-#: ../src/widgets/connector-toolbar.cpp:404
+#: ../src/widgets/connector-toolbar.cpp:407
 msgid "Remove overlaps"
 msgstr ""
 
@@ -14048,7 +14173,7 @@ msgid "Rearrange"
 msgstr ""
 
 #: ../src/ui/dialog/align-and-distribute.cpp:919
-#: ../src/widgets/toolbox.cpp:1291
+#: ../src/widgets/toolbox.cpp:1294
 msgid "Nodes"
 msgstr ""
 
@@ -14062,53 +14187,53 @@ msgid "_Treat selection as group: "
 msgstr ""
 
 #. Align
-#: ../src/ui/dialog/align-and-distribute.cpp:933 ../src/verbs.cpp:3218
-#: ../src/verbs.cpp:3219
+#: ../src/ui/dialog/align-and-distribute.cpp:933 ../src/verbs.cpp:3252
+#: ../src/verbs.cpp:3253
 msgid "Align right edges of objects to the left edge of the anchor"
 msgstr ""
 
-#: ../src/ui/dialog/align-and-distribute.cpp:936 ../src/verbs.cpp:3220
-#: ../src/verbs.cpp:3221
+#: ../src/ui/dialog/align-and-distribute.cpp:936 ../src/verbs.cpp:3254
+#: ../src/verbs.cpp:3255
 msgid "Align left edges"
 msgstr ""
 
-#: ../src/ui/dialog/align-and-distribute.cpp:939 ../src/verbs.cpp:3222
-#: ../src/verbs.cpp:3223
+#: ../src/ui/dialog/align-and-distribute.cpp:939 ../src/verbs.cpp:3256
+#: ../src/verbs.cpp:3257
 msgid "Center on vertical axis"
 msgstr ""
 
-#: ../src/ui/dialog/align-and-distribute.cpp:942 ../src/verbs.cpp:3224
-#: ../src/verbs.cpp:3225
+#: ../src/ui/dialog/align-and-distribute.cpp:942 ../src/verbs.cpp:3258
+#: ../src/verbs.cpp:3259
 msgid "Align right sides"
 msgstr ""
 
-#: ../src/ui/dialog/align-and-distribute.cpp:945 ../src/verbs.cpp:3226
-#: ../src/verbs.cpp:3227
+#: ../src/ui/dialog/align-and-distribute.cpp:945 ../src/verbs.cpp:3260
+#: ../src/verbs.cpp:3261
 msgid "Align left edges of objects to the right edge of the anchor"
 msgstr ""
 
-#: ../src/ui/dialog/align-and-distribute.cpp:948 ../src/verbs.cpp:3228
-#: ../src/verbs.cpp:3229
+#: ../src/ui/dialog/align-and-distribute.cpp:948 ../src/verbs.cpp:3262
+#: ../src/verbs.cpp:3263
 msgid "Align bottom edges of objects to the top edge of the anchor"
 msgstr ""
 
-#: ../src/ui/dialog/align-and-distribute.cpp:951 ../src/verbs.cpp:3230
-#: ../src/verbs.cpp:3231
+#: ../src/ui/dialog/align-and-distribute.cpp:951 ../src/verbs.cpp:3264
+#: ../src/verbs.cpp:3265
 msgid "Align top edges"
 msgstr ""
 
-#: ../src/ui/dialog/align-and-distribute.cpp:954 ../src/verbs.cpp:3232
-#: ../src/verbs.cpp:3233
+#: ../src/ui/dialog/align-and-distribute.cpp:954 ../src/verbs.cpp:3266
+#: ../src/verbs.cpp:3267
 msgid "Center on horizontal axis"
 msgstr ""
 
-#: ../src/ui/dialog/align-and-distribute.cpp:957 ../src/verbs.cpp:3234
-#: ../src/verbs.cpp:3235
+#: ../src/ui/dialog/align-and-distribute.cpp:957 ../src/verbs.cpp:3268
+#: ../src/verbs.cpp:3269
 msgid "Align bottom edges"
 msgstr ""
 
-#: ../src/ui/dialog/align-and-distribute.cpp:960 ../src/verbs.cpp:3236
-#: ../src/verbs.cpp:3237
+#: ../src/ui/dialog/align-and-distribute.cpp:960 ../src/verbs.cpp:3270
+#: ../src/verbs.cpp:3271
 msgid "Align top edges of objects to the bottom edge of the anchor"
 msgstr ""
 
@@ -14161,7 +14286,7 @@ msgid "Distribute baselines of texts vertically"
 msgstr ""
 
 #: ../src/ui/dialog/align-and-distribute.cpp:1011
-#: ../src/widgets/connector-toolbar.cpp:366
+#: ../src/widgets/connector-toolbar.cpp:369
 msgid "Nicely arrange selected connector network"
 msgstr ""
 
@@ -14228,8 +14353,8 @@ msgstr ""
 
 #: ../src/ui/dialog/align-and-distribute.cpp:1059
 #: ../src/ui/dialog/document-properties.cpp:145
-#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:1486
-#: ../src/widgets/desktop-widget.cpp:1984
+#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:1489
+#: ../src/widgets/desktop-widget.cpp:1997
 #: ../share/extensions/empty_page.inx.h:1
 #: ../share/extensions/voronoi2svg.inx.h:10
 msgid "Page"
@@ -14261,16 +14386,16 @@ msgid "Profile name:"
 msgstr ""
 
 #: ../src/ui/dialog/calligraphic-profile-rename.cpp:54
-#: ../src/ui/dialog/guides.cpp:160 ../src/verbs.cpp:2627
+#: ../src/ui/dialog/guides.cpp:160 ../src/verbs.cpp:2657
 msgid "_Delete"
 msgstr ""
 
 #: ../src/ui/dialog/calligraphic-profile-rename.cpp:59
-#: ../src/ui/dialog/export.cpp:1300
-#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:1053
-#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:1600
-#: ../src/ui/dialog/input.cpp:914 ../src/verbs.cpp:2565
-#: ../src/widgets/desktop-widget.cpp:1090
+#: ../src/ui/dialog/export.cpp:1297
+#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:1043
+#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:1603
+#: ../src/ui/dialog/input.cpp:915 ../src/verbs.cpp:2595
+#: ../src/widgets/desktop-widget.cpp:1103
 msgid "_Save"
 msgstr ""
 
@@ -14932,15 +15057,15 @@ msgstr ""
 msgid "<small>Object has no tiled clones.</small>"
 msgstr ""
 
-#: ../src/ui/dialog/clonetiler.cpp:1939
+#: ../src/ui/dialog/clonetiler.cpp:1941
 msgid "Select <b>one object</b> whose tiled clones to unclump."
 msgstr ""
 
-#: ../src/ui/dialog/clonetiler.cpp:1959
+#: ../src/ui/dialog/clonetiler.cpp:1961
 msgid "Unclump tiled clones"
 msgstr ""
 
-#: ../src/ui/dialog/clonetiler.cpp:1988
+#: ../src/ui/dialog/clonetiler.cpp:1990
 msgid "Select <b>one object</b> whose tiled clones to remove."
 msgstr ""
 
@@ -14963,15 +15088,15 @@ msgstr ""
 msgid "Create tiled clones"
 msgstr ""
 
-#: ../src/ui/dialog/clonetiler.cpp:2683
+#: ../src/ui/dialog/clonetiler.cpp:2682
 msgid "<small>Per row:</small>"
 msgstr ""
 
-#: ../src/ui/dialog/clonetiler.cpp:2697
+#: ../src/ui/dialog/clonetiler.cpp:2696
 msgid "<small>Per column:</small>"
 msgstr ""
 
-#: ../src/ui/dialog/clonetiler.cpp:2705
+#: ../src/ui/dialog/clonetiler.cpp:2704
 msgid "<small>Randomize:</small>"
 msgstr ""
 
@@ -15032,12 +15157,12 @@ msgid "License"
 msgstr ""
 
 #: ../src/ui/dialog/document-metadata.cpp:115
-#: ../src/ui/dialog/document-properties.cpp:958
+#: ../src/ui/dialog/document-properties.cpp:970
 msgid "<b>Dublin Core Entities</b>"
 msgstr ""
 
 #: ../src/ui/dialog/document-metadata.cpp:147
-#: ../src/ui/dialog/document-properties.cpp:1004
+#: ../src/ui/dialog/document-properties.cpp:1016
 msgid "<b>License</b>"
 msgstr ""
 
@@ -15272,11 +15397,11 @@ msgstr ""
 msgid "Remove selected grid."
 msgstr ""
 
-#: ../src/ui/dialog/document-properties.cpp:146 ../src/widgets/toolbox.cpp:1398
+#: ../src/ui/dialog/document-properties.cpp:146 ../src/widgets/toolbox.cpp:1401
 msgid "Guides"
 msgstr ""
 
-#: ../src/ui/dialog/document-properties.cpp:148 ../src/verbs.cpp:3030
+#: ../src/ui/dialog/document-properties.cpp:148 ../src/verbs.cpp:3064
 msgid "Snap"
 msgstr ""
 
@@ -15328,373 +15453,374 @@ msgstr ""
 #. Inkscape::GC::release(defsRepr);
 #. inform the document, so we can undo
 #. Color Management
-#: ../src/ui/dialog/document-properties.cpp:520 ../src/verbs.cpp:3202
+#: ../src/ui/dialog/document-properties.cpp:520 ../src/verbs.cpp:3236
 msgid "Link Color Profile"
 msgstr ""
 
-#: ../src/ui/dialog/document-properties.cpp:587
-#: ../src/ui/dialog/document-properties.cpp:597
-#: ../src/ui/dialog/document-properties.cpp:606
-#: ../src/ui/dialog/filter-effects-dialog.cpp:1308
-#: ../src/ui/dialog/svg-fonts-dialog.cpp:299
-#: ../src/ui/dialog/svg-fonts-dialog.cpp:308
-#: ../src/ui/dialog/svg-fonts-dialog.cpp:317
+#: ../src/ui/dialog/document-properties.cpp:599
+#: ../src/ui/dialog/document-properties.cpp:609
+#: ../src/ui/dialog/document-properties.cpp:618
+#: ../src/ui/dialog/filter-effects-dialog.cpp:1314
+#: ../src/ui/dialog/svg-fonts-dialog.cpp:311
+#: ../src/ui/dialog/svg-fonts-dialog.cpp:320
+#: ../src/ui/dialog/svg-fonts-dialog.cpp:329
 msgid "_Remove"
 msgstr ""
 
-#: ../src/ui/dialog/document-properties.cpp:639
+#: ../src/ui/dialog/document-properties.cpp:651
 msgid "Remove linked color profile"
 msgstr ""
 
-#: ../src/ui/dialog/document-properties.cpp:658
+#: ../src/ui/dialog/document-properties.cpp:670
 msgid "<b>Linked Color Profiles:</b>"
 msgstr ""
 
-#: ../src/ui/dialog/document-properties.cpp:660
+#: ../src/ui/dialog/document-properties.cpp:672
 msgid "<b>Available Color Profiles:</b>"
 msgstr ""
 
-#: ../src/ui/dialog/document-properties.cpp:662
+#: ../src/ui/dialog/document-properties.cpp:674
 msgid "Link Profile"
 msgstr ""
 
-#: ../src/ui/dialog/document-properties.cpp:665
+#: ../src/ui/dialog/document-properties.cpp:677
 msgid "Unlink Profile"
 msgstr ""
 
-#: ../src/ui/dialog/document-properties.cpp:730
+#: ../src/ui/dialog/document-properties.cpp:742
 msgid "Profile Name"
 msgstr ""
 
-#: ../src/ui/dialog/document-properties.cpp:766
+#: ../src/ui/dialog/document-properties.cpp:778
 msgid "External scripts"
 msgstr ""
 
-#: ../src/ui/dialog/document-properties.cpp:767
+#: ../src/ui/dialog/document-properties.cpp:779
 msgid "Embedded scripts"
 msgstr ""
 
-#: ../src/ui/dialog/document-properties.cpp:772
+#: ../src/ui/dialog/document-properties.cpp:784
 msgid "<b>External script files:</b>"
 msgstr ""
 
-#: ../src/ui/dialog/document-properties.cpp:774
+#: ../src/ui/dialog/document-properties.cpp:786
 msgid "Add the current file name or browse for a file"
 msgstr ""
 
-#: ../src/ui/dialog/document-properties.cpp:777
-#: ../src/ui/dialog/document-properties.cpp:842
-#: ../src/ui/widget/selected-style.cpp:361
+#: ../src/ui/dialog/document-properties.cpp:789
+#: ../src/ui/dialog/document-properties.cpp:854
+#: ../src/ui/widget/selected-style.cpp:359
 msgid "Remove"
 msgstr ""
 
-#: ../src/ui/dialog/document-properties.cpp:829
+#: ../src/ui/dialog/document-properties.cpp:841
 msgid "Filename"
 msgstr ""
 
-#: ../src/ui/dialog/document-properties.cpp:837
+#: ../src/ui/dialog/document-properties.cpp:849
 msgid "<b>Embedded script files:</b>"
 msgstr ""
 
-#: ../src/ui/dialog/document-properties.cpp:839
-#: ../src/ui/dialog/objects.cpp:1920
+#. Name
+#: ../src/ui/dialog/document-properties.cpp:851
+#: ../src/ui/dialog/objects.cpp:1882 ../src/widgets/gradient-toolbar.cpp:875
 msgid "New"
 msgstr ""
 
-#: ../src/ui/dialog/document-properties.cpp:882
+#: ../src/ui/dialog/document-properties.cpp:894
 msgid "Script id"
 msgstr ""
 
-#: ../src/ui/dialog/document-properties.cpp:888
+#: ../src/ui/dialog/document-properties.cpp:900
 msgid "<b>Content:</b>"
 msgstr ""
 
-#: ../src/ui/dialog/document-properties.cpp:984
+#: ../src/ui/dialog/document-properties.cpp:996
 msgid "_Save as default"
 msgstr ""
 
-#: ../src/ui/dialog/document-properties.cpp:985
+#: ../src/ui/dialog/document-properties.cpp:997
 msgid "Save this metadata as the default metadata"
 msgstr ""
 
-#: ../src/ui/dialog/document-properties.cpp:986
+#: ../src/ui/dialog/document-properties.cpp:998
 msgid "Use _default"
 msgstr ""
 
-#: ../src/ui/dialog/document-properties.cpp:987
+#: ../src/ui/dialog/document-properties.cpp:999
 msgid "Use the previously saved default metadata here"
 msgstr ""
 
 #. inform the document, so we can undo
-#: ../src/ui/dialog/document-properties.cpp:1046
+#: ../src/ui/dialog/document-properties.cpp:1058
 msgid "Add external script..."
 msgstr ""
 
-#: ../src/ui/dialog/document-properties.cpp:1085
+#: ../src/ui/dialog/document-properties.cpp:1097
 msgid "Select a script to load"
 msgstr ""
 
 #. inform the document, so we can undo
-#: ../src/ui/dialog/document-properties.cpp:1113
+#: ../src/ui/dialog/document-properties.cpp:1125
 msgid "Add embedded script..."
 msgstr ""
 
 #. inform the document, so we can undo
-#: ../src/ui/dialog/document-properties.cpp:1144
+#: ../src/ui/dialog/document-properties.cpp:1156
 msgid "Remove external script"
 msgstr ""
 
 #. inform the document, so we can undo
-#: ../src/ui/dialog/document-properties.cpp:1173
+#: ../src/ui/dialog/document-properties.cpp:1185
 msgid "Remove embedded script"
 msgstr ""
 
 #. TODO repr->set_content(_EmbeddedContent.get_buffer()->get_text());
 #. inform the document, so we can undo
-#: ../src/ui/dialog/document-properties.cpp:1267
+#: ../src/ui/dialog/document-properties.cpp:1279
 msgid "Edit embedded script"
 msgstr ""
 
-#: ../src/ui/dialog/document-properties.cpp:1351
+#: ../src/ui/dialog/document-properties.cpp:1363
 msgid "<b>Creation</b>"
 msgstr ""
 
-#: ../src/ui/dialog/document-properties.cpp:1352
+#: ../src/ui/dialog/document-properties.cpp:1364
 msgid "<b>Defined grids</b>"
 msgstr ""
 
-#: ../src/ui/dialog/document-properties.cpp:1598
+#: ../src/ui/dialog/document-properties.cpp:1610
 msgid "Remove grid"
 msgstr ""
 
-#: ../src/ui/dialog/document-properties.cpp:1690
+#: ../src/ui/dialog/document-properties.cpp:1702
 msgid "Changed default display unit"
 msgstr ""
 
-#: ../src/ui/dialog/export.cpp:124 ../src/verbs.cpp:3005
+#: ../src/ui/dialog/export.cpp:120 ../src/verbs.cpp:3039
 msgid "_Page"
 msgstr ""
 
-#: ../src/ui/dialog/export.cpp:124 ../src/verbs.cpp:3009
+#: ../src/ui/dialog/export.cpp:120 ../src/verbs.cpp:3043
 msgid "_Drawing"
 msgstr ""
 
-#: ../src/ui/dialog/export.cpp:124 ../src/verbs.cpp:3011
+#: ../src/ui/dialog/export.cpp:120 ../src/verbs.cpp:3045
 msgid "_Selection"
 msgstr ""
 
-#: ../src/ui/dialog/export.cpp:124
+#: ../src/ui/dialog/export.cpp:120
 msgid "_Custom"
 msgstr ""
 
-#: ../src/ui/dialog/export.cpp:142 ../src/widgets/measure-toolbar.cpp:286
-#: ../src/widgets/measure-toolbar.cpp:294
+#: ../src/ui/dialog/export.cpp:138 ../src/widgets/measure-toolbar.cpp:304
+#: ../src/widgets/measure-toolbar.cpp:312
 #: ../share/extensions/render_gears.inx.h:6
 msgid "Units:"
 msgstr ""
 
-#: ../src/ui/dialog/export.cpp:144
+#: ../src/ui/dialog/export.cpp:140
 msgid "_Export As..."
 msgstr ""
 
-#: ../src/ui/dialog/export.cpp:147
+#: ../src/ui/dialog/export.cpp:143
 msgid "B_atch export all selected objects"
 msgstr ""
 
-#: ../src/ui/dialog/export.cpp:147
+#: ../src/ui/dialog/export.cpp:143
 msgid ""
 "Export each selected object into its own PNG file, using export hints if any "
 "(caution, overwrites without asking!)"
 msgstr ""
 
-#: ../src/ui/dialog/export.cpp:148
+#: ../src/ui/dialog/export.cpp:144
 msgid "Use interlacing"
 msgstr ""
 
-#: ../src/ui/dialog/export.cpp:148
+#: ../src/ui/dialog/export.cpp:144
 msgid ""
 "Enables ADAM7 interlacing for PNG output. This results in slightly heavier "
 "images, but big images will look better sooner when loading the file"
 msgstr ""
 
-#: ../src/ui/dialog/export.cpp:149
+#: ../src/ui/dialog/export.cpp:145
 msgid "Bit depth"
 msgstr ""
 
-#: ../src/ui/dialog/export.cpp:151
+#: ../src/ui/dialog/export.cpp:147
 msgid "Compression"
 msgstr ""
 
-#: ../src/ui/dialog/export.cpp:153
+#: ../src/ui/dialog/export.cpp:149
 msgid "pHYs dpi"
 msgstr ""
 
-#: ../src/ui/dialog/export.cpp:158
+#: ../src/ui/dialog/export.cpp:154
 msgid "Hide all except selected"
 msgstr ""
 
-#: ../src/ui/dialog/export.cpp:158
+#: ../src/ui/dialog/export.cpp:154
 msgid "In the exported image, hide all objects except those that are selected"
 msgstr ""
 
-#: ../src/ui/dialog/export.cpp:159
+#: ../src/ui/dialog/export.cpp:155
 msgid "Close when complete"
 msgstr ""
 
-#: ../src/ui/dialog/export.cpp:159
+#: ../src/ui/dialog/export.cpp:155
 msgid "Once the export completes, close this dialog"
 msgstr ""
 
-#: ../src/ui/dialog/export.cpp:177
+#: ../src/ui/dialog/export.cpp:173
 msgid "<b>Export area</b>"
 msgstr ""
 
-#: ../src/ui/dialog/export.cpp:210
+#: ../src/ui/dialog/export.cpp:206
 msgid "_x0:"
 msgstr ""
 
-#: ../src/ui/dialog/export.cpp:214
+#: ../src/ui/dialog/export.cpp:210
 msgid "x_1:"
 msgstr ""
 
-#: ../src/ui/dialog/export.cpp:218
+#: ../src/ui/dialog/export.cpp:214
 msgid "Wid_th:"
 msgstr ""
 
-#: ../src/ui/dialog/export.cpp:222
+#: ../src/ui/dialog/export.cpp:218
 msgid "_y0:"
 msgstr ""
 
-#: ../src/ui/dialog/export.cpp:226
+#: ../src/ui/dialog/export.cpp:222
 msgid "y_1:"
 msgstr ""
 
-#: ../src/ui/dialog/export.cpp:230
+#: ../src/ui/dialog/export.cpp:226
 msgid "Hei_ght:"
 msgstr ""
 
-#: ../src/ui/dialog/export.cpp:245
+#: ../src/ui/dialog/export.cpp:241
 msgid "<b>Image size</b>"
 msgstr ""
 
-#: ../src/ui/dialog/export.cpp:257 ../src/ui/dialog/export.cpp:268
+#: ../src/ui/dialog/export.cpp:253 ../src/ui/dialog/export.cpp:264
 msgid "pixels at"
 msgstr ""
 
-#: ../src/ui/dialog/export.cpp:263
+#: ../src/ui/dialog/export.cpp:259
 msgid "dp_i"
 msgstr ""
 
-#: ../src/ui/dialog/export.cpp:268 ../src/ui/dialog/transformation.cpp:69
+#: ../src/ui/dialog/export.cpp:264 ../src/ui/dialog/transformation.cpp:69
 #: ../src/ui/widget/page-sizer.cpp:221
 msgid "_Height:"
 msgstr ""
 
-#: ../src/ui/dialog/export.cpp:276
-#: ../src/ui/dialog/inkscape-preferences.cpp:1478
-#: ../src/ui/dialog/inkscape-preferences.cpp:1482
-#: ../src/ui/dialog/inkscape-preferences.cpp:1506
+#: ../src/ui/dialog/export.cpp:272
+#: ../src/ui/dialog/inkscape-preferences.cpp:1539
+#: ../src/ui/dialog/inkscape-preferences.cpp:1543
+#: ../src/ui/dialog/inkscape-preferences.cpp:1567
 msgid "dpi"
 msgstr ""
 
-#: ../src/ui/dialog/export.cpp:284
+#: ../src/ui/dialog/export.cpp:280
 msgid "<b>_Filename</b>"
 msgstr ""
 
-#: ../src/ui/dialog/export.cpp:322
+#: ../src/ui/dialog/export.cpp:318
 msgid "_Export"
 msgstr ""
 
-#: ../src/ui/dialog/export.cpp:324
+#: ../src/ui/dialog/export.cpp:320
 msgid "Export the bitmap file with these settings"
 msgstr ""
 
 #. Advanced
-#: ../src/ui/dialog/export.cpp:330
+#: ../src/ui/dialog/export.cpp:326
 msgid "Advanced"
 msgstr ""
 
-#: ../src/ui/dialog/export.cpp:344
+#: ../src/ui/dialog/export.cpp:340
 msgid ""
 "Will force-set the physical dpi for the png file. Set this to 72 if you're "
 "planning to work on your png with Photoshop"
 msgstr ""
 
-#: ../src/ui/dialog/export.cpp:484
+#: ../src/ui/dialog/export.cpp:480
 msgid "bitmap"
 msgstr ""
 
-#: ../src/ui/dialog/export.cpp:591
+#: ../src/ui/dialog/export.cpp:587
 #, c-format
 msgid "B_atch export %d selected object"
 msgid_plural "B_atch export %d selected objects"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ui/dialog/export.cpp:907
+#: ../src/ui/dialog/export.cpp:903
 msgid "Export in progress"
 msgstr ""
 
-#: ../src/ui/dialog/export.cpp:1008
+#: ../src/ui/dialog/export.cpp:1005
 msgid "No items selected."
 msgstr ""
 
-#: ../src/ui/dialog/export.cpp:1012 ../src/ui/dialog/export.cpp:1014
+#: ../src/ui/dialog/export.cpp:1009 ../src/ui/dialog/export.cpp:1011
 msgid "Exporting %1 files"
 msgstr ""
 
-#: ../src/ui/dialog/export.cpp:1056 ../src/ui/dialog/export.cpp:1058
+#: ../src/ui/dialog/export.cpp:1053 ../src/ui/dialog/export.cpp:1055
 #, c-format
 msgid "Exporting file <b>%s</b>..."
 msgstr ""
 
-#: ../src/ui/dialog/export.cpp:1069 ../src/ui/dialog/export.cpp:1164
+#: ../src/ui/dialog/export.cpp:1066 ../src/ui/dialog/export.cpp:1161
 #, c-format
 msgid "Could not export to filename %s.\n"
 msgstr ""
 
-#: ../src/ui/dialog/export.cpp:1072
+#: ../src/ui/dialog/export.cpp:1069
 #, c-format
 msgid "Could not export to filename <b>%s</b>."
 msgstr ""
 
-#: ../src/ui/dialog/export.cpp:1087
+#: ../src/ui/dialog/export.cpp:1084
 #, c-format
 msgid "Successfully exported <b>%d</b> files from <b>%d</b> selected items."
 msgstr ""
 
-#: ../src/ui/dialog/export.cpp:1098
+#: ../src/ui/dialog/export.cpp:1095
 msgid "You have to enter a filename."
 msgstr ""
 
-#: ../src/ui/dialog/export.cpp:1099
+#: ../src/ui/dialog/export.cpp:1096
 msgid "You have to enter a filename"
 msgstr ""
 
-#: ../src/ui/dialog/export.cpp:1114
+#: ../src/ui/dialog/export.cpp:1111
 msgid "The chosen area to be exported is invalid."
 msgstr ""
 
-#: ../src/ui/dialog/export.cpp:1115
+#: ../src/ui/dialog/export.cpp:1112
 msgid "The chosen area to be exported is invalid"
 msgstr ""
 
-#: ../src/ui/dialog/export.cpp:1130
+#: ../src/ui/dialog/export.cpp:1127
 #, c-format
 msgid "Directory %s does not exist or is not a directory.\n"
 msgstr ""
 
 #. TRANSLATORS: %1 will be the filename, %2 the width, and %3 the height of the image
-#: ../src/ui/dialog/export.cpp:1144 ../src/ui/dialog/export.cpp:1146
+#: ../src/ui/dialog/export.cpp:1141 ../src/ui/dialog/export.cpp:1143
 msgid "Exporting %1 (%2 x %3)"
 msgstr ""
 
-#: ../src/ui/dialog/export.cpp:1175
+#: ../src/ui/dialog/export.cpp:1172
 #, c-format
 msgid "Drawing exported to <b>%s</b>."
 msgstr ""
 
-#: ../src/ui/dialog/export.cpp:1179
+#: ../src/ui/dialog/export.cpp:1176
 msgid "Export aborted."
 msgstr ""
 
@@ -15702,8 +15828,8 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: ../src/ui/dialog/extension-editor.cpp:79 ../src/verbs.cpp:304
-#: ../src/verbs.cpp:323 ../share/extensions/color_HSL_adjust.inx.h:11
+#: ../src/ui/dialog/extension-editor.cpp:79 ../src/verbs.cpp:307
+#: ../src/verbs.cpp:326 ../share/extensions/color_HSL_adjust.inx.h:11
 #: ../share/extensions/color_custom.inx.h:7
 #: ../share/extensions/color_randomize.inx.h:11
 #: ../share/extensions/dots.inx.h:7
@@ -15723,7 +15849,7 @@ msgstr ""
 #: ../share/extensions/gcodetools_tools_library.inx.h:18
 #: ../share/extensions/generate_voronoi.inx.h:5
 #: ../share/extensions/gimp_xcf.inx.h:7
-#: ../share/extensions/interp_att_g.inx.h:29
+#: ../share/extensions/interp_att_g.inx.h:32
 #: ../share/extensions/jessyInk_autoTexts.inx.h:8
 #: ../share/extensions/jessyInk_effects.inx.h:13
 #: ../share/extensions/jessyInk_export.inx.h:7
@@ -15755,97 +15881,97 @@ msgstr ""
 msgid "Parameters"
 msgstr ""
 
-#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:531
+#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:527
 msgid "too large for preview"
 msgstr ""
 
-#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:617
+#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:613
 msgid "Enable preview"
 msgstr ""
 
-#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:739
+#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:729
 msgid "_Open"
 msgstr ""
 
-#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:760
-#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:772
-#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:774
-#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:781
-#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:795
+#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:750
+#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:762
+#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:764
+#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:771
+#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:785
 #: ../src/ui/dialog/filedialogimpl-win32.cpp:267
 #: ../src/ui/dialog/filedialogimpl-win32.cpp:398
 msgid "All Files"
 msgstr ""
 
-#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:778
-#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:792
+#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:768
+#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:782
 #: ../src/ui/dialog/filedialogimpl-win32.cpp:268
 msgid "All Inkscape Files"
 msgstr ""
 
-#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:785
-#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:798
+#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:775
+#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:788
 #: ../src/ui/dialog/filedialogimpl-win32.cpp:269
 msgid "All Images"
 msgstr ""
 
-#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:788
-#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:801
+#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:778
+#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:791
 #: ../src/ui/dialog/filedialogimpl-win32.cpp:270
 msgid "All Vectors"
 msgstr ""
 
-#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:791
-#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:804
+#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:781
+#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:794
 #: ../src/ui/dialog/filedialogimpl-win32.cpp:271
 msgid "All Bitmaps"
 msgstr ""
 
 #. ###### File options
 #. ###### Do we want the .xxx extension automatically added?
-#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:997
-#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:1549
+#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:985
+#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:1552
 msgid "Append filename extension automatically"
 msgstr ""
 
-#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:1164
-#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:1417
+#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:1171
+#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:1424
 msgid "Guess from extension"
 msgstr ""
 
-#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:1436
+#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:1443
 msgid "Left edge of source"
 msgstr ""
 
-#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:1437
+#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:1444
 msgid "Top edge of source"
 msgstr ""
 
-#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:1438
+#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:1445
 msgid "Right edge of source"
 msgstr ""
 
-#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:1439
+#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:1446
 msgid "Bottom edge of source"
 msgstr ""
 
-#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:1440
+#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:1447
 msgid "Source width"
 msgstr ""
 
-#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:1441
+#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:1448
 msgid "Source height"
 msgstr ""
 
-#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:1442
+#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:1449
 msgid "Destination width"
 msgstr ""
 
-#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:1443
+#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:1450
 msgid "Destination height"
 msgstr ""
 
-#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:1444
+#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:1451
 msgid "Resolution (dots per inch)"
 msgstr ""
 
@@ -15853,32 +15979,32 @@ msgstr ""
 #. ## EXTRA WIDGET -- SOURCE SIDE
 #. #########################################
 #. ##### Export options buttons/spinners, etc
-#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:1482
+#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:1485
 #: ../share/extensions/docinfo.inx.h:4 ../share/extensions/dpi90to96.inx.h:2
 #: ../share/extensions/dpi96to90.inx.h:2
 msgid "Document"
 msgstr ""
 
-#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:1490 ../src/verbs.cpp:170
-#: ../src/widgets/desktop-widget.cpp:1992
+#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:1493 ../src/verbs.cpp:173
+#: ../src/widgets/desktop-widget.cpp:2005
 #: ../share/extensions/printing_marks.inx.h:18
 msgid "Selection"
 msgstr ""
 
-#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:1494
+#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:1497
 msgctxt "Export dialog"
 msgid "Custom"
 msgstr ""
 
-#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:1514
+#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:1517
 msgid "Source"
 msgstr ""
 
-#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:1534
+#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:1537
 msgid "Cairo"
 msgstr ""
 
-#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:1537
+#: ../src/ui/dialog/filedialogimpl-gtkmm.cpp:1540
 msgid "Antialias"
 msgstr ""
 
@@ -15894,20 +16020,20 @@ msgstr ""
 msgid "No file selected"
 msgstr ""
 
-#: ../src/ui/dialog/fill-and-stroke.cpp:57
+#: ../src/ui/dialog/fill-and-stroke.cpp:59
 msgid "_Fill"
 msgstr ""
 
-#: ../src/ui/dialog/fill-and-stroke.cpp:58
+#: ../src/ui/dialog/fill-and-stroke.cpp:60
 msgid "Stroke _paint"
 msgstr ""
 
-#: ../src/ui/dialog/fill-and-stroke.cpp:59
+#: ../src/ui/dialog/fill-and-stroke.cpp:61
 msgid "Stroke st_yle"
 msgstr ""
 
 #. TRANSLATORS: this dialog is accessible via menu Filters - Filter editor
-#: ../src/ui/dialog/filter-effects-dialog.cpp:513
+#: ../src/ui/dialog/filter-effects-dialog.cpp:514
 msgid ""
 "This matrix determines a linear transform on color space. Each line affects "
 "one of the color components. Each column determines how much of each color "
@@ -15915,228 +16041,228 @@ msgid ""
 "depend on input colors, so can be used to adjust a constant component value."
 msgstr ""
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:516
+#: ../src/ui/dialog/filter-effects-dialog.cpp:517
 #: ../share/extensions/grid_polar.inx.h:4
 msgctxt "Label"
 msgid "None"
 msgstr ""
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:623
+#: ../src/ui/dialog/filter-effects-dialog.cpp:624
 msgid "Image File"
 msgstr ""
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:626
+#: ../src/ui/dialog/filter-effects-dialog.cpp:627
 msgid "Selected SVG Element"
 msgstr ""
 
 #. TODO: any image, not just svg
-#: ../src/ui/dialog/filter-effects-dialog.cpp:696
+#: ../src/ui/dialog/filter-effects-dialog.cpp:697
 msgid "Select an image to be used as feImage input"
 msgstr ""
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:788
+#: ../src/ui/dialog/filter-effects-dialog.cpp:789
 msgid "This SVG filter effect does not require any parameters."
 msgstr ""
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:794
+#: ../src/ui/dialog/filter-effects-dialog.cpp:795
 msgid "This SVG filter effect is not yet implemented in Inkscape."
 msgstr ""
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:1019
+#: ../src/ui/dialog/filter-effects-dialog.cpp:1025
 msgid "Slope"
 msgstr ""
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:1020
+#: ../src/ui/dialog/filter-effects-dialog.cpp:1026
 msgid "Intercept"
 msgstr ""
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:1023
+#: ../src/ui/dialog/filter-effects-dialog.cpp:1029
 msgid "Amplitude"
 msgstr ""
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:1024
+#: ../src/ui/dialog/filter-effects-dialog.cpp:1030
 msgid "Exponent"
 msgstr ""
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:1120
+#: ../src/ui/dialog/filter-effects-dialog.cpp:1126
 msgid "New transfer function type"
 msgstr ""
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:1155
+#: ../src/ui/dialog/filter-effects-dialog.cpp:1161
 msgid "Light Source:"
 msgstr ""
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:1172
+#: ../src/ui/dialog/filter-effects-dialog.cpp:1178
 msgid "Direction angle for the light source on the XY plane, in degrees"
 msgstr ""
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:1173
+#: ../src/ui/dialog/filter-effects-dialog.cpp:1179
 msgid "Direction angle for the light source on the YZ plane, in degrees"
 msgstr ""
 
 #. default x:
 #. default y:
 #. default z:
-#: ../src/ui/dialog/filter-effects-dialog.cpp:1176
-#: ../src/ui/dialog/filter-effects-dialog.cpp:1179
+#: ../src/ui/dialog/filter-effects-dialog.cpp:1182
+#: ../src/ui/dialog/filter-effects-dialog.cpp:1185
 msgid "Location:"
 msgstr ""
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:1176
-#: ../src/ui/dialog/filter-effects-dialog.cpp:1179
 #: ../src/ui/dialog/filter-effects-dialog.cpp:1182
+#: ../src/ui/dialog/filter-effects-dialog.cpp:1185
+#: ../src/ui/dialog/filter-effects-dialog.cpp:1188
 msgid "X coordinate"
 msgstr ""
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:1176
-#: ../src/ui/dialog/filter-effects-dialog.cpp:1179
 #: ../src/ui/dialog/filter-effects-dialog.cpp:1182
+#: ../src/ui/dialog/filter-effects-dialog.cpp:1185
+#: ../src/ui/dialog/filter-effects-dialog.cpp:1188
 msgid "Y coordinate"
 msgstr ""
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:1176
-#: ../src/ui/dialog/filter-effects-dialog.cpp:1179
 #: ../src/ui/dialog/filter-effects-dialog.cpp:1182
+#: ../src/ui/dialog/filter-effects-dialog.cpp:1185
+#: ../src/ui/dialog/filter-effects-dialog.cpp:1188
 msgid "Z coordinate"
 msgstr ""
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:1182
+#: ../src/ui/dialog/filter-effects-dialog.cpp:1188
 msgid "Points At"
 msgstr ""
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:1183
+#: ../src/ui/dialog/filter-effects-dialog.cpp:1189
 msgid "Specular Exponent"
 msgstr ""
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:1183
+#: ../src/ui/dialog/filter-effects-dialog.cpp:1189
 msgid "Exponent value controlling the focus for the light source"
 msgstr ""
 
 #. TODO: here I have used 100 degrees as default value. But spec says that if not specified, no limiting cone is applied. So, there should be a way for the user to set a "no limiting cone" option.
-#: ../src/ui/dialog/filter-effects-dialog.cpp:1185
+#: ../src/ui/dialog/filter-effects-dialog.cpp:1191
 msgid "Cone Angle"
 msgstr ""
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:1185
+#: ../src/ui/dialog/filter-effects-dialog.cpp:1191
 msgid ""
 "This is the angle between the spot light axis (i.e. the axis between the "
 "light source and the point to which it is pointing at) and the spot light "
 "cone. No light is projected outside this cone."
 msgstr ""
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:1251
+#: ../src/ui/dialog/filter-effects-dialog.cpp:1257
 msgid "New light source"
 msgstr ""
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:1303
+#: ../src/ui/dialog/filter-effects-dialog.cpp:1309
 msgid "_Duplicate"
 msgstr ""
 
 #. File
 #. Tag
-#: ../src/ui/dialog/filter-effects-dialog.cpp:1322
-#: ../src/ui/dialog/svg-fonts-dialog.cpp:987 ../src/verbs.cpp:2559
-#: ../src/verbs.cpp:2889
+#: ../src/ui/dialog/filter-effects-dialog.cpp:1328
+#: ../src/ui/dialog/svg-fonts-dialog.cpp:999 ../src/verbs.cpp:2589
+#: ../src/verbs.cpp:2923
 msgid "_New"
 msgstr ""
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:1337
+#: ../src/ui/dialog/filter-effects-dialog.cpp:1343
 msgid "_Filter"
 msgstr ""
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:1367
+#: ../src/ui/dialog/filter-effects-dialog.cpp:1373
 msgid "R_ename"
 msgstr ""
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:1501
+#: ../src/ui/dialog/filter-effects-dialog.cpp:1507
 msgid "Rename filter"
 msgstr ""
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:1553
+#: ../src/ui/dialog/filter-effects-dialog.cpp:1559
 msgid "Apply filter"
 msgstr ""
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:1633
+#: ../src/ui/dialog/filter-effects-dialog.cpp:1644
 msgid "filter"
 msgstr ""
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:1640
+#: ../src/ui/dialog/filter-effects-dialog.cpp:1651
 msgid "Add filter"
 msgstr ""
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:1690
+#: ../src/ui/dialog/filter-effects-dialog.cpp:1701
 msgid "Duplicate filter"
 msgstr ""
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:1762
+#: ../src/ui/dialog/filter-effects-dialog.cpp:1772
 msgid "_Effect"
 msgstr ""
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:1772
+#: ../src/ui/dialog/filter-effects-dialog.cpp:1782
 msgid "Connections"
 msgstr ""
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:1911
+#: ../src/ui/dialog/filter-effects-dialog.cpp:1921
 msgid "Remove filter primitive"
 msgstr ""
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2438
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2450
 msgid "Remove merge node"
 msgstr ""
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2560
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2577
 msgid "Reorder filter primitive"
 msgstr ""
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2615
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2632
 msgid "Add Effect:"
 msgstr ""
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2616
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2633
 msgid "No effect selected"
 msgstr ""
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2617
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2634
 msgid "No filter selected"
 msgstr ""
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2680
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2697
 msgid "Effect parameters"
 msgstr ""
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2681
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2698
 msgid "Filter General Settings"
 msgstr ""
 
 #. default x:
 #. default y:
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2741
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2758
 msgid "Coordinates:"
 msgstr ""
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2741
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2758
 msgid "X coordinate of the left corners of filter effects region"
 msgstr ""
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2741
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2758
 msgid "Y coordinate of the upper corners of filter effects region"
 msgstr ""
 
 #. default width:
 #. default height:
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2742
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2759
 msgid "Dimensions:"
 msgstr ""
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2742
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2759
 msgid "Width of filter effects region"
 msgstr ""
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2742
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2759
 msgid "Height of filter effects region"
 msgstr ""
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2748
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2765
 msgid ""
 "Indicates the type of matrix operation. The keyword 'matrix' indicates that "
 "a full 5x4 matrix of values will be provided. The other keywords represent "
@@ -16144,96 +16270,96 @@ msgid ""
 "performed without specifying a complete matrix."
 msgstr ""
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2749
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2766
 msgid "Value(s):"
 msgstr ""
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2753
-#: ../src/widgets/desktop-widget.cpp:648
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2770
+#: ../src/widgets/desktop-widget.cpp:662
 msgid "R:"
 msgstr ""
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2754
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2771
 #: ../src/ui/widget/color-icc-selector.cpp:158
 msgid "G:"
 msgstr ""
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2755
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2772
 msgid "B:"
 msgstr ""
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2756
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2773
 msgid "A:"
 msgstr ""
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2759
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2799
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2776
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2816
 msgid "Operator:"
 msgstr ""
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2760
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2777
 msgid "K1:"
 msgstr ""
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2760
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2761
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2762
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2763
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2777
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2778
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2779
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2780
 msgid ""
 "If the arithmetic operation is chosen, each result pixel is computed using "
 "the formula k1*i1*i2 + k2*i1 + k3*i2 + k4 where i1 and i2 are the pixel "
 "values of the first and second inputs respectively."
 msgstr ""
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2761
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2778
 msgid "K2:"
 msgstr ""
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2762
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2779
 msgid "K3:"
 msgstr ""
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2763
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2780
 msgid "K4:"
 msgstr ""
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2766
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2783
 msgid "Size:"
 msgstr ""
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2766
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2783
 msgid "width of the convolve matrix"
 msgstr ""
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2766
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2783
 msgid "height of the convolve matrix"
 msgstr ""
 
 #. default x:
 #. default y:
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2767
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2784
 #: ../src/ui/dialog/object-attributes.cpp:45
 msgid "Target:"
 msgstr ""
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2767
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2784
 msgid ""
 "X coordinate of the target point in the convolve matrix. The convolution is "
 "applied to pixels around this point."
 msgstr ""
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2767
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2784
 msgid ""
 "Y coordinate of the target point in the convolve matrix. The convolution is "
 "applied to pixels around this point."
 msgstr ""
 
 #. TRANSLATORS: for info on "Kernel", see http://en.wikipedia.org/wiki/Kernel_(matrix)
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2769
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2786
 msgid "Kernel:"
 msgstr ""
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2769
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2786
 msgid ""
 "This matrix describes the convolve operation that is applied to the input "
 "image in order to calculate the pixel colors at the output. Different "
@@ -16243,11 +16369,11 @@ msgid ""
 "would lead to a common blur effect."
 msgstr ""
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2771
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2788
 msgid "Divisor:"
 msgstr ""
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2771
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2788
 msgid ""
 "After applying the kernelMatrix to the input image to yield a number, that "
 "number is divided by divisor to yield the final destination color value. A "
@@ -16255,191 +16381,191 @@ msgid ""
 "effect on the overall color intensity of the result."
 msgstr ""
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2772
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2789
 msgid "Bias:"
 msgstr ""
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2772
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2789
 msgid ""
 "This value is added to each component. This is useful to define a constant "
 "value as the zero response of the filter."
 msgstr ""
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2773
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2790
 msgid "Edge Mode:"
 msgstr ""
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2773
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2790
 msgid ""
 "Determines how to extend the input image as necessary with color values so "
 "that the matrix operations can be applied when the kernel is positioned at "
 "or near the edge of the input image."
 msgstr ""
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2774
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2811
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2791
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2828
 msgid "Preserve Alpha"
 msgstr ""
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2774
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2811
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2791
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2828
 msgid "If set, the alpha channel won't be altered by this filter primitive."
 msgstr ""
 
 #. default: white
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2777
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2794
 msgid "Diffuse Color:"
 msgstr ""
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2777
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2816
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2794
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2833
 msgid "Defines the color of the light source"
 msgstr ""
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2778
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2817
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2795
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2834
 msgid "Surface Scale:"
 msgstr ""
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2778
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2817
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2795
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2834
 msgid ""
 "This value amplifies the heights of the bump map defined by the input alpha "
 "channel"
 msgstr ""
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2779
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2818
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2796
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2835
 msgid "Constant:"
 msgstr ""
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2779
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2818
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2796
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2835
 msgid "This constant affects the Phong lighting model."
 msgstr ""
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2780
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2820
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2797
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2837
 msgid "Kernel Unit Length:"
 msgstr ""
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2784
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2801
 msgid "This defines the intensity of the displacement effect."
 msgstr ""
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2785
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2802
 msgid "X displacement:"
 msgstr ""
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2785
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2802
 msgid "Color component that controls the displacement in the X direction"
 msgstr ""
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2786
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2803
 msgid "Y displacement:"
 msgstr ""
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2786
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2803
 msgid "Color component that controls the displacement in the Y direction"
 msgstr ""
 
 #. default: black
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2789
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2806
 msgid "Flood Color:"
 msgstr ""
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2789
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2806
 msgid "The whole filter region will be filled with this color."
 msgstr ""
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2793
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2810
 msgid "Standard Deviation:"
 msgstr ""
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2793
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2810
 msgid "The standard deviation for the blur operation."
 msgstr ""
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2799
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2816
 msgid ""
 "Erode: performs \"thinning\" of input image.\n"
 "Dilate: performs \"fattenning\" of input image."
 msgstr ""
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2803
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2820
 msgid "Source of Image:"
 msgstr ""
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2812
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2829
 msgid "Delta X:"
 msgstr ""
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2812
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2829
 msgid "This is how far the input image gets shifted to the right"
 msgstr ""
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2813
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2830
 msgid "Delta Y:"
 msgstr ""
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2813
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2830
 msgid "This is how far the input image gets shifted downwards"
 msgstr ""
 
 #. default: white
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2816
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2833
 msgid "Specular Color:"
 msgstr ""
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2819
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2836
 #: ../share/extensions/interp.inx.h:2
 msgid "Exponent:"
 msgstr ""
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2819
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2836
 msgid "Exponent for specular term, larger is more \"shiny\"."
 msgstr ""
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2828
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2845
 msgid ""
 "Indicates whether the filter primitive should perform a noise or turbulence "
 "function."
 msgstr ""
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2829
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2846
 msgid "Base Frequency:"
 msgstr ""
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2830
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2847
 msgid "Octaves:"
 msgstr ""
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2831
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2848
 msgid "Seed:"
 msgstr ""
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2831
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2848
 msgid "The starting number for the pseudo random number generator."
 msgstr ""
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2843
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2860
 msgid "Add filter primitive"
 msgstr ""
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2858
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2875
 msgid ""
 "The <b>feBlend</b> filter primitive provides 4 image blending modes: screen, "
 "multiply, darken and lighten."
 msgstr ""
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2862
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2879
 msgid ""
 "The <b>feColorMatrix</b> filter primitive applies a matrix transformation to "
 "color of each rendered pixel. This allows for effects like turning object to "
 "grayscale, modifying color saturation and changing color hue."
 msgstr ""
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2866
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2883
 msgid ""
 "The <b>feComponentTransfer</b> filter primitive manipulates the input's "
 "color components (red, green, blue, and alpha) according to particular "
@@ -16447,7 +16573,7 @@ msgid ""
 "adjustment, color balance, and thresholding."
 msgstr ""
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2870
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2887
 msgid ""
 "The <b>feComposite</b> filter primitive composites two images using one of "
 "the Porter-Duff blending modes or the arithmetic mode described in SVG "
@@ -16455,7 +16581,7 @@ msgid ""
 "between the corresponding pixel values of the images."
 msgstr ""
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2874
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2891
 msgid ""
 "The <b>feConvolveMatrix</b> lets you specify a Convolution to be applied on "
 "the image. Common effects created using convolution matrices are blur, "
@@ -16464,7 +16590,7 @@ msgid ""
 "is faster and resolution-independent."
 msgstr ""
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2878
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2895
 msgid ""
 "The <b>feDiffuseLighting</b> and feSpecularLighting filter primitives create "
 "\"embossed\" shadings.  The input's alpha channel is used to provide depth "
@@ -16472,7 +16598,7 @@ msgid ""
 "opacity areas recede away from the viewer."
 msgstr ""
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2882
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2899
 msgid ""
 "The <b>feDisplacementMap</b> filter primitive displaces the pixels in the "
 "first input using the second input as a displacement map, that shows from "
@@ -16480,26 +16606,26 @@ msgid ""
 "effects."
 msgstr ""
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2886
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2903
 msgid ""
 "The <b>feFlood</b> filter primitive fills the region with a given color and "
 "opacity.  It is usually used as an input to other filters to apply color to "
 "a graphic."
 msgstr ""
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2890
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2907
 msgid ""
 "The <b>feGaussianBlur</b> filter primitive uniformly blurs its input.  It is "
 "commonly used together with feOffset to create a drop shadow effect."
 msgstr ""
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2894
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2911
 msgid ""
 "The <b>feImage</b> filter primitive fills the region with an external image "
 "or another part of the document."
 msgstr ""
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2898
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2915
 msgid ""
 "The <b>feMerge</b> filter primitive composites several temporary images "
 "inside the filter primitive to a single image. It uses normal alpha "
@@ -16507,21 +16633,21 @@ msgid ""
 "in 'normal' mode or several feComposite primitives in 'over' mode."
 msgstr ""
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2902
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2919
 msgid ""
 "The <b>feMorphology</b> filter primitive provides erode and dilate effects. "
 "For single-color objects erode makes the object thinner and dilate makes it "
 "thicker."
 msgstr ""
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2906
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2923
 msgid ""
 "The <b>feOffset</b> filter primitive offsets the image by an user-defined "
 "amount. For example, this is useful for drop shadows, where the shadow is in "
 "a slightly different position than the actual object."
 msgstr ""
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2910
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2927
 msgid ""
 "The <b>feDiffuseLighting</b> and <b>feSpecularLighting</b> filter primitives "
 "create \"embossed\" shadings.  The input's alpha channel is used to provide "
@@ -16529,24 +16655,24 @@ msgid ""
 "lower opacity areas recede away from the viewer."
 msgstr ""
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2914
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2931
 msgid ""
 "The <b>feTile</b> filter primitive tiles a region with an input graphic. The "
 "source tile is defined by the filter primitive subregion of the input."
 msgstr ""
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2918
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2935
 msgid ""
 "The <b>feTurbulence</b> filter primitive renders Perlin noise. This kind of "
 "noise is useful in simulating several nature phenomena like clouds, fire and "
 "smoke and in generating complex textures like marble or granite."
 msgstr ""
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:2938
+#: ../src/ui/dialog/filter-effects-dialog.cpp:2955
 msgid "Duplicate filter primitive"
 msgstr ""
 
-#: ../src/ui/dialog/filter-effects-dialog.cpp:3018
+#: ../src/ui/dialog/filter-effects-dialog.cpp:3035
 msgid "Set filter primitive attribute"
 msgstr ""
 
@@ -16591,7 +16717,7 @@ msgid "Limit search to the current selection"
 msgstr ""
 
 #: ../src/ui/dialog/find.cpp:71 ../src/ui/dialog/text-edit.cpp:61
-#: ../share/ui/menus.xml.h:17
+#: ../share/ui/menus.xml.h:18
 msgid "_Text"
 msgstr ""
 
@@ -16735,7 +16861,7 @@ msgstr ""
 msgid "Search spirals"
 msgstr ""
 
-#: ../src/ui/dialog/find.cpp:96 ../src/widgets/toolbox.cpp:1299
+#: ../src/ui/dialog/find.cpp:96 ../src/widgets/toolbox.cpp:1302
 msgid "Paths"
 msgstr ""
 
@@ -17604,82 +17730,82 @@ msgstr ""
 msgid "Append"
 msgstr ""
 
-#: ../src/ui/dialog/glyphs.cpp:552
+#: ../src/ui/dialog/glyphs.cpp:550
 msgid "Append text"
 msgstr ""
 
-#: ../src/ui/dialog/grid-arrange-tab.cpp:340
+#: ../src/ui/dialog/grid-arrange-tab.cpp:338
 msgid "Arrange in a grid"
 msgstr ""
 
-#: ../src/ui/dialog/grid-arrange-tab.cpp:568
+#: ../src/ui/dialog/grid-arrange-tab.cpp:566
 #: ../src/ui/dialog/object-attributes.cpp:63
 #: ../src/ui/dialog/object-attributes.cpp:72
-#: ../src/ui/widget/page-sizer.cpp:230 ../src/widgets/desktop-widget.cpp:635
+#: ../src/ui/widget/page-sizer.cpp:232 ../src/widgets/desktop-widget.cpp:649
 #: ../src/widgets/node-toolbar.cpp:579
 msgid "X:"
 msgstr ""
 
-#: ../src/ui/dialog/grid-arrange-tab.cpp:568
+#: ../src/ui/dialog/grid-arrange-tab.cpp:566
 msgid "Horizontal spacing between columns."
 msgstr ""
 
-#: ../src/ui/dialog/grid-arrange-tab.cpp:569
+#: ../src/ui/dialog/grid-arrange-tab.cpp:567
 #: ../src/ui/dialog/object-attributes.cpp:64
 #: ../src/ui/dialog/object-attributes.cpp:73
-#: ../src/ui/widget/page-sizer.cpp:231 ../src/widgets/desktop-widget.cpp:636
+#: ../src/ui/widget/page-sizer.cpp:233 ../src/widgets/desktop-widget.cpp:650
 #: ../src/widgets/node-toolbar.cpp:597
 msgid "Y:"
 msgstr ""
 
-#: ../src/ui/dialog/grid-arrange-tab.cpp:569
+#: ../src/ui/dialog/grid-arrange-tab.cpp:567
 msgid "Vertical spacing between rows."
 msgstr ""
 
-#: ../src/ui/dialog/grid-arrange-tab.cpp:611
+#: ../src/ui/dialog/grid-arrange-tab.cpp:609
 msgid "_Rows:"
 msgstr ""
 
-#: ../src/ui/dialog/grid-arrange-tab.cpp:621
+#: ../src/ui/dialog/grid-arrange-tab.cpp:619
 msgid "Number of rows"
 msgstr ""
 
-#: ../src/ui/dialog/grid-arrange-tab.cpp:625
+#: ../src/ui/dialog/grid-arrange-tab.cpp:623
 msgid "Equal _height"
 msgstr ""
 
-#: ../src/ui/dialog/grid-arrange-tab.cpp:636
+#: ../src/ui/dialog/grid-arrange-tab.cpp:634
 msgid "If not set, each row has the height of the tallest object in it"
 msgstr ""
 
 #. #### Number of columns ####
-#: ../src/ui/dialog/grid-arrange-tab.cpp:653
+#: ../src/ui/dialog/grid-arrange-tab.cpp:651
 msgid "_Columns:"
 msgstr ""
 
-#: ../src/ui/dialog/grid-arrange-tab.cpp:663
+#: ../src/ui/dialog/grid-arrange-tab.cpp:661
 msgid "Number of columns"
 msgstr ""
 
-#: ../src/ui/dialog/grid-arrange-tab.cpp:667
+#: ../src/ui/dialog/grid-arrange-tab.cpp:665
 msgid "Equal _width"
 msgstr ""
 
-#: ../src/ui/dialog/grid-arrange-tab.cpp:677
+#: ../src/ui/dialog/grid-arrange-tab.cpp:675
 msgid "If not set, each column has the width of the widest object in it"
 msgstr ""
 
 #. Anchor selection widget
-#: ../src/ui/dialog/grid-arrange-tab.cpp:689
+#: ../src/ui/dialog/grid-arrange-tab.cpp:687
 msgid "Alignment:"
 msgstr ""
 
 #. #### Radio buttons to control spacing manually or to fit selection bbox ####
-#: ../src/ui/dialog/grid-arrange-tab.cpp:699
+#: ../src/ui/dialog/grid-arrange-tab.cpp:697
 msgid "_Fit into selection box"
 msgstr ""
 
-#: ../src/ui/dialog/grid-arrange-tab.cpp:706
+#: ../src/ui/dialog/grid-arrange-tab.cpp:704
 msgid "_Set spacing:"
 msgstr ""
 
@@ -17739,372 +17865,387 @@ msgstr ""
 msgid "Current: %s"
 msgstr ""
 
-#: ../src/ui/dialog/icon-preview.cpp:152
+#: ../src/ui/dialog/icon-preview.cpp:151
 #, c-format
 msgid "%d x %d"
 msgstr ""
 
-#: ../src/ui/dialog/icon-preview.cpp:164
+#: ../src/ui/dialog/icon-preview.cpp:163
 msgid "Magnified:"
 msgstr ""
 
-#: ../src/ui/dialog/icon-preview.cpp:232
+#: ../src/ui/dialog/icon-preview.cpp:231
 msgid "Actual Size:"
 msgstr ""
 
-#: ../src/ui/dialog/icon-preview.cpp:237
+#: ../src/ui/dialog/icon-preview.cpp:236
 msgctxt "Icon preview window"
 msgid "Sele_ction"
 msgstr ""
 
-#: ../src/ui/dialog/icon-preview.cpp:239
+#: ../src/ui/dialog/icon-preview.cpp:238
 msgid "Selection only or whole document"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:170
+#: ../src/ui/dialog/inkscape-preferences.cpp:202
 msgid "Show selection cue"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:171
+#: ../src/ui/dialog/inkscape-preferences.cpp:203
 msgid ""
 "Whether selected objects display a selection cue (the same as in selector)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:177
+#: ../src/ui/dialog/inkscape-preferences.cpp:209
 msgid "Enable gradient editing"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:178
+#: ../src/ui/dialog/inkscape-preferences.cpp:210
 msgid "Whether selected objects display gradient editing controls"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:183
+#: ../src/ui/dialog/inkscape-preferences.cpp:215
 msgid "Conversion to guides uses edges instead of bounding box"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:184
+#: ../src/ui/dialog/inkscape-preferences.cpp:216
 msgid ""
 "Converting an object to guides places these along the object's true edges "
 "(imitating the object's shape), not along the bounding box"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:191
+#: ../src/ui/dialog/inkscape-preferences.cpp:223
 msgid "Ctrl+click _dot size:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:191
+#: ../src/ui/dialog/inkscape-preferences.cpp:223
 msgid "times current stroke width"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:192
+#: ../src/ui/dialog/inkscape-preferences.cpp:224
 msgid "Size of dots created with Ctrl+click (relative to current stroke width)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:200
+#: ../src/ui/dialog/inkscape-preferences.cpp:232
 msgid "Base simplify:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:200
+#: ../src/ui/dialog/inkscape-preferences.cpp:232
 msgid "on dynamic LPE simplify"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:201
+#: ../src/ui/dialog/inkscape-preferences.cpp:233
 msgid "Base simplify of dynamic LPE based simplify"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:216
+#: ../src/ui/dialog/inkscape-preferences.cpp:241
+msgid "Pressure change for new knot:"
+msgstr ""
+
+#: ../src/ui/dialog/inkscape-preferences.cpp:241
+#: ../src/ui/dialog/inkscape-preferences.cpp:1363
+msgid "%"
+msgstr ""
+
+#: ../src/ui/dialog/inkscape-preferences.cpp:242
+msgid ""
+"Percentage increase / decrease of stylus pressure that is required to create "
+"a new PowerStroke knot."
+msgstr ""
+
+#: ../src/ui/dialog/inkscape-preferences.cpp:256
 msgid "<b>No objects selected</b> to take the style from."
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:225
+#: ../src/ui/dialog/inkscape-preferences.cpp:265
 msgid ""
 "<b>More than one object selected.</b>  Cannot take style from multiple "
 "objects."
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:261
+#: ../src/ui/dialog/inkscape-preferences.cpp:301
 msgid "Style of new objects"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:263
+#: ../src/ui/dialog/inkscape-preferences.cpp:303
 msgid "Last used style"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:265
+#: ../src/ui/dialog/inkscape-preferences.cpp:305
 msgid "Apply the style you last set on an object"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:269
+#: ../src/ui/dialog/inkscape-preferences.cpp:309
 msgid "This tool's own style:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:273
+#: ../src/ui/dialog/inkscape-preferences.cpp:313
 msgid ""
 "Each tool may store its own style to apply to the newly created objects. Use "
 "the button below to set it."
 msgstr ""
 
 #. style swatch
-#: ../src/ui/dialog/inkscape-preferences.cpp:277
+#: ../src/ui/dialog/inkscape-preferences.cpp:317
 msgid "Take from selection"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:286
+#: ../src/ui/dialog/inkscape-preferences.cpp:326
 msgid "This tool's style of new objects"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:293
+#: ../src/ui/dialog/inkscape-preferences.cpp:333
 msgid "Remember the style of the (first) selected object as this tool's style"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:298
+#: ../src/ui/dialog/inkscape-preferences.cpp:338
 msgid "Tools"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:301
+#: ../src/ui/dialog/inkscape-preferences.cpp:341
 msgid "Bounding box to use"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:302
+#: ../src/ui/dialog/inkscape-preferences.cpp:342
 msgid "Visual bounding box"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:304
+#: ../src/ui/dialog/inkscape-preferences.cpp:344
 msgid "This bounding box includes stroke width, markers, filter margins, etc."
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:305
+#: ../src/ui/dialog/inkscape-preferences.cpp:345
 msgid "Geometric bounding box"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:307
+#: ../src/ui/dialog/inkscape-preferences.cpp:347
 msgid "This bounding box includes only the bare path"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:309
+#: ../src/ui/dialog/inkscape-preferences.cpp:349
 msgid "Conversion to guides"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:310
+#: ../src/ui/dialog/inkscape-preferences.cpp:350
 msgid "Keep objects after conversion to guides"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:312
+#: ../src/ui/dialog/inkscape-preferences.cpp:352
 msgid ""
 "When converting an object to guides, don't delete the object after the "
 "conversion"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:313
+#: ../src/ui/dialog/inkscape-preferences.cpp:353
 msgid "Treat groups as a single object"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:315
+#: ../src/ui/dialog/inkscape-preferences.cpp:355
 msgid ""
 "Treat groups as a single object during conversion to guides rather than "
 "converting each child separately"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:317
+#: ../src/ui/dialog/inkscape-preferences.cpp:357
 msgid "Average all sketches"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:318
+#: ../src/ui/dialog/inkscape-preferences.cpp:358
 msgid "Width is in absolute units"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:319
+#: ../src/ui/dialog/inkscape-preferences.cpp:359
 msgid "Select new path"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:320
+#: ../src/ui/dialog/inkscape-preferences.cpp:360
 msgid "Don't attach connectors to text objects"
 msgstr ""
 
 #. Selector
-#: ../src/ui/dialog/inkscape-preferences.cpp:323
+#: ../src/ui/dialog/inkscape-preferences.cpp:363
 msgid "Selector"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:328
+#: ../src/ui/dialog/inkscape-preferences.cpp:368
 msgid "When transforming, show"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:329
+#: ../src/ui/dialog/inkscape-preferences.cpp:369
 msgid "Objects"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:331
+#: ../src/ui/dialog/inkscape-preferences.cpp:371
 msgid "Show the actual objects when moving or transforming"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:332
+#: ../src/ui/dialog/inkscape-preferences.cpp:372
 msgid "Box outline"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:334
+#: ../src/ui/dialog/inkscape-preferences.cpp:374
 msgid "Show only a box outline of the objects when moving or transforming"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:335
+#: ../src/ui/dialog/inkscape-preferences.cpp:375
 msgid "Per-object selection cue"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:336
+#: ../src/ui/dialog/inkscape-preferences.cpp:376
 msgctxt "Selection cue"
 msgid "None"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:338
+#: ../src/ui/dialog/inkscape-preferences.cpp:378
 msgid "No per-object selection indication"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:339
+#: ../src/ui/dialog/inkscape-preferences.cpp:379
 msgid "Mark"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:341
+#: ../src/ui/dialog/inkscape-preferences.cpp:381
 msgid "Each selected object has a diamond mark in the top left corner"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:342
+#: ../src/ui/dialog/inkscape-preferences.cpp:382
 msgid "Box"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:344
+#: ../src/ui/dialog/inkscape-preferences.cpp:384
 msgid "Each selected object displays its bounding box"
 msgstr ""
 
 #. Node
-#: ../src/ui/dialog/inkscape-preferences.cpp:347
+#: ../src/ui/dialog/inkscape-preferences.cpp:387
 msgid "Node"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:350
+#: ../src/ui/dialog/inkscape-preferences.cpp:390
 msgid "Path outline"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:351
+#: ../src/ui/dialog/inkscape-preferences.cpp:391
 msgid "Path outline color"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:352
+#: ../src/ui/dialog/inkscape-preferences.cpp:392
 msgid "Selects the color used for showing the path outline"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:353
+#: ../src/ui/dialog/inkscape-preferences.cpp:393
 msgid "Always show outline"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:354
+#: ../src/ui/dialog/inkscape-preferences.cpp:394
 msgid "Show outlines for all paths, not only invisible paths"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:355
+#: ../src/ui/dialog/inkscape-preferences.cpp:395
 msgid "Update outline when dragging nodes"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:356
+#: ../src/ui/dialog/inkscape-preferences.cpp:396
 msgid ""
 "Update the outline when dragging or transforming nodes; if this is off, the "
 "outline will only update when completing a drag"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:357
+#: ../src/ui/dialog/inkscape-preferences.cpp:397
 msgid "Update paths when dragging nodes"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:358
+#: ../src/ui/dialog/inkscape-preferences.cpp:398
 msgid ""
 "Update paths when dragging or transforming nodes; if this is off, paths will "
 "only be updated when completing a drag"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:359
+#: ../src/ui/dialog/inkscape-preferences.cpp:399
 msgid "Show path direction on outlines"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:360
+#: ../src/ui/dialog/inkscape-preferences.cpp:400
 msgid ""
 "Visualize the direction of selected paths by drawing small arrows in the "
 "middle of each outline segment"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:361
+#: ../src/ui/dialog/inkscape-preferences.cpp:401
 msgid "Show temporary path outline"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:362
+#: ../src/ui/dialog/inkscape-preferences.cpp:402
 msgid "When hovering over a path, briefly flash its outline"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:363
+#: ../src/ui/dialog/inkscape-preferences.cpp:403
 msgid "Show temporary outline for selected paths"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:364
+#: ../src/ui/dialog/inkscape-preferences.cpp:404
 msgid "Show temporary outline even when a path is selected for editing"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:366
+#: ../src/ui/dialog/inkscape-preferences.cpp:406
 msgid "_Flash time:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:366
+#: ../src/ui/dialog/inkscape-preferences.cpp:406
 msgid ""
 "Specifies how long the path outline will be visible after a mouse-over (in "
 "milliseconds); specify 0 to have the outline shown until mouse leaves the "
 "path"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:367
+#: ../src/ui/dialog/inkscape-preferences.cpp:407
 msgid "Editing preferences"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:368
+#: ../src/ui/dialog/inkscape-preferences.cpp:408
 msgid "Show transform handles for single nodes"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:369
+#: ../src/ui/dialog/inkscape-preferences.cpp:409
 msgid "Show transform handles even when only a single node is selected"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:370
+#: ../src/ui/dialog/inkscape-preferences.cpp:410
 msgid "Deleting nodes preserves shape"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:371
+#: ../src/ui/dialog/inkscape-preferences.cpp:411
 msgid ""
 "Move handles next to deleted nodes to resemble original shape; hold Ctrl to "
 "get the other behavior"
 msgstr ""
 
 #. Tweak
-#: ../src/ui/dialog/inkscape-preferences.cpp:374
+#: ../src/ui/dialog/inkscape-preferences.cpp:414
 msgid "Tweak"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:375
+#: ../src/ui/dialog/inkscape-preferences.cpp:415
 msgid "Object paint style"
 msgstr ""
 
 #. Zoom
-#: ../src/ui/dialog/inkscape-preferences.cpp:380
-#: ../src/widgets/desktop-widget.cpp:574
+#: ../src/ui/dialog/inkscape-preferences.cpp:420
+#: ../src/widgets/desktop-widget.cpp:588
 msgid "Zoom"
 msgstr ""
 
 #. Measure
-#: ../src/ui/dialog/inkscape-preferences.cpp:385 ../src/verbs.cpp:2924
+#: ../src/ui/dialog/inkscape-preferences.cpp:425 ../src/verbs.cpp:2958
 msgctxt "ContextVerb"
 msgid "Measure"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:387
+#: ../src/ui/dialog/inkscape-preferences.cpp:427
 msgid "Ignore first and last points"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:388
+#: ../src/ui/dialog/inkscape-preferences.cpp:428
 msgid ""
 "The start and end of the measurement tool's control line will not be "
 "considered for calculating lengths. Only lengths between actual curve "
@@ -18112,980 +18253,1014 @@ msgid ""
 msgstr ""
 
 #. Shapes
-#: ../src/ui/dialog/inkscape-preferences.cpp:391
+#: ../src/ui/dialog/inkscape-preferences.cpp:431
 msgid "Shapes"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:424
+#: ../src/ui/dialog/inkscape-preferences.cpp:464
+msgid "Pressure sensitivity settings"
+msgstr ""
+
+#: ../src/ui/dialog/inkscape-preferences.cpp:467
 msgid "Sketch mode"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:426
+#: ../src/ui/dialog/inkscape-preferences.cpp:469
 msgid ""
 "If on, the sketch result will be the normal average of all sketches made, "
 "instead of averaging the old result with the new sketch"
 msgstr ""
 
 #. Pen
-#: ../src/ui/dialog/inkscape-preferences.cpp:429
-#: ../src/ui/dialog/input.cpp:1311
+#: ../src/ui/dialog/inkscape-preferences.cpp:472
+#: ../src/ui/dialog/input.cpp:1312
 msgid "Pen"
 msgstr ""
 
 #. Calligraphy
-#: ../src/ui/dialog/inkscape-preferences.cpp:435
+#: ../src/ui/dialog/inkscape-preferences.cpp:478
 msgid "Calligraphy"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:439
+#: ../src/ui/dialog/inkscape-preferences.cpp:482
 msgid ""
 "If on, pen width is in absolute units (px) independent of zoom; otherwise "
 "pen width depends on zoom so that it looks the same at any zoom"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:441
+#: ../src/ui/dialog/inkscape-preferences.cpp:484
 msgid ""
 "If on, each newly created object will be selected (deselecting previous "
 "selection)"
 msgstr ""
 
 #. Text
-#: ../src/ui/dialog/inkscape-preferences.cpp:444 ../src/verbs.cpp:2916
+#: ../src/ui/dialog/inkscape-preferences.cpp:487 ../src/verbs.cpp:2950
 msgctxt "ContextVerb"
 msgid "Text"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:449
+#: ../src/ui/dialog/inkscape-preferences.cpp:492
 msgid "Show font samples in the drop-down list"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:450
+#: ../src/ui/dialog/inkscape-preferences.cpp:493
 msgid ""
 "Show font samples alongside font names in the drop-down list in Text bar"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:452
+#: ../src/ui/dialog/inkscape-preferences.cpp:495
 msgid "Show font substitution warning dialog"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:453
+#: ../src/ui/dialog/inkscape-preferences.cpp:496
 msgid ""
 "Show font substitution warning dialog when requested fonts are not available "
 "on the system"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:456
+#: ../src/ui/dialog/inkscape-preferences.cpp:499
 msgid "Pixel"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:456
+#: ../src/ui/dialog/inkscape-preferences.cpp:499
 msgid "Pica"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:456
+#: ../src/ui/dialog/inkscape-preferences.cpp:499
 msgid "Millimeter"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:456
+#: ../src/ui/dialog/inkscape-preferences.cpp:499
 msgid "Centimeter"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:456
+#: ../src/ui/dialog/inkscape-preferences.cpp:499
 msgid "Inch"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:456
+#: ../src/ui/dialog/inkscape-preferences.cpp:499
 msgid "Em square"
 msgstr ""
 
 #. , _("Ex square"), _("Percent")
 #. , SP_CSS_UNIT_EX, SP_CSS_UNIT_PERCENT
-#: ../src/ui/dialog/inkscape-preferences.cpp:459
+#: ../src/ui/dialog/inkscape-preferences.cpp:502
 msgid "Text units"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:461
+#: ../src/ui/dialog/inkscape-preferences.cpp:504
 msgid "Text size unit type:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:462
+#: ../src/ui/dialog/inkscape-preferences.cpp:505
 msgid "Set the type of unit used in the text toolbar and text dialogs"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:463
+#: ../src/ui/dialog/inkscape-preferences.cpp:506
 msgid "Always output text size in pixels (px)"
 msgstr ""
 
+#. _page_text.add_line( false, "", _font_output_px, "", _("Always convert the text size units above into pixels (px) before saving to file"));
+#: ../src/ui/dialog/inkscape-preferences.cpp:509
+msgid "Font directories"
+msgstr ""
+
+#: ../src/ui/dialog/inkscape-preferences.cpp:510
+msgid "Use Inkscape's fonts directory"
+msgstr ""
+
+#: ../src/ui/dialog/inkscape-preferences.cpp:511
+msgid ""
+"Load additional fonts from \"fonts\" directory located in Inkscape's global "
+"\"share\" directory"
+msgstr ""
+
+#: ../src/ui/dialog/inkscape-preferences.cpp:512
+msgid "Use user's fonts directory"
+msgstr ""
+
+#: ../src/ui/dialog/inkscape-preferences.cpp:513
+msgid ""
+"Load additional fonts from \"fonts\" directory located in Inkscape's user "
+"configuration directory"
+msgstr ""
+
+#: ../src/ui/dialog/inkscape-preferences.cpp:515
+msgid "Additional font directories"
+msgstr ""
+
+#: ../src/ui/dialog/inkscape-preferences.cpp:515
+msgid "Load additional fonts from custom locations (one path per line)"
+msgstr ""
+
 #. Spray
-#: ../src/ui/dialog/inkscape-preferences.cpp:469
+#: ../src/ui/dialog/inkscape-preferences.cpp:521
 msgid "Spray"
 msgstr ""
 
 #. Eraser
-#: ../src/ui/dialog/inkscape-preferences.cpp:474
+#: ../src/ui/dialog/inkscape-preferences.cpp:526
 msgid "Eraser"
 msgstr ""
 
 #. Paint Bucket
-#: ../src/ui/dialog/inkscape-preferences.cpp:479
+#: ../src/ui/dialog/inkscape-preferences.cpp:531
 msgid "Paint Bucket"
 msgstr ""
 
 #. Gradient
-#: ../src/ui/dialog/inkscape-preferences.cpp:485
+#: ../src/ui/dialog/inkscape-preferences.cpp:537
 #: ../src/widgets/gradient-selector.cpp:134
 #: ../src/widgets/gradient-selector.cpp:280
 msgid "Gradient"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:487
+#: ../src/ui/dialog/inkscape-preferences.cpp:539
 msgid "Prevent sharing of gradient definitions"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:489
+#: ../src/ui/dialog/inkscape-preferences.cpp:541
 msgid ""
 "When on, shared gradient definitions are automatically forked on change; "
 "uncheck to allow sharing of gradient definitions so that editing one object "
 "may affect other objects using the same gradient"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:490
+#: ../src/ui/dialog/inkscape-preferences.cpp:542
 msgid "Use legacy Gradient Editor"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:492
+#: ../src/ui/dialog/inkscape-preferences.cpp:544
 msgid ""
 "When on, the Gradient Edit button in the Fill & Stroke dialog will show the "
 "legacy Gradient Editor dialog, when off the Gradient Tool will be used"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:495
+#: ../src/ui/dialog/inkscape-preferences.cpp:547
 msgid "Linear gradient _angle:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:496
+#: ../src/ui/dialog/inkscape-preferences.cpp:548
 msgid ""
 "Default angle of new linear gradients in degrees (clockwise from horizontal)"
 msgstr ""
 
 #. Dropper
-#: ../src/ui/dialog/inkscape-preferences.cpp:500
+#: ../src/ui/dialog/inkscape-preferences.cpp:552
 msgid "Dropper"
 msgstr ""
 
 #. Connector
-#: ../src/ui/dialog/inkscape-preferences.cpp:505
+#: ../src/ui/dialog/inkscape-preferences.cpp:557
 msgid "Connector"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:508
+#: ../src/ui/dialog/inkscape-preferences.cpp:560
 msgid "If on, connector attachment points will not be shown for text objects"
 msgstr ""
 
 #. LPETool
 #. disabled, because the LPETool is not finished yet.
-#: ../src/ui/dialog/inkscape-preferences.cpp:513
+#: ../src/ui/dialog/inkscape-preferences.cpp:565
 msgid "LPE Tool"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:520
+#: ../src/ui/dialog/inkscape-preferences.cpp:572
 msgid "Interface"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:523
+#: ../src/ui/dialog/inkscape-preferences.cpp:575
 msgid "System default"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:524
+#: ../src/ui/dialog/inkscape-preferences.cpp:576
 msgid "Albanian (sq)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:524
+#: ../src/ui/dialog/inkscape-preferences.cpp:576
 msgid "Amharic (am)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:524
+#: ../src/ui/dialog/inkscape-preferences.cpp:576
 msgid "Arabic (ar)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:524
+#: ../src/ui/dialog/inkscape-preferences.cpp:576
 msgid "Armenian (hy)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:524
+#: ../src/ui/dialog/inkscape-preferences.cpp:576
 msgid "Assamese (as)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:524
+#: ../src/ui/dialog/inkscape-preferences.cpp:576
 msgid "Azerbaijani (az)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:525
+#: ../src/ui/dialog/inkscape-preferences.cpp:577
 msgid "Basque (eu)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:525
+#: ../src/ui/dialog/inkscape-preferences.cpp:577
 msgid "Belarusian (be)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:525
+#: ../src/ui/dialog/inkscape-preferences.cpp:577
 msgid "Bulgarian (bg)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:525
+#: ../src/ui/dialog/inkscape-preferences.cpp:577
 msgid "Bengali (bn)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:525
+#: ../src/ui/dialog/inkscape-preferences.cpp:577
 msgid "Bengali/Bangladesh (bn_BD)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:525
+#: ../src/ui/dialog/inkscape-preferences.cpp:577
 msgid "Bodo (brx)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:525
+#: ../src/ui/dialog/inkscape-preferences.cpp:577
 msgid "Breton (br)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:526
+#: ../src/ui/dialog/inkscape-preferences.cpp:578
 msgid "Catalan (ca)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:526
+#: ../src/ui/dialog/inkscape-preferences.cpp:578
 msgid "Valencian Catalan (ca@valencia)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:526
+#: ../src/ui/dialog/inkscape-preferences.cpp:578
 msgid "Chinese/China (zh_CN)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:526
+#: ../src/ui/dialog/inkscape-preferences.cpp:578
 msgid "Chinese/Taiwan (zh_TW)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:526
+#: ../src/ui/dialog/inkscape-preferences.cpp:578
 msgid "Croatian (hr)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:526
+#: ../src/ui/dialog/inkscape-preferences.cpp:578
 msgid "Czech (cs)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:527
+#: ../src/ui/dialog/inkscape-preferences.cpp:579
 msgid "Danish (da)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:527
+#: ../src/ui/dialog/inkscape-preferences.cpp:579
 msgid "Dogri (doi)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:527
+#: ../src/ui/dialog/inkscape-preferences.cpp:579
 msgid "Dutch (nl)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:527
+#: ../src/ui/dialog/inkscape-preferences.cpp:579
 msgid "Dzongkha (dz)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:528
+#: ../src/ui/dialog/inkscape-preferences.cpp:580
 msgid "German (de)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:528
+#: ../src/ui/dialog/inkscape-preferences.cpp:580
 msgid "Greek (el)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:529
+#: ../src/ui/dialog/inkscape-preferences.cpp:581
 msgid "English (en)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:529
+#: ../src/ui/dialog/inkscape-preferences.cpp:581
 msgid "English/Australia (en_AU)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:529
+#: ../src/ui/dialog/inkscape-preferences.cpp:581
 msgid "English/Canada (en_CA)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:529
+#: ../src/ui/dialog/inkscape-preferences.cpp:581
 msgid "English/Great Britain (en_GB)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:529
+#: ../src/ui/dialog/inkscape-preferences.cpp:581
 msgid "Pig Latin (en_US@piglatin)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:529
+#: ../src/ui/dialog/inkscape-preferences.cpp:581
 msgid "Esperanto (eo)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:529
+#: ../src/ui/dialog/inkscape-preferences.cpp:581
 msgid "Estonian (et)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:530
+#: ../src/ui/dialog/inkscape-preferences.cpp:582
 msgid "Farsi (fa)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:530
+#: ../src/ui/dialog/inkscape-preferences.cpp:582
 msgid "Finnish (fi)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:530
+#: ../src/ui/dialog/inkscape-preferences.cpp:582
 msgid "French (fr)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:531
+#: ../src/ui/dialog/inkscape-preferences.cpp:583
 msgid "Galician (gl)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:531
+#: ../src/ui/dialog/inkscape-preferences.cpp:583
 msgid "Gujarati (gu)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:532
+#: ../src/ui/dialog/inkscape-preferences.cpp:584
 msgid "Hebrew (he)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:532
+#: ../src/ui/dialog/inkscape-preferences.cpp:584
 msgid "Hindi (hi)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:532
+#: ../src/ui/dialog/inkscape-preferences.cpp:584
 msgid "Hungarian (hu)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:533
+#: ../src/ui/dialog/inkscape-preferences.cpp:585
 msgid "Icelandic (is)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:533
+#: ../src/ui/dialog/inkscape-preferences.cpp:585
 msgid "Indonesian (id)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:533
+#: ../src/ui/dialog/inkscape-preferences.cpp:585
 msgid "Irish (ga)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:533
+#: ../src/ui/dialog/inkscape-preferences.cpp:585
 msgid "Italian (it)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:534
+#: ../src/ui/dialog/inkscape-preferences.cpp:586
 msgid "Japanese (ja)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:535
+#: ../src/ui/dialog/inkscape-preferences.cpp:587
 msgid "Kannada (kn)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:535
+#: ../src/ui/dialog/inkscape-preferences.cpp:587
 msgid "Kashmiri in Perso-Arabic script (ks@aran)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:535
+#: ../src/ui/dialog/inkscape-preferences.cpp:587
 msgid "Kashmiri in Devanagari script (ks@deva)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:535
+#: ../src/ui/dialog/inkscape-preferences.cpp:587
 msgid "Khmer (km)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:535
+#: ../src/ui/dialog/inkscape-preferences.cpp:587
 msgid "Kinyarwanda (rw)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:535
+#: ../src/ui/dialog/inkscape-preferences.cpp:587
 msgid "Konkani (kok)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:535
+#: ../src/ui/dialog/inkscape-preferences.cpp:587
 msgid "Konkani in Latin script (kok@latin)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:535
+#: ../src/ui/dialog/inkscape-preferences.cpp:587
 msgid "Korean (ko)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:536
+#: ../src/ui/dialog/inkscape-preferences.cpp:588
 msgid "Latvian (lv)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:536
+#: ../src/ui/dialog/inkscape-preferences.cpp:588
 msgid "Lithuanian (lt)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:537
+#: ../src/ui/dialog/inkscape-preferences.cpp:589
 msgid "Macedonian (mk)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:537
+#: ../src/ui/dialog/inkscape-preferences.cpp:589
 msgid "Maithili (mai)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:537
+#: ../src/ui/dialog/inkscape-preferences.cpp:589
 msgid "Malayalam (ml)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:537
+#: ../src/ui/dialog/inkscape-preferences.cpp:589
 msgid "Manipuri (mni)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:537
+#: ../src/ui/dialog/inkscape-preferences.cpp:589
 msgid "Manipuri in Bengali script (mni@beng)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:537
+#: ../src/ui/dialog/inkscape-preferences.cpp:589
 msgid "Marathi (mr)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:537
+#: ../src/ui/dialog/inkscape-preferences.cpp:589
 msgid "Mongolian (mn)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:538
+#: ../src/ui/dialog/inkscape-preferences.cpp:590
 msgid "Nepali (ne)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:538
+#: ../src/ui/dialog/inkscape-preferences.cpp:590
 msgid "Norwegian Bokmål (nb)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:538
+#: ../src/ui/dialog/inkscape-preferences.cpp:590
 msgid "Norwegian Nynorsk (nn)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:539
+#: ../src/ui/dialog/inkscape-preferences.cpp:591
 msgid "Odia (or)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:540
+#: ../src/ui/dialog/inkscape-preferences.cpp:592
 msgid "Panjabi (pa)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:540
+#: ../src/ui/dialog/inkscape-preferences.cpp:592
 msgid "Polish (pl)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:540
+#: ../src/ui/dialog/inkscape-preferences.cpp:592
 msgid "Portuguese (pt)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:540
+#: ../src/ui/dialog/inkscape-preferences.cpp:592
 msgid "Portuguese/Brazil (pt_BR)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:541
+#: ../src/ui/dialog/inkscape-preferences.cpp:593
 msgid "Romanian (ro)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:541
+#: ../src/ui/dialog/inkscape-preferences.cpp:593
 msgid "Russian (ru)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:542
+#: ../src/ui/dialog/inkscape-preferences.cpp:594
 msgid "Sanskrit (sa)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:542
+#: ../src/ui/dialog/inkscape-preferences.cpp:594
 msgid "Santali (sat)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:542
+#: ../src/ui/dialog/inkscape-preferences.cpp:594
 msgid "Santali in Devanagari script (sat@deva)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:542
+#: ../src/ui/dialog/inkscape-preferences.cpp:594
 msgid "Serbian (sr)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:542
+#: ../src/ui/dialog/inkscape-preferences.cpp:594
 msgid "Serbian in Latin script (sr@latin)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:543
+#: ../src/ui/dialog/inkscape-preferences.cpp:595
 msgid "Sindhi (sd)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:543
+#: ../src/ui/dialog/inkscape-preferences.cpp:595
 msgid "Sindhi in Devanagari script (sd@deva)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:543
+#: ../src/ui/dialog/inkscape-preferences.cpp:595
 msgid "Slovak (sk)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:543
+#: ../src/ui/dialog/inkscape-preferences.cpp:595
 msgid "Slovenian (sl)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:543
+#: ../src/ui/dialog/inkscape-preferences.cpp:595
 msgid "Spanish (es)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:543
+#: ../src/ui/dialog/inkscape-preferences.cpp:595
 msgid "Spanish/Mexico (es_MX)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:543
+#: ../src/ui/dialog/inkscape-preferences.cpp:595
 msgid "Swedish (sv)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:544
+#: ../src/ui/dialog/inkscape-preferences.cpp:596
 msgid "Tamil (ta)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:544
+#: ../src/ui/dialog/inkscape-preferences.cpp:596
 msgid "Telugu (te)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:544
+#: ../src/ui/dialog/inkscape-preferences.cpp:596
 msgid "Thai (th)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:544
+#: ../src/ui/dialog/inkscape-preferences.cpp:596
 msgid "Turkish (tr)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:545
+#: ../src/ui/dialog/inkscape-preferences.cpp:597
 msgid "Ukrainian (uk)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:545
+#: ../src/ui/dialog/inkscape-preferences.cpp:597
 msgid "Urdu (ur)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:546
+#: ../src/ui/dialog/inkscape-preferences.cpp:598
 msgid "Vietnamese (vi)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:598
+#: ../src/ui/dialog/inkscape-preferences.cpp:650
 msgid "Language (requires restart):"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:599
+#: ../src/ui/dialog/inkscape-preferences.cpp:651
 msgid "Set the language for menus and number formats"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:602
+#: ../src/ui/dialog/inkscape-preferences.cpp:654
 msgctxt "Icon size"
 msgid "Larger"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:602
+#: ../src/ui/dialog/inkscape-preferences.cpp:654
 msgctxt "Icon size"
 msgid "Large"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:602
+#: ../src/ui/dialog/inkscape-preferences.cpp:654
 msgctxt "Icon size"
 msgid "Small"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:602
+#: ../src/ui/dialog/inkscape-preferences.cpp:654
 msgctxt "Icon size"
 msgid "Smaller"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:607
+#: ../src/ui/dialog/inkscape-preferences.cpp:659
 msgid "Toolbox icon size:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:608
+#: ../src/ui/dialog/inkscape-preferences.cpp:660
 msgid "Set the size for the tool icons (requires restart)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:611
+#: ../src/ui/dialog/inkscape-preferences.cpp:663
 msgid "Control bar icon size:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:612
+#: ../src/ui/dialog/inkscape-preferences.cpp:664
 msgid ""
 "Set the size for the icons in tools' control bars to use (requires restart)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:615
+#: ../src/ui/dialog/inkscape-preferences.cpp:667
 msgid "Secondary toolbar icon size:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:616
+#: ../src/ui/dialog/inkscape-preferences.cpp:668
 msgid ""
 "Set the size for the icons in secondary toolbars to use (requires restart)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:619
+#: ../src/ui/dialog/inkscape-preferences.cpp:671
 msgid "Work-around color sliders not drawing"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:621
+#: ../src/ui/dialog/inkscape-preferences.cpp:673
 msgid ""
 "When on, will attempt to work around bugs in certain GTK themes drawing "
 "color sliders"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:626
+#: ../src/ui/dialog/inkscape-preferences.cpp:678
 msgid "Clear list"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:629
+#: ../src/ui/dialog/inkscape-preferences.cpp:681
 msgid "Maximum documents in Open _Recent:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:630
+#: ../src/ui/dialog/inkscape-preferences.cpp:682
 msgid ""
 "Set the maximum length of the Open Recent list in the File menu, or clear "
 "the list"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:633
+#: ../src/ui/dialog/inkscape-preferences.cpp:685
 msgid "_Zoom correction factor (in %):"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:634
+#: ../src/ui/dialog/inkscape-preferences.cpp:686
 msgid ""
 "Adjust the slider until the length of the ruler on your screen matches its "
 "real length. This information is used when zooming to 1:1, 1:2, etc., to "
 "display objects in their true sizes"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:637
+#: ../src/ui/dialog/inkscape-preferences.cpp:689
 msgid "Enable dynamic relayout for incomplete sections"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:639
+#: ../src/ui/dialog/inkscape-preferences.cpp:691
 msgid ""
 "When on, will allow dynamic layout of components that are not completely "
 "finished being refactored"
 msgstr ""
 
 #. show infobox
-#: ../src/ui/dialog/inkscape-preferences.cpp:642
+#: ../src/ui/dialog/inkscape-preferences.cpp:694
 msgid "Show filter primitives infobox (requires restart)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:644
+#: ../src/ui/dialog/inkscape-preferences.cpp:696
 msgid ""
 "Show icons and descriptions for the filter primitives available at the "
 "filter effects dialog"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:647
-#: ../src/ui/dialog/inkscape-preferences.cpp:655
+#: ../src/ui/dialog/inkscape-preferences.cpp:699
+#: ../src/ui/dialog/inkscape-preferences.cpp:707
 msgid "Icons only"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:647
-#: ../src/ui/dialog/inkscape-preferences.cpp:655
+#: ../src/ui/dialog/inkscape-preferences.cpp:699
+#: ../src/ui/dialog/inkscape-preferences.cpp:707
 msgid "Text only"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:647
-#: ../src/ui/dialog/inkscape-preferences.cpp:655
+#: ../src/ui/dialog/inkscape-preferences.cpp:699
+#: ../src/ui/dialog/inkscape-preferences.cpp:707
 msgid "Icons and text"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:652
+#: ../src/ui/dialog/inkscape-preferences.cpp:704
 msgid "Dockbar style (requires restart):"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:653
+#: ../src/ui/dialog/inkscape-preferences.cpp:705
 msgid ""
 "Selects whether the vertical bars on the dockbar will show text labels, "
 "icons, or both"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:660
+#: ../src/ui/dialog/inkscape-preferences.cpp:712
 msgid "Switcher style (requires restart):"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:661
+#: ../src/ui/dialog/inkscape-preferences.cpp:713
 msgid ""
 "Selects whether the dockbar switcher will show text labels, icons, or both"
 msgstr ""
 
 #. Windows
-#: ../src/ui/dialog/inkscape-preferences.cpp:665
+#: ../src/ui/dialog/inkscape-preferences.cpp:717
 msgid "Save and restore window geometry for each document"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:666
+#: ../src/ui/dialog/inkscape-preferences.cpp:718
 msgid "Remember and use last window's geometry"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:667
+#: ../src/ui/dialog/inkscape-preferences.cpp:719
 msgid "Don't save window geometry"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:669
+#: ../src/ui/dialog/inkscape-preferences.cpp:721
 msgid "Save and restore dialogs status"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:670
-#: ../src/ui/dialog/inkscape-preferences.cpp:706
+#: ../src/ui/dialog/inkscape-preferences.cpp:722
+#: ../src/ui/dialog/inkscape-preferences.cpp:763
 msgid "Don't save dialogs status"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:672
-#: ../src/ui/dialog/inkscape-preferences.cpp:714
+#: ../src/ui/dialog/inkscape-preferences.cpp:724
+#: ../src/ui/dialog/inkscape-preferences.cpp:771
 msgid "Dockable"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:673
-#: ../src/ui/dialog/inkscape-preferences.cpp:716
+#: ../src/ui/dialog/inkscape-preferences.cpp:725
+#: ../src/ui/dialog/inkscape-preferences.cpp:773
 msgid "Floating"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:676
+#: ../src/ui/dialog/inkscape-preferences.cpp:728
 msgid "Native open/save dialogs"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:677
+#: ../src/ui/dialog/inkscape-preferences.cpp:729
 msgid "GTK open/save dialogs"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:679
+#: ../src/ui/dialog/inkscape-preferences.cpp:731
 msgid "Dialogs are hidden in taskbar"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:680
+#: ../src/ui/dialog/inkscape-preferences.cpp:732
 msgid "Save and restore documents viewport"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:681
+#: ../src/ui/dialog/inkscape-preferences.cpp:733
 msgid "Zoom when window is resized"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:682
-msgid "Show close button on dialogs"
-msgstr ""
-
-#: ../src/ui/dialog/inkscape-preferences.cpp:683
+#: ../src/ui/dialog/inkscape-preferences.cpp:734
 msgctxt "Dialog on top"
 msgid "None"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:685
+#: ../src/ui/dialog/inkscape-preferences.cpp:736
 msgid "Aggressive"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:688
+#: ../src/ui/dialog/inkscape-preferences.cpp:739
+msgctxt "Window size"
+msgid "Default"
+msgstr ""
+
+#: ../src/ui/dialog/inkscape-preferences.cpp:740
 msgctxt "Window size"
 msgid "Small"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:688
+#: ../src/ui/dialog/inkscape-preferences.cpp:741
 msgctxt "Window size"
 msgid "Large"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:688
+#: ../src/ui/dialog/inkscape-preferences.cpp:742
 msgctxt "Window size"
 msgid "Maximized"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:692
+#: ../src/ui/dialog/inkscape-preferences.cpp:749
 msgid "Default window size:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:693
+#: ../src/ui/dialog/inkscape-preferences.cpp:750
 msgid "Set the default window size"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:696
+#: ../src/ui/dialog/inkscape-preferences.cpp:753
 msgid "Saving window geometry (size and position)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:698
+#: ../src/ui/dialog/inkscape-preferences.cpp:755
 msgid "Let the window manager determine placement of all windows"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:700
+#: ../src/ui/dialog/inkscape-preferences.cpp:757
 msgid ""
 "Remember and use the last window's geometry (saves geometry to user "
 "preferences)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:702
+#: ../src/ui/dialog/inkscape-preferences.cpp:759
 msgid ""
 "Save and restore window geometry for each document (saves geometry in the "
 "document)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:704
+#: ../src/ui/dialog/inkscape-preferences.cpp:761
 msgid "Saving dialogs status"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:708
+#: ../src/ui/dialog/inkscape-preferences.cpp:765
 msgid ""
 "Save and restore dialogs status (the last open windows dialogs are saved "
 "when it closes)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:712
+#: ../src/ui/dialog/inkscape-preferences.cpp:769
 msgid "Dialog behavior (requires restart)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:718
+#: ../src/ui/dialog/inkscape-preferences.cpp:775
 msgid "Desktop integration"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:720
+#: ../src/ui/dialog/inkscape-preferences.cpp:777
 msgid "Use Windows like open and save dialogs"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:722
+#: ../src/ui/dialog/inkscape-preferences.cpp:779
 msgid "Use GTK open and save dialogs "
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:726
+#: ../src/ui/dialog/inkscape-preferences.cpp:783
 msgid "Dialogs on top:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:729
+#: ../src/ui/dialog/inkscape-preferences.cpp:786
 msgid "Dialogs are treated as regular windows"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:731
+#: ../src/ui/dialog/inkscape-preferences.cpp:788
 msgid "Dialogs stay on top of document windows"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:733
+#: ../src/ui/dialog/inkscape-preferences.cpp:790
 msgid "Same as Normal but may work better with some window managers"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:736
+#: ../src/ui/dialog/inkscape-preferences.cpp:793
 msgid "Dialog Transparency"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:738
+#: ../src/ui/dialog/inkscape-preferences.cpp:795
 msgid "_Opacity when focused:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:740
+#: ../src/ui/dialog/inkscape-preferences.cpp:797
 msgid "Opacity when _unfocused:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:742
+#: ../src/ui/dialog/inkscape-preferences.cpp:799
 msgid "_Time of opacity change animation:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:745
+#: ../src/ui/dialog/inkscape-preferences.cpp:802
 msgid "Miscellaneous"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:748
+#: ../src/ui/dialog/inkscape-preferences.cpp:805
 msgid "Whether dialog windows are to be hidden in the window manager taskbar"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:751
+#: ../src/ui/dialog/inkscape-preferences.cpp:808
 msgid ""
 "Zoom drawing when document window is resized, to keep the same area visible "
 "(this is the default which can be changed in any window using the button "
 "above the right scrollbar)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:753
+#: ../src/ui/dialog/inkscape-preferences.cpp:810
 msgid ""
 "Save documents viewport (zoom and panning position). Useful to turn off when "
 "sharing version controlled files."
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:755
-msgid "Whether dialog windows have a close button (requires restart)"
-msgstr ""
-
-#: ../src/ui/dialog/inkscape-preferences.cpp:756
+#: ../src/ui/dialog/inkscape-preferences.cpp:811
 msgid "Windows"
 msgstr ""
 
 #. Grids
-#: ../src/ui/dialog/inkscape-preferences.cpp:759
+#: ../src/ui/dialog/inkscape-preferences.cpp:814
 msgid "Line color when zooming out"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:762
+#: ../src/ui/dialog/inkscape-preferences.cpp:817
 msgid "The gridlines will be shown in minor grid line color"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:764
+#: ../src/ui/dialog/inkscape-preferences.cpp:819
 msgid "The gridlines will be shown in major grid line color"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:766
+#: ../src/ui/dialog/inkscape-preferences.cpp:821
 msgid "Default grid settings"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:772
-#: ../src/ui/dialog/inkscape-preferences.cpp:797
+#: ../src/ui/dialog/inkscape-preferences.cpp:827
+#: ../src/ui/dialog/inkscape-preferences.cpp:852
 msgid "Grid units:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:777
-#: ../src/ui/dialog/inkscape-preferences.cpp:802
+#: ../src/ui/dialog/inkscape-preferences.cpp:832
+#: ../src/ui/dialog/inkscape-preferences.cpp:857
 msgid "Origin X:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:778
-#: ../src/ui/dialog/inkscape-preferences.cpp:803
+#: ../src/ui/dialog/inkscape-preferences.cpp:833
+#: ../src/ui/dialog/inkscape-preferences.cpp:858
 msgid "Origin Y:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:783
+#: ../src/ui/dialog/inkscape-preferences.cpp:838
 msgid "Spacing X:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:784
-#: ../src/ui/dialog/inkscape-preferences.cpp:806
+#: ../src/ui/dialog/inkscape-preferences.cpp:839
+#: ../src/ui/dialog/inkscape-preferences.cpp:861
 msgid "Spacing Y:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:786
-#: ../src/ui/dialog/inkscape-preferences.cpp:787
-#: ../src/ui/dialog/inkscape-preferences.cpp:811
-#: ../src/ui/dialog/inkscape-preferences.cpp:812
+#: ../src/ui/dialog/inkscape-preferences.cpp:841
+#: ../src/ui/dialog/inkscape-preferences.cpp:842
+#: ../src/ui/dialog/inkscape-preferences.cpp:866
+#: ../src/ui/dialog/inkscape-preferences.cpp:867
 msgid "Minor grid line color:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:787
-#: ../src/ui/dialog/inkscape-preferences.cpp:812
+#: ../src/ui/dialog/inkscape-preferences.cpp:842
+#: ../src/ui/dialog/inkscape-preferences.cpp:867
 msgid "Color used for normal grid lines"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:788
-#: ../src/ui/dialog/inkscape-preferences.cpp:789
-#: ../src/ui/dialog/inkscape-preferences.cpp:813
-#: ../src/ui/dialog/inkscape-preferences.cpp:814
+#: ../src/ui/dialog/inkscape-preferences.cpp:843
+#: ../src/ui/dialog/inkscape-preferences.cpp:844
+#: ../src/ui/dialog/inkscape-preferences.cpp:868
+#: ../src/ui/dialog/inkscape-preferences.cpp:869
 msgid "Major grid line color:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:789
-#: ../src/ui/dialog/inkscape-preferences.cpp:814
+#: ../src/ui/dialog/inkscape-preferences.cpp:844
+#: ../src/ui/dialog/inkscape-preferences.cpp:869
 msgid "Color used for major (highlighted) grid lines"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:791
-#: ../src/ui/dialog/inkscape-preferences.cpp:816
+#: ../src/ui/dialog/inkscape-preferences.cpp:846
+#: ../src/ui/dialog/inkscape-preferences.cpp:871
 msgid "Major grid line every:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:792
+#: ../src/ui/dialog/inkscape-preferences.cpp:847
 msgid "Show dots instead of lines"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:793
+#: ../src/ui/dialog/inkscape-preferences.cpp:848
 msgid "If set, display dots at gridpoints instead of gridlines"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:867
+#: ../src/ui/dialog/inkscape-preferences.cpp:922
 msgid "Input/Output"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:870
+#: ../src/ui/dialog/inkscape-preferences.cpp:925
 msgid "Use current directory for \"Save As ...\""
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:872
+#: ../src/ui/dialog/inkscape-preferences.cpp:927
 msgid ""
 "When this option is on, the \"Save as...\" and \"Save a Copy...\" dialogs "
 "will always open in the directory where the currently open document is; when "
@@ -19093,176 +19268,176 @@ msgid ""
 "it"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:874
+#: ../src/ui/dialog/inkscape-preferences.cpp:929
 msgid "Add label comments to printing output"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:876
+#: ../src/ui/dialog/inkscape-preferences.cpp:931
 msgid ""
 "When on, a comment will be added to the raw print output, marking the "
 "rendered output for an object with its label"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:878
+#: ../src/ui/dialog/inkscape-preferences.cpp:933
 msgid "Add default metadata to new documents"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:880
+#: ../src/ui/dialog/inkscape-preferences.cpp:935
 msgid ""
 "Add default metadata to new documents. Default metadata can be set from "
 "Document Properties->Metadata."
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:884
+#: ../src/ui/dialog/inkscape-preferences.cpp:939
 msgid "_Grab sensitivity:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:884
+#: ../src/ui/dialog/inkscape-preferences.cpp:939
 msgid "pixels (requires restart)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:885
+#: ../src/ui/dialog/inkscape-preferences.cpp:940
 msgid ""
 "How close on the screen you need to be to an object to be able to grab it "
 "with mouse (in screen pixels)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:887
+#: ../src/ui/dialog/inkscape-preferences.cpp:942
 msgid "_Click/drag threshold:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:887
-#: ../src/ui/dialog/inkscape-preferences.cpp:1223
-#: ../src/ui/dialog/inkscape-preferences.cpp:1227
-#: ../src/ui/dialog/inkscape-preferences.cpp:1237
+#: ../src/ui/dialog/inkscape-preferences.cpp:942
+#: ../src/ui/dialog/inkscape-preferences.cpp:1278
+#: ../src/ui/dialog/inkscape-preferences.cpp:1282
+#: ../src/ui/dialog/inkscape-preferences.cpp:1292
 msgid "pixels"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:888
+#: ../src/ui/dialog/inkscape-preferences.cpp:943
 msgid ""
 "Maximum mouse drag (in screen pixels) which is considered a click, not a drag"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:891
+#: ../src/ui/dialog/inkscape-preferences.cpp:946
 msgid "_Handle size:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:892
+#: ../src/ui/dialog/inkscape-preferences.cpp:947
 msgid "Set the relative size of node handles"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:894
+#: ../src/ui/dialog/inkscape-preferences.cpp:949
 msgid "Use pressure-sensitive tablet (requires restart)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:896
+#: ../src/ui/dialog/inkscape-preferences.cpp:951
 msgid ""
 "Use the capabilities of a tablet or other pressure-sensitive device. Disable "
 "this only if you have problems with the tablet (you can still use it as a "
 "mouse)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:898
+#: ../src/ui/dialog/inkscape-preferences.cpp:953
 msgid "Switch tool based on tablet device (requires restart)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:900
+#: ../src/ui/dialog/inkscape-preferences.cpp:955
 msgid ""
 "Change tool as different devices are used on the tablet (pen, eraser, mouse)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:901
+#: ../src/ui/dialog/inkscape-preferences.cpp:956
 msgid "Input devices"
 msgstr ""
 
 #. SVG output options
-#: ../src/ui/dialog/inkscape-preferences.cpp:904
+#: ../src/ui/dialog/inkscape-preferences.cpp:959
 msgid "Use named colors"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:905
+#: ../src/ui/dialog/inkscape-preferences.cpp:960
 msgid ""
 "If set, write the CSS name of the color when available (e.g. 'red' or "
 "'magenta') instead of the numeric value"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:907
+#: ../src/ui/dialog/inkscape-preferences.cpp:962
 msgid "XML formatting"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:909
+#: ../src/ui/dialog/inkscape-preferences.cpp:964
 msgid "Inline attributes"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:910
+#: ../src/ui/dialog/inkscape-preferences.cpp:965
 msgid "Put attributes on the same line as the element tag"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:913
+#: ../src/ui/dialog/inkscape-preferences.cpp:968
 msgid "_Indent, spaces:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:913
+#: ../src/ui/dialog/inkscape-preferences.cpp:968
 msgid ""
 "The number of spaces to use for indenting nested elements; set to 0 for no "
 "indentation"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:915
+#: ../src/ui/dialog/inkscape-preferences.cpp:970
 msgid "Path data"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:918
+#: ../src/ui/dialog/inkscape-preferences.cpp:973
 msgid "Absolute"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:918
+#: ../src/ui/dialog/inkscape-preferences.cpp:973
 msgid "Relative"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:918
-#: ../src/ui/dialog/inkscape-preferences.cpp:1202
+#: ../src/ui/dialog/inkscape-preferences.cpp:973
+#: ../src/ui/dialog/inkscape-preferences.cpp:1257
 msgid "Optimized"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:922
+#: ../src/ui/dialog/inkscape-preferences.cpp:977
 msgid "Path string format:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:922
+#: ../src/ui/dialog/inkscape-preferences.cpp:977
 msgid ""
 "Path data should be written: only with absolute coordinates, only with "
 "relative coordinates, or optimized for string length (mixed absolute and "
 "relative coordinates)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:924
+#: ../src/ui/dialog/inkscape-preferences.cpp:979
 msgid "Force repeat commands"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:925
+#: ../src/ui/dialog/inkscape-preferences.cpp:980
 msgid ""
 "Force repeating of the same path command (for example, 'L 1,2 L 3,4' instead "
 "of 'L 1,2 3,4')"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:927
+#: ../src/ui/dialog/inkscape-preferences.cpp:982
 msgid "Numbers"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:930
+#: ../src/ui/dialog/inkscape-preferences.cpp:985
 msgid "_Numeric precision:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:930
+#: ../src/ui/dialog/inkscape-preferences.cpp:985
 msgid "Significant figures of the values written to the SVG file"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:933
+#: ../src/ui/dialog/inkscape-preferences.cpp:988
 msgid "Minimum _exponent:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:933
+#: ../src/ui/dialog/inkscape-preferences.cpp:988
 msgid ""
 "The smallest number written to SVG is 10 to the power of this exponent; "
 "anything smaller is written as zero"
@@ -19270,56 +19445,56 @@ msgstr ""
 
 #. Code to add controls for attribute checking options
 #. Add incorrect style properties options
-#: ../src/ui/dialog/inkscape-preferences.cpp:938
+#: ../src/ui/dialog/inkscape-preferences.cpp:993
 msgid "Improper Attributes Actions"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:940
-#: ../src/ui/dialog/inkscape-preferences.cpp:948
-#: ../src/ui/dialog/inkscape-preferences.cpp:956
+#: ../src/ui/dialog/inkscape-preferences.cpp:995
+#: ../src/ui/dialog/inkscape-preferences.cpp:1003
+#: ../src/ui/dialog/inkscape-preferences.cpp:1011
 msgid "Print warnings"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:941
+#: ../src/ui/dialog/inkscape-preferences.cpp:996
 msgid ""
 "Print warning if invalid or non-useful attributes found. Database files "
 "located in inkscape_data_dir/attributes."
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:942
+#: ../src/ui/dialog/inkscape-preferences.cpp:997
 msgid "Remove attributes"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:943
+#: ../src/ui/dialog/inkscape-preferences.cpp:998
 msgid "Delete invalid or non-useful attributes from element tag"
 msgstr ""
 
 #. Add incorrect style properties options
-#: ../src/ui/dialog/inkscape-preferences.cpp:946
+#: ../src/ui/dialog/inkscape-preferences.cpp:1001
 msgid "Inappropriate Style Properties Actions"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:949
+#: ../src/ui/dialog/inkscape-preferences.cpp:1004
 msgid ""
 "Print warning if inappropriate style properties found (i.e. 'font-family' "
 "set on a <rect>). Database files located in inkscape_data_dir/attributes."
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:950
-#: ../src/ui/dialog/inkscape-preferences.cpp:958
+#: ../src/ui/dialog/inkscape-preferences.cpp:1005
+#: ../src/ui/dialog/inkscape-preferences.cpp:1013
 msgid "Remove style properties"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:951
+#: ../src/ui/dialog/inkscape-preferences.cpp:1006
 msgid "Delete inappropriate style properties"
 msgstr ""
 
 #. Add default or inherited style properties options
-#: ../src/ui/dialog/inkscape-preferences.cpp:954
+#: ../src/ui/dialog/inkscape-preferences.cpp:1009
 msgid "Non-useful Style Properties Actions"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:957
+#: ../src/ui/dialog/inkscape-preferences.cpp:1012
 msgid ""
 "Print warning if redundant style properties found (i.e. if a property has "
 "the default value and a different value is not inherited or if value is the "
@@ -19327,207 +19502,207 @@ msgid ""
 "attributes."
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:959
+#: ../src/ui/dialog/inkscape-preferences.cpp:1014
 msgid "Delete redundant style properties"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:961
+#: ../src/ui/dialog/inkscape-preferences.cpp:1016
 msgid "Check Attributes and Style Properties on"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:963
+#: ../src/ui/dialog/inkscape-preferences.cpp:1018
 msgid "Reading"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:964
+#: ../src/ui/dialog/inkscape-preferences.cpp:1019
 msgid ""
 "Check attributes and style properties on reading in SVG files (including "
 "those internal to Inkscape which will slow down startup)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:965
+#: ../src/ui/dialog/inkscape-preferences.cpp:1020
 msgid "Editing"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:966
+#: ../src/ui/dialog/inkscape-preferences.cpp:1021
 msgid ""
 "Check attributes and style properties while editing SVG files (may slow down "
 "Inkscape, mostly useful for debugging)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:967
+#: ../src/ui/dialog/inkscape-preferences.cpp:1022
 msgid "Writing"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:968
+#: ../src/ui/dialog/inkscape-preferences.cpp:1023
 msgid "Check attributes and style properties on writing out SVG files"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:970
+#: ../src/ui/dialog/inkscape-preferences.cpp:1025
 msgid "SVG output"
 msgstr ""
 
 #. TRANSLATORS: see http://www.newsandtech.com/issues/2004/03-04/pt/03-04_rendering.htm
-#: ../src/ui/dialog/inkscape-preferences.cpp:976
+#: ../src/ui/dialog/inkscape-preferences.cpp:1031
 msgid "Perceptual"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:976
+#: ../src/ui/dialog/inkscape-preferences.cpp:1031
 msgid "Relative Colorimetric"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:976
+#: ../src/ui/dialog/inkscape-preferences.cpp:1031
 msgid "Absolute Colorimetric"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:980
+#: ../src/ui/dialog/inkscape-preferences.cpp:1035
 msgid "(Note: Color management has been disabled in this build)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:984
+#: ../src/ui/dialog/inkscape-preferences.cpp:1039
 msgid "Display adjustment"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:993
+#: ../src/ui/dialog/inkscape-preferences.cpp:1048
 #, c-format
 msgid ""
 "The ICC profile to use to calibrate display output.\n"
 "Searched directories:%s"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:994
+#: ../src/ui/dialog/inkscape-preferences.cpp:1049
 msgid "Display profile:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:999
+#: ../src/ui/dialog/inkscape-preferences.cpp:1054
 msgid "Retrieve profile from display"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1002
+#: ../src/ui/dialog/inkscape-preferences.cpp:1057
 msgid "Retrieve profiles from those attached to displays via XICC"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1004
+#: ../src/ui/dialog/inkscape-preferences.cpp:1059
 msgid "Retrieve profiles from those attached to displays"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1009
+#: ../src/ui/dialog/inkscape-preferences.cpp:1064
 msgid "Display rendering intent:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1010
+#: ../src/ui/dialog/inkscape-preferences.cpp:1065
 msgid "The rendering intent to use to calibrate display output"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1012
+#: ../src/ui/dialog/inkscape-preferences.cpp:1067
 msgid "Proofing"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1014
+#: ../src/ui/dialog/inkscape-preferences.cpp:1069
 msgid "Simulate output on screen"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1016
+#: ../src/ui/dialog/inkscape-preferences.cpp:1071
 msgid "Simulates output of target device"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1018
+#: ../src/ui/dialog/inkscape-preferences.cpp:1073
 msgid "Mark out of gamut colors"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1020
+#: ../src/ui/dialog/inkscape-preferences.cpp:1075
 msgid "Highlights colors that are out of gamut for the target device"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1027
+#: ../src/ui/dialog/inkscape-preferences.cpp:1082
 msgid "Out of gamut warning color:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1028
+#: ../src/ui/dialog/inkscape-preferences.cpp:1083
 msgid "Selects the color used for out of gamut warning"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1030
+#: ../src/ui/dialog/inkscape-preferences.cpp:1085
 msgid "Device profile:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1031
+#: ../src/ui/dialog/inkscape-preferences.cpp:1086
 msgid "The ICC profile to use to simulate device output"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1034
+#: ../src/ui/dialog/inkscape-preferences.cpp:1089
 msgid "Device rendering intent:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1035
+#: ../src/ui/dialog/inkscape-preferences.cpp:1090
 msgid "The rendering intent to use to calibrate device output"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1037
+#: ../src/ui/dialog/inkscape-preferences.cpp:1092
 msgid "Black point compensation"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1039
+#: ../src/ui/dialog/inkscape-preferences.cpp:1094
 msgid "Enables black point compensation"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1041
+#: ../src/ui/dialog/inkscape-preferences.cpp:1096
 msgid "Preserve black"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1048
+#: ../src/ui/dialog/inkscape-preferences.cpp:1103
 msgid "(LittleCMS 1.15 or later required)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1050
+#: ../src/ui/dialog/inkscape-preferences.cpp:1105
 msgid "Preserve K channel in CMYK -> CMYK transforms"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1064
+#: ../src/ui/dialog/inkscape-preferences.cpp:1119
 #: ../src/ui/widget/color-icc-selector.cpp:372
 #: ../src/ui/widget/color-icc-selector.cpp:671
 msgid "<none>"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1109
+#: ../src/ui/dialog/inkscape-preferences.cpp:1164
 msgid "Color management"
 msgstr ""
 
 #. Autosave options
-#: ../src/ui/dialog/inkscape-preferences.cpp:1112
+#: ../src/ui/dialog/inkscape-preferences.cpp:1167
 msgid "Enable autosave (requires restart)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1113
+#: ../src/ui/dialog/inkscape-preferences.cpp:1168
 msgid ""
 "Automatically save the current document(s) at a given interval, thus "
 "minimizing loss in case of a crash"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1119
+#: ../src/ui/dialog/inkscape-preferences.cpp:1174
 msgctxt "Filesystem"
 msgid "Autosave _directory:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1119
+#: ../src/ui/dialog/inkscape-preferences.cpp:1174
 msgid ""
 "The directory where autosaves will be written. This should be an absolute "
 "path (starts with / on UNIX or a drive letter such as C: on Windows). "
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1121
+#: ../src/ui/dialog/inkscape-preferences.cpp:1176
 msgid "_Interval (in minutes):"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1121
+#: ../src/ui/dialog/inkscape-preferences.cpp:1176
 msgid "Interval (in minutes) at which document will be autosaved"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1123
+#: ../src/ui/dialog/inkscape-preferences.cpp:1178
 msgid "_Maximum number of autosaves:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1123
+#: ../src/ui/dialog/inkscape-preferences.cpp:1178
 msgid ""
 "Maximum number of autosaved files; use this to limit the storage space used"
 msgstr ""
@@ -19544,659 +19719,663 @@ msgstr ""
 #. _autosave_autosave_interval.signal_changed().connect( sigc::ptr_fun(inkscape_autosave_init), TRUE );
 #.
 #. -----------
-#: ../src/ui/dialog/inkscape-preferences.cpp:1138
+#: ../src/ui/dialog/inkscape-preferences.cpp:1193
 msgid "Autosave"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1142
+#: ../src/ui/dialog/inkscape-preferences.cpp:1197
 msgid "Open Clip Art Library _Server Name:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1143
+#: ../src/ui/dialog/inkscape-preferences.cpp:1198
 msgid ""
 "The server name of the Open Clip Art Library webdav server; it's used by the "
 "Import and Export to OCAL function"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1145
+#: ../src/ui/dialog/inkscape-preferences.cpp:1200
 msgid "Open Clip Art Library _Username:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1146
+#: ../src/ui/dialog/inkscape-preferences.cpp:1201
 msgid "The username used to log into Open Clip Art Library"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1148
+#: ../src/ui/dialog/inkscape-preferences.cpp:1203
 msgid "Open Clip Art Library _Password:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1149
+#: ../src/ui/dialog/inkscape-preferences.cpp:1204
 msgid "The password used to log into Open Clip Art Library"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1150
+#: ../src/ui/dialog/inkscape-preferences.cpp:1205
 msgid "Open Clip Art"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1155
+#: ../src/ui/dialog/inkscape-preferences.cpp:1210
 msgid "Behavior"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1159
+#: ../src/ui/dialog/inkscape-preferences.cpp:1214
 msgid "_Simplification threshold:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1160
+#: ../src/ui/dialog/inkscape-preferences.cpp:1215
 msgid ""
 "How strong is the Node tool's Simplify command by default. If you invoke "
 "this command several times in quick succession, it will act more and more "
 "aggressively; invoking it again after a pause restores the default threshold."
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1162
+#: ../src/ui/dialog/inkscape-preferences.cpp:1217
 msgid "Color stock markers the same color as object"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1163
+#: ../src/ui/dialog/inkscape-preferences.cpp:1218
 msgid "Color custom markers the same color as object"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1164
-#: ../src/ui/dialog/inkscape-preferences.cpp:1387
+#: ../src/ui/dialog/inkscape-preferences.cpp:1219
+#: ../src/ui/dialog/inkscape-preferences.cpp:1447
 msgid "Update marker color when object color changes"
 msgstr ""
 
 #. Selecting options
-#: ../src/ui/dialog/inkscape-preferences.cpp:1167
+#: ../src/ui/dialog/inkscape-preferences.cpp:1222
 msgid "Select in all layers"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1168
+#: ../src/ui/dialog/inkscape-preferences.cpp:1223
 msgid "Select only within current layer"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1169
+#: ../src/ui/dialog/inkscape-preferences.cpp:1224
 msgid "Select in current layer and sublayers"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1170
+#: ../src/ui/dialog/inkscape-preferences.cpp:1225
 msgid "Ignore hidden objects and layers"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1171
+#: ../src/ui/dialog/inkscape-preferences.cpp:1226
 msgid "Ignore locked objects and layers"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1172
+#: ../src/ui/dialog/inkscape-preferences.cpp:1227
 msgid "Deselect upon layer change"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1175
+#: ../src/ui/dialog/inkscape-preferences.cpp:1230
 msgid ""
 "Uncheck this to be able to keep the current objects selected when the "
 "current layer changes"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1177
+#: ../src/ui/dialog/inkscape-preferences.cpp:1232
 msgid "Ctrl+A, Tab, Shift+Tab"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1179
+#: ../src/ui/dialog/inkscape-preferences.cpp:1234
 msgid "Make keyboard selection commands work on objects in all layers"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1181
+#: ../src/ui/dialog/inkscape-preferences.cpp:1236
 msgid "Make keyboard selection commands work on objects in current layer only"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1183
+#: ../src/ui/dialog/inkscape-preferences.cpp:1238
 msgid ""
 "Make keyboard selection commands work on objects in current layer and all "
 "its sublayers"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1185
+#: ../src/ui/dialog/inkscape-preferences.cpp:1240
 msgid ""
 "Uncheck this to be able to select objects that are hidden (either by "
 "themselves or by being in a hidden layer)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1187
+#: ../src/ui/dialog/inkscape-preferences.cpp:1242
 msgid ""
 "Uncheck this to be able to select objects that are locked (either by "
 "themselves or by being in a locked layer)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1189
+#: ../src/ui/dialog/inkscape-preferences.cpp:1244
 msgid "Wrap when cycling objects in z-order"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1191
+#: ../src/ui/dialog/inkscape-preferences.cpp:1246
 msgid "Alt+Scroll Wheel"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1193
+#: ../src/ui/dialog/inkscape-preferences.cpp:1248
 msgid "Wrap around at start and end when cycling objects in z-order"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1195
+#: ../src/ui/dialog/inkscape-preferences.cpp:1250
 msgid "Selecting"
 msgstr ""
 
 #. Transforms options
-#: ../src/ui/dialog/inkscape-preferences.cpp:1198
+#: ../src/ui/dialog/inkscape-preferences.cpp:1253
 #: ../src/widgets/select-toolbar.cpp:554
 msgid "Scale stroke width"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1199
+#: ../src/ui/dialog/inkscape-preferences.cpp:1254
 msgid "Scale rounded corners in rectangles"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1200
+#: ../src/ui/dialog/inkscape-preferences.cpp:1255
 msgid "Transform gradients"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1201
+#: ../src/ui/dialog/inkscape-preferences.cpp:1256
 msgid "Transform patterns"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1203
+#: ../src/ui/dialog/inkscape-preferences.cpp:1258
 msgid "Preserved"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1206
+#: ../src/ui/dialog/inkscape-preferences.cpp:1261
 #: ../src/widgets/select-toolbar.cpp:555
 msgid "When scaling objects, scale the stroke width by the same proportion"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1208
+#: ../src/ui/dialog/inkscape-preferences.cpp:1263
 #: ../src/widgets/select-toolbar.cpp:566
 msgid "When scaling rectangles, scale the radii of rounded corners"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1210
+#: ../src/ui/dialog/inkscape-preferences.cpp:1265
 #: ../src/widgets/select-toolbar.cpp:577
 msgid "Move gradients (in fill or stroke) along with the objects"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1212
+#: ../src/ui/dialog/inkscape-preferences.cpp:1267
 #: ../src/widgets/select-toolbar.cpp:588
 msgid "Move patterns (in fill or stroke) along with the objects"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1213
+#: ../src/ui/dialog/inkscape-preferences.cpp:1268
 msgid "Store transformation"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1215
+#: ../src/ui/dialog/inkscape-preferences.cpp:1270
 msgid ""
 "If possible, apply transformation to objects without adding a transform= "
 "attribute"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1217
+#: ../src/ui/dialog/inkscape-preferences.cpp:1272
 msgid "Always store transformation as a transform= attribute on objects"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1219
+#: ../src/ui/dialog/inkscape-preferences.cpp:1274
 msgid "Transforms"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1223
+#: ../src/ui/dialog/inkscape-preferences.cpp:1278
 msgid "Mouse _wheel scrolls by:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1224
+#: ../src/ui/dialog/inkscape-preferences.cpp:1279
 msgid ""
 "One mouse wheel notch scrolls by this distance in screen pixels "
 "(horizontally with Shift)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1225
+#: ../src/ui/dialog/inkscape-preferences.cpp:1280
 msgid "Ctrl+arrows"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1227
+#: ../src/ui/dialog/inkscape-preferences.cpp:1282
 msgid "Sc_roll by:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1228
+#: ../src/ui/dialog/inkscape-preferences.cpp:1283
 msgid "Pressing Ctrl+arrow key scrolls by this distance (in screen pixels)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1230
+#: ../src/ui/dialog/inkscape-preferences.cpp:1285
 msgid "_Acceleration:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1231
+#: ../src/ui/dialog/inkscape-preferences.cpp:1286
 msgid ""
 "Pressing and holding Ctrl+arrow will gradually speed up scrolling (0 for no "
 "acceleration)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1232
+#: ../src/ui/dialog/inkscape-preferences.cpp:1287
 msgid "Autoscrolling"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1234
+#: ../src/ui/dialog/inkscape-preferences.cpp:1289
 msgid "_Speed:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1235
+#: ../src/ui/dialog/inkscape-preferences.cpp:1290
 msgid ""
 "How fast the canvas autoscrolls when you drag beyond canvas edge (0 to turn "
 "autoscroll off)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1237
+#: ../src/ui/dialog/inkscape-preferences.cpp:1292
 #: ../src/ui/dialog/tracedialog.cpp:520 ../src/ui/dialog/tracedialog.cpp:719
 msgid "_Threshold:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1238
+#: ../src/ui/dialog/inkscape-preferences.cpp:1293
 msgid ""
 "How far (in screen pixels) you need to be from the canvas edge to trigger "
 "autoscroll; positive is outside the canvas, negative is within the canvas"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1239
+#: ../src/ui/dialog/inkscape-preferences.cpp:1294
 msgid "Mouse move pans when Space is pressed"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1241
+#: ../src/ui/dialog/inkscape-preferences.cpp:1296
 msgid "When on, pressing and holding Space and dragging pans canvas"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1242
+#: ../src/ui/dialog/inkscape-preferences.cpp:1297
 msgid "Mouse wheel zooms by default"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1244
+#: ../src/ui/dialog/inkscape-preferences.cpp:1299
 msgid ""
 "When on, mouse wheel zooms without Ctrl and scrolls canvas with Ctrl; when "
 "off, it zooms with Ctrl and scrolls without Ctrl"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1245
+#: ../src/ui/dialog/inkscape-preferences.cpp:1300
 msgid "Scrolling"
 msgstr ""
 
 #. Snapping options
-#: ../src/ui/dialog/inkscape-preferences.cpp:1248
+#: ../src/ui/dialog/inkscape-preferences.cpp:1303
 msgid "Snap indicator"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1250
+#: ../src/ui/dialog/inkscape-preferences.cpp:1305
 msgid "Enable snap indicator"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1252
+#: ../src/ui/dialog/inkscape-preferences.cpp:1307
 msgid "After snapping, a symbol is drawn at the point that has snapped"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1257
+#: ../src/ui/dialog/inkscape-preferences.cpp:1312
 msgid "Snap indicator persistence (in seconds):"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1258
+#: ../src/ui/dialog/inkscape-preferences.cpp:1313
 msgid ""
 "Controls how long the snap indicator message will be shown, before it "
 "disappears"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1260
+#: ../src/ui/dialog/inkscape-preferences.cpp:1315
 msgid "What should snap"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1262
+#: ../src/ui/dialog/inkscape-preferences.cpp:1317
 msgid "Only snap the node closest to the pointer"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1264
+#: ../src/ui/dialog/inkscape-preferences.cpp:1319
 msgid ""
 "Only try to snap the node that is initially closest to the mouse pointer"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1267
+#: ../src/ui/dialog/inkscape-preferences.cpp:1322
 msgid "_Weight factor:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1268
+#: ../src/ui/dialog/inkscape-preferences.cpp:1323
 msgid ""
 "When multiple snap solutions are found, then Inkscape can either prefer the "
 "closest transformation (when set to 0), or prefer the node that was "
 "initially the closest to the pointer (when set to 1)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1270
+#: ../src/ui/dialog/inkscape-preferences.cpp:1325
 msgid "Snap the mouse pointer when dragging a constrained knot"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1272
+#: ../src/ui/dialog/inkscape-preferences.cpp:1327
 msgid ""
 "When dragging a knot along a constraint line, then snap the position of the "
 "mouse pointer instead of snapping the projection of the knot onto the "
 "constraint line"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1274
+#: ../src/ui/dialog/inkscape-preferences.cpp:1329
 msgid "Delayed snap"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1277
+#: ../src/ui/dialog/inkscape-preferences.cpp:1332
 msgid "Delay (in seconds):"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1278
+#: ../src/ui/dialog/inkscape-preferences.cpp:1333
 msgid ""
 "Postpone snapping as long as the mouse is moving, and then wait an "
 "additional fraction of a second. This additional delay is specified here. "
 "When set to zero or to a very small number, snapping will be immediate."
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1280
+#: ../src/ui/dialog/inkscape-preferences.cpp:1335
 msgid "Snapping"
 msgstr ""
 
 #. nudgedistance is limited to 1000 in select-context.cpp: use the same limit here
-#: ../src/ui/dialog/inkscape-preferences.cpp:1285
+#: ../src/ui/dialog/inkscape-preferences.cpp:1340
 msgid "_Arrow keys move by:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1286
+#: ../src/ui/dialog/inkscape-preferences.cpp:1341
 msgid ""
 "Pressing an arrow key moves selected object(s) or node(s) by this distance"
 msgstr ""
 
 #. defaultscale is limited to 1000 in select-context.cpp: use the same limit here
-#: ../src/ui/dialog/inkscape-preferences.cpp:1289
+#: ../src/ui/dialog/inkscape-preferences.cpp:1344
 msgid "> and < _scale by:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1290
+#: ../src/ui/dialog/inkscape-preferences.cpp:1345
 msgid "Pressing > or < scales selection up or down by this increment"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1292
+#: ../src/ui/dialog/inkscape-preferences.cpp:1347
 msgid "_Inset/Outset by:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1293
+#: ../src/ui/dialog/inkscape-preferences.cpp:1348
 msgid "Inset and Outset commands displace the path by this distance"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1294
+#: ../src/ui/dialog/inkscape-preferences.cpp:1349
 msgid "Compass-like display of angles"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1296
+#: ../src/ui/dialog/inkscape-preferences.cpp:1351
 msgid ""
 "When on, angles are displayed with 0 at north, 0 to 360 range, positive "
 "clockwise; otherwise with 0 at east, -180 to 180 range, positive "
 "counterclockwise"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1298
+#: ../src/ui/dialog/inkscape-preferences.cpp:1353
 msgctxt "Rotation angle"
 msgid "None"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1302
+#: ../src/ui/dialog/inkscape-preferences.cpp:1357
 msgid "_Rotation snaps every:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1302
-#: ../src/ui/dialog/inkscape-preferences.cpp:1311
+#: ../src/ui/dialog/inkscape-preferences.cpp:1357
+#: ../src/ui/dialog/inkscape-preferences.cpp:1366
 msgid "degrees"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1303
+#: ../src/ui/dialog/inkscape-preferences.cpp:1358
 msgid ""
 "Rotating with Ctrl pressed snaps every that much degrees; also, pressing "
 "[ or ] rotates by this amount"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1304
+#: ../src/ui/dialog/inkscape-preferences.cpp:1359
 msgid "Relative snapping of guideline angles"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1306
+#: ../src/ui/dialog/inkscape-preferences.cpp:1361
 msgid ""
 "When on, the snap angles when rotating a guideline will be relative to the "
 "original angle"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1308
+#: ../src/ui/dialog/inkscape-preferences.cpp:1363
 msgid "_Zoom in/out by:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1308
-#: ../src/ui/dialog/objects.cpp:1651
-#: ../src/ui/widget/filter-effect-chooser.cpp:23
-msgid "%"
-msgstr ""
-
-#: ../src/ui/dialog/inkscape-preferences.cpp:1309
+#: ../src/ui/dialog/inkscape-preferences.cpp:1364
 msgid ""
 "Zoom tool click, +/- keys, and middle click zoom in and out by this "
 "multiplier"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1311
+#: ../src/ui/dialog/inkscape-preferences.cpp:1366
 msgid "_Rotate canvas by:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1312
+#: ../src/ui/dialog/inkscape-preferences.cpp:1367
 msgid "Rotate canvas clockwise and counter-clockwise by this amount."
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1313
+#: ../src/ui/dialog/inkscape-preferences.cpp:1368
 msgid "Steps"
 msgstr ""
 
 #. Clones options
-#: ../src/ui/dialog/inkscape-preferences.cpp:1316
+#: ../src/ui/dialog/inkscape-preferences.cpp:1371
 msgid "Move in parallel"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1318
+#: ../src/ui/dialog/inkscape-preferences.cpp:1373
 msgid "Stay unmoved"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1320
+#: ../src/ui/dialog/inkscape-preferences.cpp:1375
 msgid "Move according to transform"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1322
+#: ../src/ui/dialog/inkscape-preferences.cpp:1377
 msgid "Are unlinked"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1324
+#: ../src/ui/dialog/inkscape-preferences.cpp:1379
 msgid "Are deleted"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1327
+#: ../src/ui/dialog/inkscape-preferences.cpp:1382
 msgid "Moving original: clones and linked offsets"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1329
+#: ../src/ui/dialog/inkscape-preferences.cpp:1384
 msgid "Clones are translated by the same vector as their original"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1331
+#: ../src/ui/dialog/inkscape-preferences.cpp:1386
 msgid "Clones preserve their positions when their original is moved"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1333
+#: ../src/ui/dialog/inkscape-preferences.cpp:1388
 msgid ""
 "Each clone moves according to the value of its transform= attribute; for "
 "example, a rotated clone will move in a different direction than its original"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1334
+#: ../src/ui/dialog/inkscape-preferences.cpp:1389
 msgid "Deleting original: clones"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1336
+#: ../src/ui/dialog/inkscape-preferences.cpp:1391
 msgid "Orphaned clones are converted to regular objects"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1338
+#: ../src/ui/dialog/inkscape-preferences.cpp:1393
 msgid "Orphaned clones are deleted along with their original"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1340
+#: ../src/ui/dialog/inkscape-preferences.cpp:1395
 msgid "Duplicating original+clones/linked offset"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1342
+#: ../src/ui/dialog/inkscape-preferences.cpp:1397
 msgid "Relink duplicated clones"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1344
+#: ../src/ui/dialog/inkscape-preferences.cpp:1399
 msgid ""
 "When duplicating a selection containing both a clone and its original "
 "(possibly in groups), relink the duplicated clone to the duplicated original "
 "instead of the old original"
 msgstr ""
 
+#: ../src/ui/dialog/inkscape-preferences.cpp:1401
+msgid "Unlinking clones"
+msgstr ""
+
+#: ../src/ui/dialog/inkscape-preferences.cpp:1402
+msgid "Path operations unlink clones"
+msgstr ""
+
+#: ../src/ui/dialog/inkscape-preferences.cpp:1404
+msgid ""
+"The following path operations will unlink clones: Stroke to path, Object to "
+"path, Boolean operations, Combine, Break apart"
+msgstr ""
+
 #. TRANSLATORS: Heading for the Inkscape Preferences "Clones" Page
-#: ../src/ui/dialog/inkscape-preferences.cpp:1347
+#: ../src/ui/dialog/inkscape-preferences.cpp:1407
 msgid "Clones"
 msgstr ""
 
 #. Clip paths and masks options
-#: ../src/ui/dialog/inkscape-preferences.cpp:1350
+#: ../src/ui/dialog/inkscape-preferences.cpp:1410
 msgid "When applying, use the topmost selected object as clippath/mask"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1352
+#: ../src/ui/dialog/inkscape-preferences.cpp:1412
 msgid ""
 "Uncheck this to use the bottom selected object as the clipping path or mask"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1353
+#: ../src/ui/dialog/inkscape-preferences.cpp:1413
 msgid "Remove clippath/mask object after applying"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1355
+#: ../src/ui/dialog/inkscape-preferences.cpp:1415
 msgid ""
 "After applying, remove the object used as the clipping path or mask from the "
 "drawing"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1357
+#: ../src/ui/dialog/inkscape-preferences.cpp:1417
 msgid "Before applying"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1359
+#: ../src/ui/dialog/inkscape-preferences.cpp:1419
 msgid "Do not group clipped/masked objects"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1360
+#: ../src/ui/dialog/inkscape-preferences.cpp:1420
 msgid "Put every clipped/masked object in its own group"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1361
+#: ../src/ui/dialog/inkscape-preferences.cpp:1421
 msgid "Put all clipped/masked objects into one group"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1364
+#: ../src/ui/dialog/inkscape-preferences.cpp:1424
 msgid "Apply clippath/mask to every object"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1367
+#: ../src/ui/dialog/inkscape-preferences.cpp:1427
 msgid "Apply clippath/mask to groups containing single object"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1370
+#: ../src/ui/dialog/inkscape-preferences.cpp:1430
 msgid "Apply clippath/mask to group containing all objects"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1372
+#: ../src/ui/dialog/inkscape-preferences.cpp:1432
 msgid "After releasing"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1374
+#: ../src/ui/dialog/inkscape-preferences.cpp:1434
 msgid "Ungroup automatically created groups"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1376
+#: ../src/ui/dialog/inkscape-preferences.cpp:1436
 msgid "Ungroup groups created when setting clip/mask"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1378
+#: ../src/ui/dialog/inkscape-preferences.cpp:1438
 msgid "Clippaths and masks"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1381
+#: ../src/ui/dialog/inkscape-preferences.cpp:1441
 msgid "Stroke Style Markers"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1383
-#: ../src/ui/dialog/inkscape-preferences.cpp:1385
+#: ../src/ui/dialog/inkscape-preferences.cpp:1443
+#: ../src/ui/dialog/inkscape-preferences.cpp:1445
 msgid ""
 "Stroke color same as object, fill color either object fill color or marker "
 "fill color"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1389
+#: ../src/ui/dialog/inkscape-preferences.cpp:1449
 #: ../share/extensions/hershey.inx.h:27
 msgid "Markers"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1392
+#: ../src/ui/dialog/inkscape-preferences.cpp:1452
 msgid "Document cleanup"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1393
-#: ../src/ui/dialog/inkscape-preferences.cpp:1395
+#: ../src/ui/dialog/inkscape-preferences.cpp:1453
+#: ../src/ui/dialog/inkscape-preferences.cpp:1455
 msgid "Remove unused swatches when doing a document cleanup"
 msgstr ""
 
 #. tooltip
-#: ../src/ui/dialog/inkscape-preferences.cpp:1396
+#: ../src/ui/dialog/inkscape-preferences.cpp:1456
 msgid "Cleanup"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1404
+#: ../src/ui/dialog/inkscape-preferences.cpp:1464
 msgid "Number of _Threads:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1404
-#: ../src/ui/dialog/inkscape-preferences.cpp:1936
+#: ../src/ui/dialog/inkscape-preferences.cpp:1464
+#: ../src/ui/dialog/inkscape-preferences.cpp:1992
 msgid "(requires restart)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1405
+#: ../src/ui/dialog/inkscape-preferences.cpp:1465
 msgid "Configure number of processors/threads to use when rendering filters"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1409
+#: ../src/ui/dialog/inkscape-preferences.cpp:1469
 msgid "Rendering _cache size:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1409
+#: ../src/ui/dialog/inkscape-preferences.cpp:1469
 msgctxt "mebibyte (2^20 bytes) abbreviation"
 msgid "MiB"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1409
+#: ../src/ui/dialog/inkscape-preferences.cpp:1469
 msgid ""
 "Set the amount of memory per document which can be used to store rendered "
 "parts of the drawing for later reuse; set to zero to disable caching"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1413
+#: ../src/ui/dialog/inkscape-preferences.cpp:1473
 msgid "Rendering tile multiplier:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1413
-msgid "requires restart"
-msgstr ""
-
-#: ../src/ui/dialog/inkscape-preferences.cpp:1413
+#: ../src/ui/dialog/inkscape-preferences.cpp:1474
 msgid ""
 "Set the relative size of tiles used to render the canvas. The larger the "
 "value, the bigger the tile size."
@@ -20204,467 +20383,467 @@ msgstr ""
 
 #. blur quality
 #. filter quality
-#: ../src/ui/dialog/inkscape-preferences.cpp:1416
-#: ../src/ui/dialog/inkscape-preferences.cpp:1440
+#: ../src/ui/dialog/inkscape-preferences.cpp:1477
+#: ../src/ui/dialog/inkscape-preferences.cpp:1501
 msgid "Best quality (slowest)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1418
-#: ../src/ui/dialog/inkscape-preferences.cpp:1442
+#: ../src/ui/dialog/inkscape-preferences.cpp:1479
+#: ../src/ui/dialog/inkscape-preferences.cpp:1503
 msgid "Better quality (slower)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1420
-#: ../src/ui/dialog/inkscape-preferences.cpp:1444
+#: ../src/ui/dialog/inkscape-preferences.cpp:1481
+#: ../src/ui/dialog/inkscape-preferences.cpp:1505
 msgid "Average quality"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1422
-#: ../src/ui/dialog/inkscape-preferences.cpp:1446
+#: ../src/ui/dialog/inkscape-preferences.cpp:1483
+#: ../src/ui/dialog/inkscape-preferences.cpp:1507
 msgid "Lower quality (faster)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1424
-#: ../src/ui/dialog/inkscape-preferences.cpp:1448
+#: ../src/ui/dialog/inkscape-preferences.cpp:1485
+#: ../src/ui/dialog/inkscape-preferences.cpp:1509
 msgid "Lowest quality (fastest)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1427
+#: ../src/ui/dialog/inkscape-preferences.cpp:1488
 msgid "Gaussian blur quality for display"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1429
-#: ../src/ui/dialog/inkscape-preferences.cpp:1453
+#: ../src/ui/dialog/inkscape-preferences.cpp:1490
+#: ../src/ui/dialog/inkscape-preferences.cpp:1514
 msgid ""
 "Best quality, but display may be very slow at high zooms (bitmap export "
 "always uses best quality)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1431
-#: ../src/ui/dialog/inkscape-preferences.cpp:1455
+#: ../src/ui/dialog/inkscape-preferences.cpp:1492
+#: ../src/ui/dialog/inkscape-preferences.cpp:1516
 msgid "Better quality, but slower display"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1433
-#: ../src/ui/dialog/inkscape-preferences.cpp:1457
+#: ../src/ui/dialog/inkscape-preferences.cpp:1494
+#: ../src/ui/dialog/inkscape-preferences.cpp:1518
 msgid "Average quality, acceptable display speed"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1435
-#: ../src/ui/dialog/inkscape-preferences.cpp:1459
+#: ../src/ui/dialog/inkscape-preferences.cpp:1496
+#: ../src/ui/dialog/inkscape-preferences.cpp:1520
 msgid "Lower quality (some artifacts), but display is faster"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1437
-#: ../src/ui/dialog/inkscape-preferences.cpp:1461
+#: ../src/ui/dialog/inkscape-preferences.cpp:1498
+#: ../src/ui/dialog/inkscape-preferences.cpp:1522
 msgid "Lowest quality (considerable artifacts), but display is fastest"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1451
+#: ../src/ui/dialog/inkscape-preferences.cpp:1512
 msgid "Filter effects quality for display"
 msgstr ""
 
 #. build custom preferences tab
-#: ../src/ui/dialog/inkscape-preferences.cpp:1463
-#: ../src/ui/dialog/print.cpp:204
+#: ../src/ui/dialog/inkscape-preferences.cpp:1524
+#: ../src/ui/dialog/print.cpp:207
 msgid "Rendering"
 msgstr ""
 
 #. Note: /options/bitmapoversample removed with Cairo renderer
-#: ../src/ui/dialog/inkscape-preferences.cpp:1469 ../src/verbs.cpp:151
-#: ../src/widgets/calligraphy-toolbar.cpp:626
+#: ../src/ui/dialog/inkscape-preferences.cpp:1530 ../src/verbs.cpp:154
+#: ../src/widgets/calligraphy-toolbar.cpp:606
 msgid "Edit"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1470
+#: ../src/ui/dialog/inkscape-preferences.cpp:1531
 msgid "Automatically reload bitmaps"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1472
+#: ../src/ui/dialog/inkscape-preferences.cpp:1533
 msgid "Automatically reload linked images when file is changed on disk"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1474
+#: ../src/ui/dialog/inkscape-preferences.cpp:1535
 msgid "_Bitmap editor:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1476
-#: ../share/extensions/guillotine.inx.h:5 ../share/extensions/plotter.inx.h:65
+#: ../src/ui/dialog/inkscape-preferences.cpp:1537
+#: ../share/extensions/guillotine.inx.h:5 ../share/extensions/plotter.inx.h:67
 #: ../share/extensions/prepare_file_save_as.inx.h:2
 #: ../share/extensions/prepare_print_win32_vector.inx.h:2
 #: ../share/extensions/print_win32_vector.inx.h:2
 msgid "Export"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1478
+#: ../src/ui/dialog/inkscape-preferences.cpp:1539
 msgid "Default export _resolution:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1479
+#: ../src/ui/dialog/inkscape-preferences.cpp:1540
 msgid "Default bitmap resolution (in dots per inch) in the Export dialog"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1480
+#: ../src/ui/dialog/inkscape-preferences.cpp:1541
 #: ../src/ui/dialog/xml-tree.cpp:911
 msgid "Create"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1482
+#: ../src/ui/dialog/inkscape-preferences.cpp:1543
 msgid "Resolution for Create Bitmap _Copy:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1483
+#: ../src/ui/dialog/inkscape-preferences.cpp:1544
 msgid "Resolution used by the Create Bitmap Copy command"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1486
+#: ../src/ui/dialog/inkscape-preferences.cpp:1547
 msgid "Ask about linking and scaling when importing"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1488
+#: ../src/ui/dialog/inkscape-preferences.cpp:1549
 msgid "Pop-up linking and scaling dialog when importing bitmap image."
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1494
+#: ../src/ui/dialog/inkscape-preferences.cpp:1555
 msgid "Bitmap link:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1501
+#: ../src/ui/dialog/inkscape-preferences.cpp:1562
 msgid "Bitmap scale (image-rendering):"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1506
+#: ../src/ui/dialog/inkscape-preferences.cpp:1567
 msgid "Default _import resolution:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1507
+#: ../src/ui/dialog/inkscape-preferences.cpp:1568
 msgid "Default bitmap resolution (in dots per inch) for bitmap import"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1508
+#: ../src/ui/dialog/inkscape-preferences.cpp:1569
 msgid "Override file resolution"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1510
+#: ../src/ui/dialog/inkscape-preferences.cpp:1571
 msgid "Use default bitmap resolution in favor of information from file"
 msgstr ""
 
 #. rendering outlines for pixmap image tags
-#: ../src/ui/dialog/inkscape-preferences.cpp:1514
+#: ../src/ui/dialog/inkscape-preferences.cpp:1575
 msgid "Images in Outline Mode"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1515
+#: ../src/ui/dialog/inkscape-preferences.cpp:1576
 msgid ""
 "When active will render images while in outline mode instead of a red box "
 "with an x. This is useful for manual tracing."
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1517
+#: ../src/ui/dialog/inkscape-preferences.cpp:1578
 msgid "Bitmaps"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1529
+#: ../src/ui/dialog/inkscape-preferences.cpp:1590
 msgid ""
 "Select a file of predefined shortcuts to use. Any customized shortcuts you "
 "create will be added separately to "
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1532
+#: ../src/ui/dialog/inkscape-preferences.cpp:1593
 msgid "Shortcut file:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1535
+#: ../src/ui/dialog/inkscape-preferences.cpp:1596
 #: ../src/ui/dialog/template-load-tab.cpp:43
 msgid "Search:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1547
+#: ../src/ui/dialog/inkscape-preferences.cpp:1608
 msgid "Shortcut"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1548
-#: ../src/ui/widget/page-sizer.cpp:270
+#: ../src/ui/dialog/inkscape-preferences.cpp:1609
+#: ../src/ui/widget/page-sizer.cpp:271
 msgid "Description"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1591
+#: ../src/ui/dialog/inkscape-preferences.cpp:1652
 msgid ""
 "Remove all your customized keyboard shortcuts, and revert to the shortcuts "
 "in the shortcut file listed above"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1595
+#: ../src/ui/dialog/inkscape-preferences.cpp:1656
 msgid "Import ..."
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1595
+#: ../src/ui/dialog/inkscape-preferences.cpp:1656
 msgid "Import custom keyboard shortcuts from a file"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1598
+#: ../src/ui/dialog/inkscape-preferences.cpp:1659
 msgid "Export ..."
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1598
+#: ../src/ui/dialog/inkscape-preferences.cpp:1659
 msgid "Export custom keyboard shortcuts to a file"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1608
+#: ../src/ui/dialog/inkscape-preferences.cpp:1669
 msgid "Keyboard Shortcuts"
 msgstr ""
 
 #. Find this group in the tree
-#: ../src/ui/dialog/inkscape-preferences.cpp:1771
+#: ../src/ui/dialog/inkscape-preferences.cpp:1832
 msgid "Misc"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1877
+#: ../src/ui/dialog/inkscape-preferences.cpp:1938
 msgctxt "Spellchecker language"
 msgid "None"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1898
+#: ../src/ui/dialog/inkscape-preferences.cpp:1959
 msgid "Set the main spell check language"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1901
+#: ../src/ui/dialog/inkscape-preferences.cpp:1962
 msgid "Second language:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1902
+#: ../src/ui/dialog/inkscape-preferences.cpp:1963
 msgid ""
 "Set the second spell check language; checking will only stop on words "
 "unknown in ALL chosen languages"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1905
+#: ../src/ui/dialog/inkscape-preferences.cpp:1966
 msgid "Third language:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1906
+#: ../src/ui/dialog/inkscape-preferences.cpp:1967
 msgid ""
 "Set the third spell check language; checking will only stop on words unknown "
 "in ALL chosen languages"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1908
+#: ../src/ui/dialog/inkscape-preferences.cpp:1969
 msgid "Ignore words with digits"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1910
+#: ../src/ui/dialog/inkscape-preferences.cpp:1971
 msgid "Ignore words containing digits, such as \"R2D2\""
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1912
+#: ../src/ui/dialog/inkscape-preferences.cpp:1973
 msgid "Ignore words in ALL CAPITALS"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1914
+#: ../src/ui/dialog/inkscape-preferences.cpp:1975
 msgid "Ignore words in all capitals, such as \"IUPAC\""
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1916
+#: ../src/ui/dialog/inkscape-preferences.cpp:1977
 msgid "Spellcheck"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1936
+#: ../src/ui/dialog/inkscape-preferences.cpp:1992
 msgid "Latency _skew:"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1937
+#: ../src/ui/dialog/inkscape-preferences.cpp:1993
 msgid ""
 "Factor by which the event clock is skewed from the actual time (0.9766 on "
 "some systems)"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1939
+#: ../src/ui/dialog/inkscape-preferences.cpp:1995
 msgid "Pre-render named icons"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1941
+#: ../src/ui/dialog/inkscape-preferences.cpp:1997
 msgid ""
 "When on, named icons will be rendered before displaying the ui. This is for "
 "working around bugs in GTK+ named icon notification"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1949
+#: ../src/ui/dialog/inkscape-preferences.cpp:2001
 msgid "System info"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1953
+#: ../src/ui/dialog/inkscape-preferences.cpp:2005
 msgid "User config: "
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1953
+#: ../src/ui/dialog/inkscape-preferences.cpp:2005
 msgid "Location of users configuration"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1957
+#: ../src/ui/dialog/inkscape-preferences.cpp:2009
 msgid "User preferences: "
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1957
+#: ../src/ui/dialog/inkscape-preferences.cpp:2009
 msgid "Location of the users preferences file"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1961
+#: ../src/ui/dialog/inkscape-preferences.cpp:2013
 msgid "User extensions: "
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1961
+#: ../src/ui/dialog/inkscape-preferences.cpp:2013
 msgid "Location of the users extensions"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1965
+#: ../src/ui/dialog/inkscape-preferences.cpp:2017
 msgid "User cache: "
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1965
+#: ../src/ui/dialog/inkscape-preferences.cpp:2017
 msgid "Location of users cache"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1973
+#: ../src/ui/dialog/inkscape-preferences.cpp:2025
 msgid "Temporary files: "
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1973
+#: ../src/ui/dialog/inkscape-preferences.cpp:2025
 msgid "Location of the temporary files used for autosave"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1977
+#: ../src/ui/dialog/inkscape-preferences.cpp:2029
 msgid "Inkscape data: "
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1977
+#: ../src/ui/dialog/inkscape-preferences.cpp:2029
 msgid "Location of Inkscape data"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1981
+#: ../src/ui/dialog/inkscape-preferences.cpp:2033
 msgid "Inkscape extensions: "
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1981
+#: ../src/ui/dialog/inkscape-preferences.cpp:2033
 msgid "Location of the Inkscape extensions"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1990
+#: ../src/ui/dialog/inkscape-preferences.cpp:2043
 msgid "System data: "
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:1990
+#: ../src/ui/dialog/inkscape-preferences.cpp:2043
 msgid "Locations of system data"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:2014
+#: ../src/ui/dialog/inkscape-preferences.cpp:2057
 msgid "Icon theme: "
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:2014
+#: ../src/ui/dialog/inkscape-preferences.cpp:2057
 msgid "Locations of icon themes"
 msgstr ""
 
-#: ../src/ui/dialog/inkscape-preferences.cpp:2016
+#: ../src/ui/dialog/inkscape-preferences.cpp:2059
 msgid "System"
 msgstr ""
 
-#: ../src/ui/dialog/input.cpp:345 ../src/ui/dialog/input.cpp:366
-#: ../src/ui/dialog/input.cpp:1467 ../src/widgets/toolbox.cpp:227
+#: ../src/ui/dialog/input.cpp:346 ../src/ui/dialog/input.cpp:367
+#: ../src/ui/dialog/input.cpp:1468 ../src/widgets/toolbox.cpp:227
 msgid "Disabled"
 msgstr ""
 
-#: ../src/ui/dialog/input.cpp:346
+#: ../src/ui/dialog/input.cpp:347
 msgctxt "Input device"
 msgid "Screen"
 msgstr ""
 
-#: ../src/ui/dialog/input.cpp:347 ../src/ui/dialog/input.cpp:368
+#: ../src/ui/dialog/input.cpp:348 ../src/ui/dialog/input.cpp:369
 msgid "Window"
 msgstr ""
 
-#: ../src/ui/dialog/input.cpp:578
+#: ../src/ui/dialog/input.cpp:579
 msgid "Test Area"
 msgstr ""
 
-#: ../src/ui/dialog/input.cpp:579
+#: ../src/ui/dialog/input.cpp:580
 msgid "Axis"
 msgstr ""
 
-#: ../src/ui/dialog/input.cpp:651 ../share/extensions/svgcalendar.inx.h:2
+#: ../src/ui/dialog/input.cpp:652 ../share/extensions/svgcalendar.inx.h:2
 msgid "Configuration"
 msgstr ""
 
-#: ../src/ui/dialog/input.cpp:652
+#: ../src/ui/dialog/input.cpp:653
 msgid "Hardware"
 msgstr ""
 
-#: ../src/ui/dialog/input.cpp:665
+#: ../src/ui/dialog/input.cpp:666
 msgid "Link:"
 msgstr ""
 
-#: ../src/ui/dialog/input.cpp:667 ../src/ui/dialog/input.cpp:668
-#: ../src/ui/dialog/input.cpp:1397 ../src/ui/widget/color-scales.cpp:43
+#: ../src/ui/dialog/input.cpp:668 ../src/ui/dialog/input.cpp:669
+#: ../src/ui/dialog/input.cpp:1398 ../src/ui/widget/color-scales.cpp:43
 #: ../share/extensions/plotter.inx.h:24
 msgid "None"
 msgstr ""
 
-#: ../src/ui/dialog/input.cpp:674
+#: ../src/ui/dialog/input.cpp:675
 msgid "Axes count:"
 msgstr ""
 
-#: ../src/ui/dialog/input.cpp:680
+#: ../src/ui/dialog/input.cpp:681
 msgid "axis:"
 msgstr ""
 
-#: ../src/ui/dialog/input.cpp:693
+#: ../src/ui/dialog/input.cpp:694
 msgid "Button count:"
 msgstr ""
 
-#: ../src/ui/dialog/input.cpp:842
+#: ../src/ui/dialog/input.cpp:843
 msgid "Tablet"
 msgstr ""
 
-#: ../src/ui/dialog/input.cpp:871 ../src/ui/dialog/input.cpp:1754
+#: ../src/ui/dialog/input.cpp:872 ../src/ui/dialog/input.cpp:1755
 msgid "pad"
 msgstr ""
 
-#: ../src/ui/dialog/input.cpp:913
+#: ../src/ui/dialog/input.cpp:914
 msgid "_Use pressure-sensitive tablet (requires restart)"
 msgstr ""
 
-#: ../src/ui/dialog/input.cpp:918
+#: ../src/ui/dialog/input.cpp:919
 msgid "Axes"
 msgstr ""
 
-#: ../src/ui/dialog/input.cpp:919
+#: ../src/ui/dialog/input.cpp:920
 msgid "Keys"
 msgstr ""
 
-#: ../src/ui/dialog/input.cpp:996
+#: ../src/ui/dialog/input.cpp:997
 msgid ""
 "A device can be 'Disabled', its co-ordinates mapped to the whole 'Screen', "
 "or to a single (usually focused) 'Window'"
 msgstr ""
 
-#: ../src/ui/dialog/input.cpp:1442 ../src/widgets/calligraphy-toolbar.cpp:578
-#: ../src/widgets/spray-toolbar.cpp:311 ../src/widgets/spray-toolbar.cpp:427
-#: ../src/widgets/spray-toolbar.cpp:476 ../src/widgets/tweak-toolbar.cpp:372
+#: ../src/ui/dialog/input.cpp:1443 ../src/widgets/calligraphy-toolbar.cpp:549
+#: ../src/widgets/spray-toolbar.cpp:311 ../src/widgets/spray-toolbar.cpp:425
+#: ../src/widgets/spray-toolbar.cpp:474 ../src/widgets/tweak-toolbar.cpp:372
 msgid "Pressure"
 msgstr ""
 
-#: ../src/ui/dialog/input.cpp:1442
+#: ../src/ui/dialog/input.cpp:1443
 msgid "X tilt"
 msgstr ""
 
-#: ../src/ui/dialog/input.cpp:1442
+#: ../src/ui/dialog/input.cpp:1443
 msgid "Y tilt"
 msgstr ""
 
-#: ../src/ui/dialog/input.cpp:1442 ../src/ui/widget/color-wheel-selector.cpp:25
+#: ../src/ui/dialog/input.cpp:1443 ../src/ui/widget/color-wheel-selector.cpp:25
 msgid "Wheel"
 msgstr ""
 
-#: ../src/ui/dialog/input.cpp:1451
+#: ../src/ui/dialog/input.cpp:1452
 msgctxt "Input device axe"
 msgid "None"
 msgstr ""
@@ -20724,8 +20903,8 @@ msgstr ""
 
 #. TODO: find an unused layer number, forming name from _("Layer ") + "%d"
 #: ../src/ui/dialog/layer-properties.cpp:326
-#: ../src/ui/dialog/layer-properties.cpp:382 ../src/verbs.cpp:189
-#: ../src/verbs.cpp:2496
+#: ../src/ui/dialog/layer-properties.cpp:382 ../src/verbs.cpp:192
+#: ../src/verbs.cpp:2526
 msgid "Layer"
 msgstr ""
 
@@ -20733,7 +20912,7 @@ msgstr ""
 msgid "_Rename"
 msgstr ""
 
-#: ../src/ui/dialog/layer-properties.cpp:340 ../src/ui/dialog/layers.cpp:756
+#: ../src/ui/dialog/layer-properties.cpp:340 ../src/ui/dialog/layers.cpp:761
 msgid "Rename layer"
 msgstr ""
 
@@ -20775,41 +20954,41 @@ msgstr ""
 msgid "Unlock layer"
 msgstr ""
 
-#: ../src/ui/dialog/layers.cpp:622 ../src/ui/dialog/objects.cpp:852
-#: ../src/verbs.cpp:1471
+#: ../src/ui/dialog/layers.cpp:627 ../src/ui/dialog/objects.cpp:867
+#: ../src/verbs.cpp:1493
 msgid "Toggle layer solo"
 msgstr ""
 
-#: ../src/ui/dialog/layers.cpp:625 ../src/ui/dialog/objects.cpp:855
-#: ../src/verbs.cpp:1495
+#: ../src/ui/dialog/layers.cpp:630 ../src/ui/dialog/objects.cpp:870
+#: ../src/verbs.cpp:1517
 msgid "Lock other layers"
 msgstr ""
 
-#: ../src/ui/dialog/layers.cpp:728
+#: ../src/ui/dialog/layers.cpp:733
 msgid "Move layer"
 msgstr ""
 
-#: ../src/ui/dialog/layers.cpp:886
+#: ../src/ui/dialog/layers.cpp:894
 msgctxt "Layers"
 msgid "New"
 msgstr ""
 
-#: ../src/ui/dialog/layers.cpp:891
+#: ../src/ui/dialog/layers.cpp:899
 msgctxt "Layers"
 msgid "Bot"
 msgstr ""
 
-#: ../src/ui/dialog/layers.cpp:897
+#: ../src/ui/dialog/layers.cpp:905
 msgctxt "Layers"
 msgid "Dn"
 msgstr ""
 
-#: ../src/ui/dialog/layers.cpp:903
+#: ../src/ui/dialog/layers.cpp:911
 msgctxt "Layers"
 msgid "Up"
 msgstr ""
 
-#: ../src/ui/dialog/layers.cpp:909
+#: ../src/ui/dialog/layers.cpp:917
 msgctxt "Layers"
 msgid "Top"
 msgstr ""
@@ -20834,57 +21013,57 @@ msgstr ""
 msgid "Lower the current path effect"
 msgstr ""
 
-#: ../src/ui/dialog/livepatheffect-editor.cpp:311
+#: ../src/ui/dialog/livepatheffect-editor.cpp:313
 msgid "Unknown effect is applied"
 msgstr ""
 
-#: ../src/ui/dialog/livepatheffect-editor.cpp:314
+#: ../src/ui/dialog/livepatheffect-editor.cpp:316
 msgid "Click button to add an effect"
 msgstr ""
 
-#: ../src/ui/dialog/livepatheffect-editor.cpp:329
+#: ../src/ui/dialog/livepatheffect-editor.cpp:331
 msgid "Click add button to convert clone"
 msgstr ""
 
-#: ../src/ui/dialog/livepatheffect-editor.cpp:334
-#: ../src/ui/dialog/livepatheffect-editor.cpp:338
-#: ../src/ui/dialog/livepatheffect-editor.cpp:347
+#: ../src/ui/dialog/livepatheffect-editor.cpp:336
+#: ../src/ui/dialog/livepatheffect-editor.cpp:340
+#: ../src/ui/dialog/livepatheffect-editor.cpp:349
 msgid "Select a path or shape"
 msgstr ""
 
-#: ../src/ui/dialog/livepatheffect-editor.cpp:343
+#: ../src/ui/dialog/livepatheffect-editor.cpp:345
 msgid "Only one item can be selected"
 msgstr ""
 
-#: ../src/ui/dialog/livepatheffect-editor.cpp:375
+#: ../src/ui/dialog/livepatheffect-editor.cpp:377
 msgid "Unknown effect"
 msgstr ""
 
-#: ../src/ui/dialog/livepatheffect-editor.cpp:451
+#: ../src/ui/dialog/livepatheffect-editor.cpp:453
 msgid "Create and apply path effect"
 msgstr ""
 
-#: ../src/ui/dialog/livepatheffect-editor.cpp:491
+#: ../src/ui/dialog/livepatheffect-editor.cpp:493
 msgid "Create and apply Clone original path effect"
 msgstr ""
 
-#: ../src/ui/dialog/livepatheffect-editor.cpp:513
+#: ../src/ui/dialog/livepatheffect-editor.cpp:515
 msgid "Remove path effect"
 msgstr ""
 
-#: ../src/ui/dialog/livepatheffect-editor.cpp:531
+#: ../src/ui/dialog/livepatheffect-editor.cpp:533
 msgid "Move path effect up"
 msgstr ""
 
-#: ../src/ui/dialog/livepatheffect-editor.cpp:548
+#: ../src/ui/dialog/livepatheffect-editor.cpp:550
 msgid "Move path effect down"
 msgstr ""
 
-#: ../src/ui/dialog/livepatheffect-editor.cpp:603
+#: ../src/ui/dialog/livepatheffect-editor.cpp:605
 msgid "Activate path effect"
 msgstr ""
 
-#: ../src/ui/dialog/livepatheffect-editor.cpp:603
+#: ../src/ui/dialog/livepatheffect-editor.cpp:605
 msgid "Deactivate path effect"
 msgstr ""
 
@@ -20928,34 +21107,34 @@ msgstr ""
 msgid "Modify Node Position"
 msgstr ""
 
-#: ../src/ui/dialog/memory.cpp:97
+#: ../src/ui/dialog/memory.cpp:98
 msgid "Heap"
 msgstr ""
 
-#: ../src/ui/dialog/memory.cpp:98
+#: ../src/ui/dialog/memory.cpp:99
 msgid "In Use"
 msgstr ""
 
 #. TRANSLATORS: "Slack" refers to memory which is in the heap but currently unused.
 #. More typical usage is to call this memory "free" rather than "slack".
-#: ../src/ui/dialog/memory.cpp:101
+#: ../src/ui/dialog/memory.cpp:102
 msgid "Slack"
 msgstr ""
 
-#: ../src/ui/dialog/memory.cpp:102
+#: ../src/ui/dialog/memory.cpp:103
 msgid "Total"
 msgstr ""
 
-#: ../src/ui/dialog/memory.cpp:142 ../src/ui/dialog/memory.cpp:148
-#: ../src/ui/dialog/memory.cpp:155 ../src/ui/dialog/memory.cpp:187
+#: ../src/ui/dialog/memory.cpp:143 ../src/ui/dialog/memory.cpp:149
+#: ../src/ui/dialog/memory.cpp:156 ../src/ui/dialog/memory.cpp:188
 msgid "Unknown"
 msgstr ""
 
-#: ../src/ui/dialog/memory.cpp:168
+#: ../src/ui/dialog/memory.cpp:169
 msgid "Combined"
 msgstr ""
 
-#: ../src/ui/dialog/memory.cpp:210
+#: ../src/ui/dialog/memory.cpp:218
 msgid "Recalculate"
 msgstr ""
 
@@ -21078,8 +21257,8 @@ msgid "Check to make the object insensitive (not selectable by mouse)"
 msgstr ""
 
 #. Button for setting the object's id, label, title and description.
-#: ../src/ui/dialog/object-properties.cpp:237 ../src/verbs.cpp:2874
-#: ../src/verbs.cpp:2880
+#: ../src/ui/dialog/object-properties.cpp:237 ../src/verbs.cpp:2904
+#: ../src/verbs.cpp:2912
 msgid "_Set"
 msgstr ""
 
@@ -21137,187 +21316,187 @@ msgstr ""
 msgid "Unhide object"
 msgstr ""
 
-#: ../src/ui/dialog/objects.cpp:882
+#: ../src/ui/dialog/objects.cpp:897
 msgid "Unhide objects"
 msgstr ""
 
-#: ../src/ui/dialog/objects.cpp:882
+#: ../src/ui/dialog/objects.cpp:897
 msgid "Hide objects"
 msgstr ""
 
-#: ../src/ui/dialog/objects.cpp:902
+#: ../src/ui/dialog/objects.cpp:917
 msgid "Lock objects"
 msgstr ""
 
-#: ../src/ui/dialog/objects.cpp:902
+#: ../src/ui/dialog/objects.cpp:917
 msgid "Unlock objects"
 msgstr ""
 
-#: ../src/ui/dialog/objects.cpp:914
+#: ../src/ui/dialog/objects.cpp:929
 msgid "Layer to group"
 msgstr ""
 
-#: ../src/ui/dialog/objects.cpp:914
+#: ../src/ui/dialog/objects.cpp:929
 msgid "Group to layer"
 msgstr ""
 
-#: ../src/ui/dialog/objects.cpp:1112
+#: ../src/ui/dialog/objects.cpp:1127
 msgid "Moved objects"
 msgstr ""
 
-#: ../src/ui/dialog/objects.cpp:1361 ../src/ui/dialog/tags.cpp:838
-#: ../src/ui/dialog/tags.cpp:845
+#: ../src/ui/dialog/objects.cpp:1376 ../src/ui/dialog/tags.cpp:842
+#: ../src/ui/dialog/tags.cpp:849
 msgid "Rename object"
 msgstr ""
 
-#: ../src/ui/dialog/objects.cpp:1468
+#: ../src/ui/dialog/objects.cpp:1483
 msgid "Set object highlight color"
 msgstr ""
 
-#: ../src/ui/dialog/objects.cpp:1478
+#: ../src/ui/dialog/objects.cpp:1493
 msgid "Set object opacity"
 msgstr ""
 
-#: ../src/ui/dialog/objects.cpp:1507
+#: ../src/ui/dialog/objects.cpp:1522
 msgid "Set object blend mode"
 msgstr ""
 
-#: ../src/ui/dialog/objects.cpp:1576
+#: ../src/ui/dialog/objects.cpp:1592
 msgid "Set object blur"
 msgstr ""
 
-#: ../src/ui/dialog/objects.cpp:1642
+#: ../src/ui/dialog/objects.cpp:1658
 msgctxt "Visibility"
 msgid "V"
 msgstr ""
 
-#: ../src/ui/dialog/objects.cpp:1643
+#: ../src/ui/dialog/objects.cpp:1659
 msgctxt "Lock"
 msgid "L"
 msgstr ""
 
-#: ../src/ui/dialog/objects.cpp:1644
+#: ../src/ui/dialog/objects.cpp:1660
 msgctxt "Type"
 msgid "T"
 msgstr ""
 
-#: ../src/ui/dialog/objects.cpp:1645
+#: ../src/ui/dialog/objects.cpp:1661
 msgctxt "Clip and mask"
 msgid "CM"
 msgstr ""
 
-#: ../src/ui/dialog/objects.cpp:1646
+#: ../src/ui/dialog/objects.cpp:1662
 msgctxt "Highlight"
 msgid "HL"
 msgstr ""
 
-#: ../src/ui/dialog/objects.cpp:1647
+#: ../src/ui/dialog/objects.cpp:1663
 msgid "Label"
 msgstr ""
 
 #. In order to get tooltips on header, we must create our own label.
-#: ../src/ui/dialog/objects.cpp:1683
+#: ../src/ui/dialog/objects.cpp:1691
 msgid "Toggle visibility of Layer, Group, or Object."
 msgstr ""
 
-#: ../src/ui/dialog/objects.cpp:1696
+#: ../src/ui/dialog/objects.cpp:1704
 msgid "Toggle lock of Layer, Group, or Object."
 msgstr ""
 
-#: ../src/ui/dialog/objects.cpp:1708
+#: ../src/ui/dialog/objects.cpp:1716
 msgid ""
 "Type: Layer, Group, or Object. Clicking on Layer or Group icon, toggles "
 "between the two types."
 msgstr ""
 
-#: ../src/ui/dialog/objects.cpp:1727
+#: ../src/ui/dialog/objects.cpp:1735
 msgid "Is object clipped and/or masked?"
 msgstr ""
 
-#: ../src/ui/dialog/objects.cpp:1738
+#: ../src/ui/dialog/objects.cpp:1746
 msgid ""
 "Highlight color of outline in Node tool. Click to set. If alpha is zero, use "
 "inherited color."
 msgstr ""
 
-#: ../src/ui/dialog/objects.cpp:1749
+#: ../src/ui/dialog/objects.cpp:1757
 msgid ""
 "Layer/Group/Object label (inkscape:label). Double-click to set. Default "
 "value is object 'id'."
 msgstr ""
 
-#: ../src/ui/dialog/objects.cpp:1857
+#: ../src/ui/dialog/objects.cpp:1819
 msgid "Add layer..."
 msgstr ""
 
-#: ../src/ui/dialog/objects.cpp:1864
+#: ../src/ui/dialog/objects.cpp:1826
 msgid "Remove object"
 msgstr ""
 
-#: ../src/ui/dialog/objects.cpp:1872
+#: ../src/ui/dialog/objects.cpp:1834
 msgid "Move To Bottom"
 msgstr ""
 
-#: ../src/ui/dialog/objects.cpp:1896
+#: ../src/ui/dialog/objects.cpp:1858
 msgid "Move To Top"
 msgstr ""
 
-#: ../src/ui/dialog/objects.cpp:1904
+#: ../src/ui/dialog/objects.cpp:1866
 msgid "Collapse All"
 msgstr ""
 
-#: ../src/ui/dialog/objects.cpp:1918
+#: ../src/ui/dialog/objects.cpp:1880
 msgid "Rename"
 msgstr ""
 
-#: ../src/ui/dialog/objects.cpp:1924
+#: ../src/ui/dialog/objects.cpp:1886
 msgid "Solo"
 msgstr ""
 
-#: ../src/ui/dialog/objects.cpp:1925
+#: ../src/ui/dialog/objects.cpp:1887
 msgid "Show All"
 msgstr ""
 
-#: ../src/ui/dialog/objects.cpp:1926
+#: ../src/ui/dialog/objects.cpp:1888
 msgid "Hide All"
 msgstr ""
 
-#: ../src/ui/dialog/objects.cpp:1930
+#: ../src/ui/dialog/objects.cpp:1892
 msgid "Lock Others"
 msgstr ""
 
-#: ../src/ui/dialog/objects.cpp:1931
+#: ../src/ui/dialog/objects.cpp:1893
 msgid "Lock All"
 msgstr ""
 
 #. LockAndHide
-#: ../src/ui/dialog/objects.cpp:1932 ../src/verbs.cpp:3193
+#: ../src/ui/dialog/objects.cpp:1894 ../src/verbs.cpp:3227
 msgid "Unlock All"
 msgstr ""
 
-#: ../src/ui/dialog/objects.cpp:1936
+#: ../src/ui/dialog/objects.cpp:1898
 msgid "Up"
 msgstr ""
 
-#: ../src/ui/dialog/objects.cpp:1937
+#: ../src/ui/dialog/objects.cpp:1899
 msgid "Down"
 msgstr ""
 
-#: ../src/ui/dialog/objects.cpp:1946
+#: ../src/ui/dialog/objects.cpp:1908
 msgid "Set Clip"
 msgstr ""
 
 #. will never be implemented
 #. _watching.push_back( &_addPopupItem( targetDesktop, SP_VERB_OBJECT_SET_INVERSE_CLIPPATH, 0, "Set Inverse Clip", (int)BUTTON_SETINVCLIP ) );
-#: ../src/ui/dialog/objects.cpp:1952
+#: ../src/ui/dialog/objects.cpp:1914
 msgid "Unset Clip"
 msgstr ""
 
-#: ../src/ui/dialog/objects.cpp:1957
+#: ../src/ui/dialog/objects.cpp:1919
 msgid "Unset Mask"
 msgstr ""
 
-#: ../src/ui/dialog/objects.cpp:1979
+#: ../src/ui/dialog/objects.cpp:1941
 msgid "Select Highlight Color"
 msgstr ""
 
@@ -21349,25 +21528,25 @@ msgstr ""
 msgid "Searching clipart..."
 msgstr ""
 
-#: ../src/ui/dialog/ocaldialogs.cpp:969 ../src/ui/dialog/ocaldialogs.cpp:990
+#: ../src/ui/dialog/ocaldialogs.cpp:991
 msgid "Could not connect to the Open Clip Art Library"
 msgstr ""
 
-#: ../src/ui/dialog/ocaldialogs.cpp:1015
+#: ../src/ui/dialog/ocaldialogs.cpp:1016
 msgid "Could not parse search results"
 msgstr ""
 
-#: ../src/ui/dialog/ocaldialogs.cpp:1047
+#: ../src/ui/dialog/ocaldialogs.cpp:1048
 msgid "No clipart named <b>%1</b> was found."
 msgstr ""
 
-#: ../src/ui/dialog/ocaldialogs.cpp:1049
+#: ../src/ui/dialog/ocaldialogs.cpp:1050
 msgid ""
 "Please make sure all keywords are spelled correctly, or try again with "
 "different keywords."
 msgstr ""
 
-#: ../src/ui/dialog/ocaldialogs.cpp:1082
+#: ../src/ui/dialog/ocaldialogs.cpp:1083
 msgid "Search"
 msgstr ""
 
@@ -21448,7 +21627,7 @@ msgid "Reset all settings to defaults"
 msgstr ""
 
 #. ## The OK button
-#: ../src/ui/dialog/pixelartdialog.cpp:293 ../src/ui/dialog/spellcheck.cpp:70
+#: ../src/ui/dialog/pixelartdialog.cpp:293 ../src/ui/dialog/spellcheck.cpp:68
 #: ../src/ui/dialog/tracedialog.cpp:815
 msgid "_Stop"
 msgstr ""
@@ -21565,24 +21744,24 @@ msgstr ""
 msgid "Arrange on ellipse"
 msgstr ""
 
-#: ../src/ui/dialog/print.cpp:100
+#: ../src/ui/dialog/print.cpp:103
 msgid "Could not open temporary PNG for bitmap printing"
 msgstr ""
 
-#: ../src/ui/dialog/print.cpp:127
+#: ../src/ui/dialog/print.cpp:130
 msgid "Could not set up Document"
 msgstr ""
 
-#: ../src/ui/dialog/print.cpp:131
+#: ../src/ui/dialog/print.cpp:134
 msgid "Failed to set CairoRenderContext"
 msgstr ""
 
 #. set up dialog title, based on document name
-#: ../src/ui/dialog/print.cpp:169
+#: ../src/ui/dialog/print.cpp:172
 msgid "SVG Document"
 msgstr ""
 
-#: ../src/ui/dialog/print.cpp:170
+#: ../src/ui/dialog/print.cpp:173
 msgid "Print"
 msgstr ""
 
@@ -21608,73 +21787,73 @@ msgstr ""
 msgid "Keywords: "
 msgstr ""
 
-#: ../src/ui/dialog/spellcheck.cpp:65
+#: ../src/ui/dialog/spellcheck.cpp:63
 msgid "_Accept"
 msgstr ""
 
-#: ../src/ui/dialog/spellcheck.cpp:66
+#: ../src/ui/dialog/spellcheck.cpp:64
 msgid "_Ignore once"
 msgstr ""
 
-#: ../src/ui/dialog/spellcheck.cpp:67
+#: ../src/ui/dialog/spellcheck.cpp:65
 msgid "_Ignore"
 msgstr ""
 
-#: ../src/ui/dialog/spellcheck.cpp:68
+#: ../src/ui/dialog/spellcheck.cpp:66
 msgid "A_dd"
 msgstr ""
 
-#: ../src/ui/dialog/spellcheck.cpp:71
+#: ../src/ui/dialog/spellcheck.cpp:69
 msgid "_Start"
 msgstr ""
 
-#: ../src/ui/dialog/spellcheck.cpp:101
+#: ../src/ui/dialog/spellcheck.cpp:99
 msgid "Suggestions:"
 msgstr ""
 
-#: ../src/ui/dialog/spellcheck.cpp:116
+#: ../src/ui/dialog/spellcheck.cpp:114
 msgid "Accept the chosen suggestion"
 msgstr ""
 
-#: ../src/ui/dialog/spellcheck.cpp:117
+#: ../src/ui/dialog/spellcheck.cpp:115
 msgid "Ignore this word only once"
 msgstr ""
 
-#: ../src/ui/dialog/spellcheck.cpp:118
+#: ../src/ui/dialog/spellcheck.cpp:116
 msgid "Ignore this word in this session"
 msgstr ""
 
-#: ../src/ui/dialog/spellcheck.cpp:119
+#: ../src/ui/dialog/spellcheck.cpp:117
 msgid "Add this word to the chosen dictionary"
 msgstr ""
 
-#: ../src/ui/dialog/spellcheck.cpp:133
+#: ../src/ui/dialog/spellcheck.cpp:131
 msgid "Stop the check"
 msgstr ""
 
-#: ../src/ui/dialog/spellcheck.cpp:134
+#: ../src/ui/dialog/spellcheck.cpp:132
 msgid "Start the check"
 msgstr ""
 
-#: ../src/ui/dialog/spellcheck.cpp:452
+#: ../src/ui/dialog/spellcheck.cpp:427
 #, c-format
 msgid "<b>Finished</b>, <b>%d</b> words added to dictionary"
 msgstr ""
 
-#: ../src/ui/dialog/spellcheck.cpp:454
+#: ../src/ui/dialog/spellcheck.cpp:429
 msgid "<b>Finished</b>, nothing suspicious found"
 msgstr ""
 
-#: ../src/ui/dialog/spellcheck.cpp:570
+#: ../src/ui/dialog/spellcheck.cpp:544
 #, c-format
 msgid "Not in dictionary (%s): <b>%s</b>"
 msgstr ""
 
-#: ../src/ui/dialog/spellcheck.cpp:719
+#: ../src/ui/dialog/spellcheck.cpp:693
 msgid "<i>Checking...</i>"
 msgstr ""
 
-#: ../src/ui/dialog/spellcheck.cpp:788
+#: ../src/ui/dialog/spellcheck.cpp:762
 msgid "Fix spelling"
 msgstr ""
 
@@ -21707,272 +21886,427 @@ msgstr ""
 msgid "Adjust kerning value"
 msgstr ""
 
-#: ../src/ui/dialog/svg-fonts-dialog.cpp:452
+#: ../src/ui/dialog/svg-fonts-dialog.cpp:464
 msgid "Font Attributes"
 msgstr ""
 
-#: ../src/ui/dialog/svg-fonts-dialog.cpp:453
+#: ../src/ui/dialog/svg-fonts-dialog.cpp:465
 msgid "Horiz. Advance X"
 msgstr ""
 
-#: ../src/ui/dialog/svg-fonts-dialog.cpp:454
+#: ../src/ui/dialog/svg-fonts-dialog.cpp:466
 msgid "Horiz. Origin X "
 msgstr ""
 
-#: ../src/ui/dialog/svg-fonts-dialog.cpp:455
+#: ../src/ui/dialog/svg-fonts-dialog.cpp:467
 msgid "Horiz. Origin Y "
 msgstr ""
 
-#: ../src/ui/dialog/svg-fonts-dialog.cpp:456
+#: ../src/ui/dialog/svg-fonts-dialog.cpp:468
 msgid "Font Face Attributes"
 msgstr ""
 
-#: ../src/ui/dialog/svg-fonts-dialog.cpp:457
+#: ../src/ui/dialog/svg-fonts-dialog.cpp:469
 msgid "Family Name:"
 msgstr ""
 
-#: ../src/ui/dialog/svg-fonts-dialog.cpp:458
+#: ../src/ui/dialog/svg-fonts-dialog.cpp:470
 msgid "Units per em"
 msgstr ""
 
-#: ../src/ui/dialog/svg-fonts-dialog.cpp:459
+#: ../src/ui/dialog/svg-fonts-dialog.cpp:471
 msgid "Ascent:"
 msgstr ""
 
-#: ../src/ui/dialog/svg-fonts-dialog.cpp:460
+#: ../src/ui/dialog/svg-fonts-dialog.cpp:472
 msgid "Descent:"
 msgstr ""
 
-#: ../src/ui/dialog/svg-fonts-dialog.cpp:461
+#: ../src/ui/dialog/svg-fonts-dialog.cpp:473
 msgid "Cap Height:"
 msgstr ""
 
-#: ../src/ui/dialog/svg-fonts-dialog.cpp:462
+#: ../src/ui/dialog/svg-fonts-dialog.cpp:474
 msgid "x Height:"
 msgstr ""
 
-#: ../src/ui/dialog/svg-fonts-dialog.cpp:535
+#: ../src/ui/dialog/svg-fonts-dialog.cpp:547
 msgid "glyph"
 msgstr ""
 
 #. SPGlyph* glyph =
-#: ../src/ui/dialog/svg-fonts-dialog.cpp:567
+#: ../src/ui/dialog/svg-fonts-dialog.cpp:579
 msgid "Add glyph"
 msgstr ""
 
-#: ../src/ui/dialog/svg-fonts-dialog.cpp:598
-#: ../src/ui/dialog/svg-fonts-dialog.cpp:640
+#: ../src/ui/dialog/svg-fonts-dialog.cpp:610
+#: ../src/ui/dialog/svg-fonts-dialog.cpp:652
 msgid "Select a <b>path</b> to define the curves of a glyph"
 msgstr ""
 
-#: ../src/ui/dialog/svg-fonts-dialog.cpp:606
-#: ../src/ui/dialog/svg-fonts-dialog.cpp:648
+#: ../src/ui/dialog/svg-fonts-dialog.cpp:618
+#: ../src/ui/dialog/svg-fonts-dialog.cpp:660
 msgid "The selected object does not have a <b>path</b> description."
 msgstr ""
 
-#: ../src/ui/dialog/svg-fonts-dialog.cpp:613
+#: ../src/ui/dialog/svg-fonts-dialog.cpp:625
 msgid "No glyph selected in the SVGFonts dialog."
 msgstr ""
 
-#: ../src/ui/dialog/svg-fonts-dialog.cpp:624
-#: ../src/ui/dialog/svg-fonts-dialog.cpp:662
+#: ../src/ui/dialog/svg-fonts-dialog.cpp:636
+#: ../src/ui/dialog/svg-fonts-dialog.cpp:674
 msgid "Set glyph curves"
 msgstr ""
 
-#: ../src/ui/dialog/svg-fonts-dialog.cpp:681
+#: ../src/ui/dialog/svg-fonts-dialog.cpp:693
 msgid "Reset missing-glyph"
 msgstr ""
 
-#: ../src/ui/dialog/svg-fonts-dialog.cpp:697
+#: ../src/ui/dialog/svg-fonts-dialog.cpp:709
 msgid "Edit glyph name"
 msgstr ""
 
-#: ../src/ui/dialog/svg-fonts-dialog.cpp:711
+#: ../src/ui/dialog/svg-fonts-dialog.cpp:723
 msgid "Set glyph unicode"
 msgstr ""
 
-#: ../src/ui/dialog/svg-fonts-dialog.cpp:728
+#: ../src/ui/dialog/svg-fonts-dialog.cpp:740
 msgid "Set glyph advance"
 msgstr ""
 
-#: ../src/ui/dialog/svg-fonts-dialog.cpp:743
+#: ../src/ui/dialog/svg-fonts-dialog.cpp:755
 msgid "Remove font"
 msgstr ""
 
-#: ../src/ui/dialog/svg-fonts-dialog.cpp:760
+#: ../src/ui/dialog/svg-fonts-dialog.cpp:772
 msgid "Remove glyph"
 msgstr ""
 
-#: ../src/ui/dialog/svg-fonts-dialog.cpp:777
+#: ../src/ui/dialog/svg-fonts-dialog.cpp:789
 msgid "Remove kerning pair"
 msgstr ""
 
-#: ../src/ui/dialog/svg-fonts-dialog.cpp:787
+#: ../src/ui/dialog/svg-fonts-dialog.cpp:799
 msgid "Missing Glyph:"
 msgstr ""
 
-#: ../src/ui/dialog/svg-fonts-dialog.cpp:791
+#: ../src/ui/dialog/svg-fonts-dialog.cpp:803
 msgid "From selection..."
 msgstr ""
 
-#: ../src/ui/dialog/svg-fonts-dialog.cpp:804
+#: ../src/ui/dialog/svg-fonts-dialog.cpp:816
 msgid "Glyph name"
 msgstr ""
 
-#: ../src/ui/dialog/svg-fonts-dialog.cpp:805
+#: ../src/ui/dialog/svg-fonts-dialog.cpp:817
 msgid "Matching string"
 msgstr ""
 
-#: ../src/ui/dialog/svg-fonts-dialog.cpp:806
+#: ../src/ui/dialog/svg-fonts-dialog.cpp:818
 msgid "Advance"
 msgstr ""
 
-#: ../src/ui/dialog/svg-fonts-dialog.cpp:808
+#: ../src/ui/dialog/svg-fonts-dialog.cpp:820
 msgid "Add Glyph"
 msgstr ""
 
-#: ../src/ui/dialog/svg-fonts-dialog.cpp:815
+#: ../src/ui/dialog/svg-fonts-dialog.cpp:827
 msgid "Get curves from selection..."
 msgstr ""
 
-#: ../src/ui/dialog/svg-fonts-dialog.cpp:867
+#: ../src/ui/dialog/svg-fonts-dialog.cpp:879
 msgid "Add kerning pair"
 msgstr ""
 
 #. Kerning Setup:
-#: ../src/ui/dialog/svg-fonts-dialog.cpp:875
+#: ../src/ui/dialog/svg-fonts-dialog.cpp:887
 msgid "Kerning Setup"
 msgstr ""
 
-#: ../src/ui/dialog/svg-fonts-dialog.cpp:877
+#: ../src/ui/dialog/svg-fonts-dialog.cpp:889
 msgid "1st Glyph:"
 msgstr ""
 
-#: ../src/ui/dialog/svg-fonts-dialog.cpp:879
+#: ../src/ui/dialog/svg-fonts-dialog.cpp:891
 msgid "2nd Glyph:"
 msgstr ""
 
-#: ../src/ui/dialog/svg-fonts-dialog.cpp:882
+#: ../src/ui/dialog/svg-fonts-dialog.cpp:894
 msgid "Add pair"
 msgstr ""
 
-#: ../src/ui/dialog/svg-fonts-dialog.cpp:894
+#: ../src/ui/dialog/svg-fonts-dialog.cpp:906
 msgid "First Unicode range"
 msgstr ""
 
-#: ../src/ui/dialog/svg-fonts-dialog.cpp:895
+#: ../src/ui/dialog/svg-fonts-dialog.cpp:907
 msgid "Second Unicode range"
 msgstr ""
 
-#: ../src/ui/dialog/svg-fonts-dialog.cpp:902
+#: ../src/ui/dialog/svg-fonts-dialog.cpp:914
 msgid "Kerning value:"
 msgstr ""
 
-#: ../src/ui/dialog/svg-fonts-dialog.cpp:959
+#: ../src/ui/dialog/svg-fonts-dialog.cpp:971
 msgid "Set font family"
 msgstr ""
 
-#: ../src/ui/dialog/svg-fonts-dialog.cpp:968
+#: ../src/ui/dialog/svg-fonts-dialog.cpp:980
 msgid "font"
 msgstr ""
 
 #. select_font(font);
-#: ../src/ui/dialog/svg-fonts-dialog.cpp:982
+#: ../src/ui/dialog/svg-fonts-dialog.cpp:994
 msgid "Add font"
 msgstr ""
 
-#: ../src/ui/dialog/svg-fonts-dialog.cpp:1004 ../src/ui/dialog/text-edit.cpp:60
+#: ../src/ui/dialog/svg-fonts-dialog.cpp:1016 ../src/ui/dialog/text-edit.cpp:60
 msgid "_Font"
 msgstr ""
 
-#: ../src/ui/dialog/svg-fonts-dialog.cpp:1012
+#: ../src/ui/dialog/svg-fonts-dialog.cpp:1024
 msgid "_Global Settings"
 msgstr ""
 
-#: ../src/ui/dialog/svg-fonts-dialog.cpp:1013
+#: ../src/ui/dialog/svg-fonts-dialog.cpp:1025
 msgid "_Glyphs"
 msgstr ""
 
-#: ../src/ui/dialog/svg-fonts-dialog.cpp:1014
+#: ../src/ui/dialog/svg-fonts-dialog.cpp:1026
 msgid "_Kerning"
 msgstr ""
 
-#: ../src/ui/dialog/svg-fonts-dialog.cpp:1021
-#: ../src/ui/dialog/svg-fonts-dialog.cpp:1022
+#: ../src/ui/dialog/svg-fonts-dialog.cpp:1033
+#: ../src/ui/dialog/svg-fonts-dialog.cpp:1034
 msgid "Sample Text"
 msgstr ""
 
-#: ../src/ui/dialog/svg-fonts-dialog.cpp:1026
+#: ../src/ui/dialog/svg-fonts-dialog.cpp:1038
 msgid "Preview Text:"
 msgstr ""
 
-#: ../src/ui/dialog/swatches.cpp:195 ../src/ui/tools/gradient-tool.cpp:359
-#: ../src/ui/tools/gradient-tool.cpp:457 ../src/widgets/gradient-vector.cpp:765
+#: ../src/ui/dialog/swatches.cpp:207 ../src/ui/tools/gradient-tool.cpp:359
+#: ../src/ui/tools/gradient-tool.cpp:446 ../src/widgets/gradient-vector.cpp:744
 msgid "Add gradient stop"
 msgstr ""
 
 #. TRANSLATORS: An item in context menu on a colour in the swatches
-#: ../src/ui/dialog/swatches.cpp:250
+#: ../src/ui/dialog/swatches.cpp:262
 msgid "Set fill"
 msgstr ""
 
 #. TRANSLATORS: An item in context menu on a colour in the swatches
-#: ../src/ui/dialog/swatches.cpp:258
+#: ../src/ui/dialog/swatches.cpp:270
 msgid "Set stroke"
 msgstr ""
 
-#: ../src/ui/dialog/swatches.cpp:279
+#: ../src/ui/dialog/swatches.cpp:291
 msgid "Edit..."
 msgstr ""
 
-#: ../src/ui/dialog/swatches.cpp:291
+#: ../src/ui/dialog/swatches.cpp:303
 msgid "Convert"
 msgstr ""
 
+#: ../src/ui/dialog/swatches.cpp:707
+msgid "List"
+msgstr ""
+
+#: ../src/ui/dialog/swatches.cpp:727
+msgctxt "Swatches"
+msgid "Size"
+msgstr ""
+
+#: ../src/ui/dialog/swatches.cpp:731
+msgctxt "Swatches height"
+msgid "Tiny"
+msgstr ""
+
+#: ../src/ui/dialog/swatches.cpp:732
+msgctxt "Swatches height"
+msgid "Small"
+msgstr ""
+
+#: ../src/ui/dialog/swatches.cpp:733
+msgctxt "Swatches height"
+msgid "Medium"
+msgstr ""
+
+#: ../src/ui/dialog/swatches.cpp:734
+msgctxt "Swatches height"
+msgid "Large"
+msgstr ""
+
+#: ../src/ui/dialog/swatches.cpp:735
+msgctxt "Swatches height"
+msgid "Huge"
+msgstr ""
+
+#: ../src/ui/dialog/swatches.cpp:757
+msgctxt "Swatches"
+msgid "Width"
+msgstr ""
+
+#: ../src/ui/dialog/swatches.cpp:761
+msgctxt "Swatches width"
+msgid "Narrower"
+msgstr ""
+
+#: ../src/ui/dialog/swatches.cpp:762
+msgctxt "Swatches width"
+msgid "Narrow"
+msgstr ""
+
+#: ../src/ui/dialog/swatches.cpp:763
+msgctxt "Swatches width"
+msgid "Medium"
+msgstr ""
+
+#: ../src/ui/dialog/swatches.cpp:764
+msgctxt "Swatches width"
+msgid "Wide"
+msgstr ""
+
+#: ../src/ui/dialog/swatches.cpp:765
+msgctxt "Swatches width"
+msgid "Wider"
+msgstr ""
+
+#: ../src/ui/dialog/swatches.cpp:795
+msgctxt "Swatches"
+msgid "Border"
+msgstr ""
+
+#: ../src/ui/dialog/swatches.cpp:799
+msgctxt "Swatches border"
+msgid "None"
+msgstr ""
+
+#: ../src/ui/dialog/swatches.cpp:800
+msgctxt "Swatches border"
+msgid "Solid"
+msgstr ""
+
+#: ../src/ui/dialog/swatches.cpp:801
+msgctxt "Swatches border"
+msgid "Wide"
+msgstr ""
+
+#. TRANSLATORS: "Wrap" indicates how colour swatches are displayed
+#: ../src/ui/dialog/swatches.cpp:832
+msgctxt "Swatches"
+msgid "Wrap"
+msgstr ""
+
+#: ../src/ui/dialog/symbols.cpp:75
+msgid "Current document"
+msgstr ""
+
+#: ../src/ui/dialog/symbols.cpp:76
+msgid "All symbol sets"
+msgstr ""
+
 #. ******************* Symbol Sets ************************
-#: ../src/ui/dialog/symbols.cpp:124
+#: ../src/ui/dialog/symbols.cpp:134
 msgid "Symbol set: "
 msgstr ""
 
-#. Fill in later
-#: ../src/ui/dialog/symbols.cpp:127 ../src/ui/dialog/symbols.cpp:128
-msgid "Current Document"
+#. *******************    Search    ************************
+#. Search
+#: ../src/ui/dialog/symbols.cpp:163
+msgid "Return to start search."
 msgstr ""
 
-#: ../src/ui/dialog/symbols.cpp:182
+#: ../src/ui/dialog/symbols.cpp:279
 msgid "Add Symbol from the current document."
 msgstr ""
 
-#: ../src/ui/dialog/symbols.cpp:193
+#: ../src/ui/dialog/symbols.cpp:290
 msgid "Remove Symbol from the current document."
 msgstr ""
 
-#: ../src/ui/dialog/symbols.cpp:210
+#: ../src/ui/dialog/symbols.cpp:307
 msgid "Display more icons in row."
 msgstr ""
 
-#: ../src/ui/dialog/symbols.cpp:221
+#: ../src/ui/dialog/symbols.cpp:318
 msgid "Display fewer icons in row."
 msgstr ""
 
-#: ../src/ui/dialog/symbols.cpp:233
+#: ../src/ui/dialog/symbols.cpp:330
 msgid "Toggle 'fit' symbols in icon space."
 msgstr ""
 
-#: ../src/ui/dialog/symbols.cpp:247
+#: ../src/ui/dialog/symbols.cpp:344
 msgid "Make symbols smaller by zooming out."
 msgstr ""
 
-#: ../src/ui/dialog/symbols.cpp:259
+#: ../src/ui/dialog/symbols.cpp:356
 msgid "Make symbols bigger by zooming in."
 msgstr ""
 
-#: ../src/ui/dialog/symbols.cpp:602
+#. We are not in search all docs
+#: ../src/ui/dialog/symbols.cpp:457 ../src/ui/dialog/symbols.cpp:1053
+msgid "Searching..."
+msgstr ""
+
+#: ../src/ui/dialog/symbols.cpp:458 ../src/ui/dialog/symbols.cpp:1060
+#: ../src/ui/dialog/symbols.cpp:1124
+msgid "Loading all symbols..."
+msgstr ""
+
+#: ../src/ui/dialog/symbols.cpp:459
+msgid "Searching...."
+msgstr ""
+
+#: ../src/ui/dialog/symbols.cpp:478 ../src/ui/dialog/symbols.cpp:485
+msgid "Search in all symbol sets..."
+msgstr ""
+
+#: ../src/ui/dialog/symbols.cpp:479
+msgid "First search can be slow."
+msgstr ""
+
+#: ../src/ui/dialog/symbols.cpp:481 ../src/ui/dialog/symbols.cpp:489
+#: ../src/ui/dialog/symbols.cpp:495
+msgid "No results found"
+msgstr ""
+
+#: ../src/ui/dialog/symbols.cpp:482
+msgid "Try a different search term."
+msgstr ""
+
+#: ../src/ui/dialog/symbols.cpp:490 ../src/ui/dialog/symbols.cpp:496
+msgid ""
+"Try a different search term,\n"
+"or switch to a different symbol set."
+msgstr ""
+
+#: ../src/ui/dialog/symbols.cpp:492
+msgid "No symbols found"
+msgstr ""
+
+#: ../src/ui/dialog/symbols.cpp:493
+msgid ""
+"No symbols in current document.\n"
+"Choose a different symbol set\n"
+"or add a new symbol."
+msgstr ""
+
+#: ../src/ui/dialog/symbols.cpp:816 ../src/ui/dialog/symbols.cpp:836
 msgid "Unnamed Symbols"
 msgstr ""
 
+#: ../src/ui/dialog/symbols.cpp:955
+msgid "notitle_"
+msgstr ""
+
+#: ../src/ui/dialog/symbols.cpp:1227
+msgid "Symbol without title "
+msgstr ""
+
 #: ../src/ui/dialog/tags.cpp:256 ../src/ui/dialog/tags.cpp:554
-#: ../src/ui/dialog/tags.cpp:668 ../src/ui/dialog/tags.cpp:931
+#: ../src/ui/dialog/tags.cpp:672 ../src/ui/dialog/tags.cpp:935
 msgid "Remove from selection set"
 msgstr ""
 
@@ -21980,19 +22314,19 @@ msgstr ""
 msgid "Items"
 msgstr ""
 
-#: ../src/ui/dialog/tags.cpp:651 ../src/ui/dialog/tags.cpp:929
+#: ../src/ui/dialog/tags.cpp:655 ../src/ui/dialog/tags.cpp:933
 msgid "Add selection to set"
 msgstr ""
 
-#: ../src/ui/dialog/tags.cpp:809
+#: ../src/ui/dialog/tags.cpp:813
 msgid "Moved sets"
 msgstr ""
 
-#: ../src/ui/dialog/tags.cpp:985
+#: ../src/ui/dialog/tags.cpp:989
 msgid "Add a new selection set"
 msgstr ""
 
-#: ../src/ui/dialog/tags.cpp:994
+#: ../src/ui/dialog/tags.cpp:998
 msgid "Remove Item/Set"
 msgstr ""
 
@@ -22025,27 +22359,27 @@ msgid "AaBbCcIiPpQq12369$€¢?.;/()"
 msgstr ""
 
 #. Align buttons
-#: ../src/ui/dialog/text-edit.cpp:87 ../src/widgets/text-toolbar.cpp:1813
-#: ../src/widgets/text-toolbar.cpp:1814
+#: ../src/ui/dialog/text-edit.cpp:87 ../src/widgets/text-toolbar.cpp:2115
+#: ../src/widgets/text-toolbar.cpp:2116
 msgid "Align left"
 msgstr ""
 
-#: ../src/ui/dialog/text-edit.cpp:88 ../src/widgets/text-toolbar.cpp:1819
-#: ../src/widgets/text-toolbar.cpp:1820
+#: ../src/ui/dialog/text-edit.cpp:88 ../src/widgets/text-toolbar.cpp:2121
+#: ../src/widgets/text-toolbar.cpp:2122
 msgid "Align center"
 msgstr ""
 
-#: ../src/ui/dialog/text-edit.cpp:89 ../src/widgets/text-toolbar.cpp:1825
-#: ../src/widgets/text-toolbar.cpp:1826
+#: ../src/ui/dialog/text-edit.cpp:89 ../src/widgets/text-toolbar.cpp:2127
+#: ../src/widgets/text-toolbar.cpp:2128
 msgid "Align right"
 msgstr ""
 
-#: ../src/ui/dialog/text-edit.cpp:90 ../src/widgets/text-toolbar.cpp:1832
+#: ../src/ui/dialog/text-edit.cpp:90 ../src/widgets/text-toolbar.cpp:2134
 msgid "Justify (only flowed text)"
 msgstr ""
 
 #. Direction buttons
-#: ../src/ui/dialog/text-edit.cpp:97 ../src/widgets/text-toolbar.cpp:1863
+#: ../src/ui/dialog/text-edit.cpp:97 ../src/widgets/text-toolbar.cpp:2165
 msgid "Horizontal text"
 msgstr ""
 
@@ -22057,8 +22391,8 @@ msgstr ""
 msgid "Text path offset"
 msgstr ""
 
-#: ../src/ui/dialog/text-edit.cpp:550 ../src/ui/dialog/text-edit.cpp:637
-#: ../src/ui/tools/text-tool.cpp:1493
+#: ../src/ui/dialog/text-edit.cpp:552 ../src/ui/dialog/text-edit.cpp:639
+#: ../src/ui/tools/text-tool.cpp:1489
 msgid "Set text style"
 msgstr ""
 
@@ -22570,68 +22904,68 @@ msgstr ""
 msgid "Change attribute"
 msgstr ""
 
-#: ../src/ui/interface.cpp:767
+#: ../src/ui/interface.cpp:729
 msgctxt "Interface setup"
 msgid "Default"
 msgstr ""
 
-#: ../src/ui/interface.cpp:767
+#: ../src/ui/interface.cpp:729
 msgid "Default interface setup"
 msgstr ""
 
-#: ../src/ui/interface.cpp:768
+#: ../src/ui/interface.cpp:730
 msgctxt "Interface setup"
 msgid "Custom"
 msgstr ""
 
-#: ../src/ui/interface.cpp:768
+#: ../src/ui/interface.cpp:730
 msgid "Setup for custom task"
 msgstr ""
 
-#: ../src/ui/interface.cpp:769
+#: ../src/ui/interface.cpp:731
 msgctxt "Interface setup"
 msgid "Wide"
 msgstr ""
 
-#: ../src/ui/interface.cpp:769
+#: ../src/ui/interface.cpp:731
 msgid "Setup for widescreen work"
 msgstr ""
 
-#: ../src/ui/interface.cpp:888
+#: ../src/ui/interface.cpp:849
 #, c-format
 msgid "Verb \"%s\" Unknown"
 msgstr ""
 
-#: ../src/ui/interface.cpp:923
+#: ../src/ui/interface.cpp:884
 msgid "Open _Recent"
 msgstr ""
 
-#: ../src/ui/interface.cpp:1031 ../src/ui/interface.cpp:1117
-#: ../src/ui/interface.cpp:1220 ../src/ui/widget/selected-style.cpp:531
+#: ../src/ui/interface.cpp:992 ../src/ui/interface.cpp:1078
+#: ../src/ui/interface.cpp:1181 ../src/ui/widget/selected-style.cpp:528
 msgid "Drop color"
 msgstr ""
 
-#: ../src/ui/interface.cpp:1070 ../src/ui/interface.cpp:1180
+#: ../src/ui/interface.cpp:1031 ../src/ui/interface.cpp:1141
 msgid "Drop color on gradient"
 msgstr ""
 
-#: ../src/ui/interface.cpp:1233
+#: ../src/ui/interface.cpp:1194
 msgid "Could not parse SVG data"
 msgstr ""
 
-#: ../src/ui/interface.cpp:1272
+#: ../src/ui/interface.cpp:1233
 msgid "Drop SVG"
 msgstr ""
 
-#: ../src/ui/interface.cpp:1285
+#: ../src/ui/interface.cpp:1246
 msgid "Drop Symbol"
 msgstr ""
 
-#: ../src/ui/interface.cpp:1308
+#: ../src/ui/interface.cpp:1269
 msgid "Drop bitmap image"
 msgstr ""
 
-#: ../src/ui/interface.cpp:1400
+#: ../src/ui/interface.cpp:1362
 #, c-format
 msgid ""
 "<span weight=\"bold\" size=\"larger\">A file named \"%s\" already exists. Do "
@@ -22640,115 +22974,120 @@ msgid ""
 "The file already exists in \"%s\". Replacing it will overwrite its contents."
 msgstr ""
 
-#: ../src/ui/interface.cpp:1407 ../share/extensions/web-set-att.inx.h:21
+#: ../src/ui/interface.cpp:1369 ../share/extensions/web-set-att.inx.h:21
 #: ../share/extensions/web-transmit-att.inx.h:19
 msgid "Replace"
 msgstr ""
 
-#: ../src/ui/object-edit.cpp:479
+#: ../src/ui/shape-editor-knotholders.cpp:527
 msgid ""
 "Adjust the <b>horizontal rounding</b> radius; with <b>Ctrl</b> to make the "
 "vertical radius the same"
 msgstr ""
 
-#: ../src/ui/object-edit.cpp:484
+#: ../src/ui/shape-editor-knotholders.cpp:532
 msgid ""
 "Adjust the <b>vertical rounding</b> radius; with <b>Ctrl</b> to make the "
 "horizontal radius the same"
 msgstr ""
 
-#: ../src/ui/object-edit.cpp:489 ../src/ui/object-edit.cpp:494
+#: ../src/ui/shape-editor-knotholders.cpp:537
+#: ../src/ui/shape-editor-knotholders.cpp:542
 msgid ""
 "Adjust the <b>width and height</b> of the rectangle; with <b>Ctrl</b> to "
 "lock ratio or stretch in one dimension only"
 msgstr ""
 
-#: ../src/ui/object-edit.cpp:499
+#: ../src/ui/shape-editor-knotholders.cpp:547
 msgid "Drag to move the rectangle"
 msgstr ""
 
-#: ../src/ui/object-edit.cpp:746 ../src/ui/object-edit.cpp:750
-#: ../src/ui/object-edit.cpp:754 ../src/ui/object-edit.cpp:758
+#: ../src/ui/shape-editor-knotholders.cpp:794
+#: ../src/ui/shape-editor-knotholders.cpp:798
+#: ../src/ui/shape-editor-knotholders.cpp:802
+#: ../src/ui/shape-editor-knotholders.cpp:806
 msgid ""
 "Resize box in X/Y direction; with <b>Shift</b> along the Z axis; with "
 "<b>Ctrl</b> to constrain to the directions of edges or diagonals"
 msgstr ""
 
-#: ../src/ui/object-edit.cpp:762 ../src/ui/object-edit.cpp:766
-#: ../src/ui/object-edit.cpp:770 ../src/ui/object-edit.cpp:774
+#: ../src/ui/shape-editor-knotholders.cpp:810
+#: ../src/ui/shape-editor-knotholders.cpp:814
+#: ../src/ui/shape-editor-knotholders.cpp:818
+#: ../src/ui/shape-editor-knotholders.cpp:822
 msgid ""
 "Resize box along the Z axis; with <b>Shift</b> in X/Y direction; with "
 "<b>Ctrl</b> to constrain to the directions of edges or diagonals"
 msgstr ""
 
-#: ../src/ui/object-edit.cpp:778
+#: ../src/ui/shape-editor-knotholders.cpp:826
 msgid "Move the box in perspective"
 msgstr ""
 
-#: ../src/ui/object-edit.cpp:1065
+#: ../src/ui/shape-editor-knotholders.cpp:1113
 msgid "Adjust ellipse <b>width</b>, with <b>Ctrl</b> to make circle"
 msgstr ""
 
-#: ../src/ui/object-edit.cpp:1069
+#: ../src/ui/shape-editor-knotholders.cpp:1117
 msgid "Adjust ellipse <b>height</b>, with <b>Ctrl</b> to make circle"
 msgstr ""
 
-#: ../src/ui/object-edit.cpp:1073
+#: ../src/ui/shape-editor-knotholders.cpp:1121
 msgid ""
 "Position the <b>start point</b> of the arc or segment; with <b>Shift</b> to "
 "move with <b>end point</b>; with <b>Ctrl</b> to snap angle; drag <b>inside</"
 "b> the ellipse for arc, <b>outside</b> for segment"
 msgstr ""
 
-#: ../src/ui/object-edit.cpp:1079
+#: ../src/ui/shape-editor-knotholders.cpp:1127
 msgid ""
 "Position the <b>end point</b> of the arc or segment; with <b>Shift</b> to "
 "move with <b>start point</b>; with <b>Ctrl</b> to snap angle; drag "
 "<b>inside</b> the ellipse for arc, <b>outside</b> for segment"
 msgstr ""
 
-#: ../src/ui/object-edit.cpp:1085
+#: ../src/ui/shape-editor-knotholders.cpp:1133
 msgid "Drag to move the ellipse"
 msgstr ""
 
-#: ../src/ui/object-edit.cpp:1259
+#: ../src/ui/shape-editor-knotholders.cpp:1307
 msgid ""
 "Adjust the <b>tip radius</b> of the star or polygon; with <b>Shift</b> to "
 "round; with <b>Alt</b> to randomize"
 msgstr ""
 
-#: ../src/ui/object-edit.cpp:1267
+#: ../src/ui/shape-editor-knotholders.cpp:1315
 msgid ""
 "Adjust the <b>base radius</b> of the star; with <b>Ctrl</b> to keep star "
 "rays radial (no skew); with <b>Shift</b> to round; with <b>Alt</b> to "
 "randomize"
 msgstr ""
 
-#: ../src/ui/object-edit.cpp:1274
+#: ../src/ui/shape-editor-knotholders.cpp:1322
 msgid "Drag to move the star"
 msgstr ""
 
-#: ../src/ui/object-edit.cpp:1510
+#: ../src/ui/shape-editor-knotholders.cpp:1558
 msgid "Drag to move the spiral"
 msgstr ""
 
-#: ../src/ui/object-edit.cpp:1514
+#: ../src/ui/shape-editor-knotholders.cpp:1562
 msgid ""
 "Roll/unroll the spiral from <b>inside</b>; with <b>Ctrl</b> to snap angle; "
 "with <b>Alt</b> to converge/diverge"
 msgstr ""
 
-#: ../src/ui/object-edit.cpp:1518
+#: ../src/ui/shape-editor-knotholders.cpp:1566
 msgid ""
 "Roll/unroll the spiral from <b>outside</b>; with <b>Ctrl</b> to snap angle; "
 "with <b>Shift</b> to scale/rotate; with <b>Alt</b> to lock radius"
 msgstr ""
 
-#: ../src/ui/object-edit.cpp:1568
+#: ../src/ui/shape-editor-knotholders.cpp:1616
 msgid "Adjust the <b>offset distance</b>"
 msgstr ""
 
-#: ../src/ui/object-edit.cpp:1605
+#: ../src/ui/shape-editor-knotholders.cpp:1653
 msgid "Drag to resize the <b>flowed text frame</b>"
 msgstr ""
 
@@ -22792,96 +23131,96 @@ msgid ""
 "node, click to select (more: Shift, Ctrl+Alt)"
 msgstr ""
 
-#: ../src/ui/tool/multi-path-manipulator.cpp:313
+#: ../src/ui/tool/multi-path-manipulator.cpp:312
 msgid "Retract handles"
 msgstr ""
 
-#: ../src/ui/tool/multi-path-manipulator.cpp:313 ../src/ui/tool/node.cpp:292
+#: ../src/ui/tool/multi-path-manipulator.cpp:312 ../src/ui/tool/node.cpp:292
 msgid "Change node type"
 msgstr ""
 
-#: ../src/ui/tool/multi-path-manipulator.cpp:321
+#: ../src/ui/tool/multi-path-manipulator.cpp:320
 msgid "Straighten segments"
 msgstr ""
 
-#: ../src/ui/tool/multi-path-manipulator.cpp:323
+#: ../src/ui/tool/multi-path-manipulator.cpp:322
 msgid "Make segments curves"
 msgstr ""
 
-#: ../src/ui/tool/multi-path-manipulator.cpp:331
-#: ../src/ui/tool/multi-path-manipulator.cpp:345
+#: ../src/ui/tool/multi-path-manipulator.cpp:330
+#: ../src/ui/tool/multi-path-manipulator.cpp:344
 msgid "Add nodes"
 msgstr ""
 
-#: ../src/ui/tool/multi-path-manipulator.cpp:337
+#: ../src/ui/tool/multi-path-manipulator.cpp:336
 msgid "Add extremum nodes"
 msgstr ""
 
-#: ../src/ui/tool/multi-path-manipulator.cpp:352
+#: ../src/ui/tool/multi-path-manipulator.cpp:351
 msgid "Duplicate nodes"
 msgstr ""
 
-#: ../src/ui/tool/multi-path-manipulator.cpp:415
+#: ../src/ui/tool/multi-path-manipulator.cpp:414
 #: ../src/widgets/node-toolbar.cpp:406
 msgid "Join nodes"
 msgstr ""
 
-#: ../src/ui/tool/multi-path-manipulator.cpp:422
+#: ../src/ui/tool/multi-path-manipulator.cpp:421
 #: ../src/widgets/node-toolbar.cpp:417
 msgid "Break nodes"
 msgstr ""
 
-#: ../src/ui/tool/multi-path-manipulator.cpp:429
+#: ../src/ui/tool/multi-path-manipulator.cpp:428
 msgid "Delete nodes"
 msgstr ""
 
-#: ../src/ui/tool/multi-path-manipulator.cpp:775
+#: ../src/ui/tool/multi-path-manipulator.cpp:774
 msgid "Move nodes"
 msgstr ""
 
-#: ../src/ui/tool/multi-path-manipulator.cpp:778
+#: ../src/ui/tool/multi-path-manipulator.cpp:777
 msgid "Move nodes horizontally"
 msgstr ""
 
-#: ../src/ui/tool/multi-path-manipulator.cpp:782
+#: ../src/ui/tool/multi-path-manipulator.cpp:781
 msgid "Move nodes vertically"
 msgstr ""
 
-#: ../src/ui/tool/multi-path-manipulator.cpp:786
-#: ../src/ui/tool/multi-path-manipulator.cpp:789
+#: ../src/ui/tool/multi-path-manipulator.cpp:785
+#: ../src/ui/tool/multi-path-manipulator.cpp:788
 msgid "Rotate nodes"
 msgstr ""
 
-#: ../src/ui/tool/multi-path-manipulator.cpp:793
-#: ../src/ui/tool/multi-path-manipulator.cpp:799
+#: ../src/ui/tool/multi-path-manipulator.cpp:792
+#: ../src/ui/tool/multi-path-manipulator.cpp:798
 msgid "Scale nodes uniformly"
 msgstr ""
 
-#: ../src/ui/tool/multi-path-manipulator.cpp:796
+#: ../src/ui/tool/multi-path-manipulator.cpp:795
 msgid "Scale nodes"
 msgstr ""
 
-#: ../src/ui/tool/multi-path-manipulator.cpp:803
+#: ../src/ui/tool/multi-path-manipulator.cpp:802
 msgid "Scale nodes horizontally"
 msgstr ""
 
-#: ../src/ui/tool/multi-path-manipulator.cpp:807
+#: ../src/ui/tool/multi-path-manipulator.cpp:806
 msgid "Scale nodes vertically"
 msgstr ""
 
-#: ../src/ui/tool/multi-path-manipulator.cpp:811
+#: ../src/ui/tool/multi-path-manipulator.cpp:810
 msgid "Skew nodes horizontally"
 msgstr ""
 
-#: ../src/ui/tool/multi-path-manipulator.cpp:815
+#: ../src/ui/tool/multi-path-manipulator.cpp:814
 msgid "Skew nodes vertically"
 msgstr ""
 
-#: ../src/ui/tool/multi-path-manipulator.cpp:819
+#: ../src/ui/tool/multi-path-manipulator.cpp:818
 msgid "Flip nodes horizontally"
 msgstr ""
 
-#: ../src/ui/tool/multi-path-manipulator.cpp:822
+#: ../src/ui/tool/multi-path-manipulator.cpp:821
 msgid "Flip nodes vertically"
 msgstr ""
 
@@ -22990,38 +23329,38 @@ msgctxt "Path handle tip"
 msgid "Move handle by %s, %s; angle %.2f°, length %s"
 msgstr ""
 
-#: ../src/ui/tool/node.cpp:1414
+#: ../src/ui/tool/node.cpp:1411
 msgctxt "Path node tip"
 msgid "<b>Shift</b>: drag out a handle, click to toggle selection"
 msgstr ""
 
-#: ../src/ui/tool/node.cpp:1416
+#: ../src/ui/tool/node.cpp:1413
 msgctxt "Path node tip"
 msgid "<b>Shift</b>: click to toggle selection"
 msgstr ""
 
-#: ../src/ui/tool/node.cpp:1421
+#: ../src/ui/tool/node.cpp:1418
 msgctxt "Path node tip"
 msgid "<b>Ctrl+Alt</b>: move along handle lines, click to delete node"
 msgstr ""
 
-#: ../src/ui/tool/node.cpp:1424
+#: ../src/ui/tool/node.cpp:1421
 msgctxt "Path node tip"
 msgid "<b>Ctrl</b>: move along axes, click to change node type"
 msgstr ""
 
-#: ../src/ui/tool/node.cpp:1428
+#: ../src/ui/tool/node.cpp:1425
 msgctxt "Path node tip"
 msgid "<b>Alt</b>: sculpt nodes"
 msgstr ""
 
-#: ../src/ui/tool/node.cpp:1437
+#: ../src/ui/tool/node.cpp:1434
 #, c-format
 msgctxt "Path node tip"
 msgid "<b>%s</b>: drag to shape the path (more: Shift, Ctrl, Alt)"
 msgstr ""
 
-#: ../src/ui/tool/node.cpp:1440
+#: ../src/ui/tool/node.cpp:1437
 #, c-format
 msgctxt "Path node tip"
 msgid ""
@@ -23029,7 +23368,7 @@ msgid ""
 "power"
 msgstr ""
 
-#: ../src/ui/tool/node.cpp:1443
+#: ../src/ui/tool/node.cpp:1440
 #, c-format
 msgctxt "Path node tip"
 msgid ""
@@ -23037,7 +23376,7 @@ msgid ""
 "(more: Shift, Ctrl, Alt)"
 msgstr ""
 
-#: ../src/ui/tool/node.cpp:1447
+#: ../src/ui/tool/node.cpp:1444
 #, c-format
 msgctxt "Path node tip"
 msgid ""
@@ -23045,7 +23384,7 @@ msgid ""
 "Shift, Ctrl, Alt)"
 msgstr ""
 
-#: ../src/ui/tool/node.cpp:1450
+#: ../src/ui/tool/node.cpp:1447
 #, c-format
 msgctxt "Path node tip"
 msgid ""
@@ -23053,17 +23392,17 @@ msgid ""
 "(more: Shift, Ctrl, Alt). %g power"
 msgstr ""
 
-#: ../src/ui/tool/node.cpp:1463
+#: ../src/ui/tool/node.cpp:1460
 #, c-format
 msgctxt "Path node tip"
 msgid "Move node by %s, %s"
 msgstr ""
 
-#: ../src/ui/tool/node.cpp:1474
+#: ../src/ui/tool/node.cpp:1469
 msgid "Symmetric node"
 msgstr ""
 
-#: ../src/ui/tool/node.cpp:1475
+#: ../src/ui/tool/node.cpp:1470
 msgid "Auto-smooth node"
 msgstr ""
 
@@ -23277,7 +23616,7 @@ msgid ""
 "path. <b>Arrow keys</b> adjust width (left/right) and angle (up/down)."
 msgstr ""
 
-#: ../src/ui/tools-switch.cpp:107 ../src/ui/tools/text-tool.cpp:1629
+#: ../src/ui/tools-switch.cpp:107 ../src/ui/tools/text-tool.cpp:1625
 msgid ""
 "<b>Click</b> to select or create text, <b>drag</b> to create flowed text; "
 "then type."
@@ -23354,7 +23693,7 @@ msgid ""
 "ratio ellipse; with <b>Shift</b> to draw around the starting point"
 msgstr ""
 
-#: ../src/ui/tools/arc-tool.cpp:427
+#: ../src/ui/tools/arc-tool.cpp:424
 msgid "Create ellipse"
 msgstr ""
 
@@ -23373,66 +23712,66 @@ msgstr ""
 msgid "Create 3D box"
 msgstr ""
 
-#: ../src/ui/tools/calligraphic-tool.cpp:517
+#: ../src/ui/tools/calligraphic-tool.cpp:516
 msgid ""
 "<b>Guide path selected</b>; start drawing along the guide with <b>Ctrl</b>"
 msgstr ""
 
-#: ../src/ui/tools/calligraphic-tool.cpp:519
+#: ../src/ui/tools/calligraphic-tool.cpp:518
 msgid "<b>Select a guide path</b> to track with <b>Ctrl</b>"
 msgstr ""
 
-#: ../src/ui/tools/calligraphic-tool.cpp:654
+#: ../src/ui/tools/calligraphic-tool.cpp:653
 msgid "Tracking: <b>connection to guide path lost!</b>"
 msgstr ""
 
-#: ../src/ui/tools/calligraphic-tool.cpp:654
+#: ../src/ui/tools/calligraphic-tool.cpp:653
 msgid "<b>Tracking</b> a guide path"
 msgstr ""
 
-#: ../src/ui/tools/calligraphic-tool.cpp:657
+#: ../src/ui/tools/calligraphic-tool.cpp:656
 msgid "<b>Drawing</b> a calligraphic stroke"
 msgstr ""
 
-#: ../src/ui/tools/calligraphic-tool.cpp:960
+#: ../src/ui/tools/calligraphic-tool.cpp:958
 msgid "Draw calligraphic stroke"
 msgstr ""
 
-#: ../src/ui/tools/connector-tool.cpp:482
+#: ../src/ui/tools/connector-tool.cpp:489
 msgid "Creating new connector"
 msgstr ""
 
-#: ../src/ui/tools/connector-tool.cpp:723
+#: ../src/ui/tools/connector-tool.cpp:730
 msgid "Connector endpoint drag cancelled."
 msgstr ""
 
-#: ../src/ui/tools/connector-tool.cpp:766
+#: ../src/ui/tools/connector-tool.cpp:770
 msgid "Reroute connector"
 msgstr ""
 
-#: ../src/ui/tools/connector-tool.cpp:919
+#: ../src/ui/tools/connector-tool.cpp:926
 msgid "Create connector"
 msgstr ""
 
-#: ../src/ui/tools/connector-tool.cpp:936
+#: ../src/ui/tools/connector-tool.cpp:945
 msgid "Finishing connector"
 msgstr ""
 
-#: ../src/ui/tools/connector-tool.cpp:1173
+#: ../src/ui/tools/connector-tool.cpp:1174
 msgid "<b>Connector endpoint</b>: drag to reroute or connect to new shapes"
 msgstr ""
 
-#: ../src/ui/tools/connector-tool.cpp:1316
+#: ../src/ui/tools/connector-tool.cpp:1310
 msgid "Select <b>at least one non-connector object</b>."
 msgstr ""
 
-#: ../src/ui/tools/connector-tool.cpp:1321
-#: ../src/widgets/connector-toolbar.cpp:307
+#: ../src/ui/tools/connector-tool.cpp:1315
+#: ../src/widgets/connector-toolbar.cpp:310
 msgid "Make connectors avoid selected objects"
 msgstr ""
 
-#: ../src/ui/tools/connector-tool.cpp:1322
-#: ../src/widgets/connector-toolbar.cpp:317
+#: ../src/ui/tools/connector-tool.cpp:1316
+#: ../src/widgets/connector-toolbar.cpp:320
 msgid "Make connectors ignore selected objects"
 msgstr ""
 
@@ -23462,11 +23801,11 @@ msgstr ""
 msgid "<b>Release mouse</b> to set color."
 msgstr ""
 
-#: ../src/ui/tools/eraser-tool.cpp:431
+#: ../src/ui/tools/eraser-tool.cpp:430
 msgid "<b>Drawing</b> an eraser stroke"
 msgstr ""
 
-#: ../src/ui/tools/eraser-tool.cpp:862
+#: ../src/ui/tools/eraser-tool.cpp:860
 msgid "Draw eraser stroke"
 msgstr ""
 
@@ -23537,24 +23876,24 @@ msgid "<b>Draw over</b> areas to add to fill, hold <b>Alt</b> for touch fill"
 msgstr ""
 
 #. We hit green anchor, closing Green-Blue-Red
-#: ../src/ui/tools/freehand-base.cpp:660 ../src/ui/tools/freehand-base.cpp:742
+#: ../src/ui/tools/freehand-base.cpp:758 ../src/ui/tools/freehand-base.cpp:825
 msgid "Path is closed."
 msgstr ""
 
 #. We hit bot start and end of single curve, closing paths
-#: ../src/ui/tools/freehand-base.cpp:675
+#: ../src/ui/tools/freehand-base.cpp:773
 msgid "Closing path."
 msgstr ""
 
-#: ../src/ui/tools/freehand-base.cpp:818
+#: ../src/ui/tools/freehand-base.cpp:907
 msgid "Draw path"
 msgstr ""
 
-#: ../src/ui/tools/freehand-base.cpp:975
+#: ../src/ui/tools/freehand-base.cpp:1063
 msgid "Creating single dot"
 msgstr ""
 
-#: ../src/ui/tools/freehand-base.cpp:976
+#: ../src/ui/tools/freehand-base.cpp:1064
 msgid "Create single dot"
 msgstr ""
 
@@ -23609,34 +23948,34 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ui/tools/gradient-tool.cpp:432
+#: ../src/ui/tools/gradient-tool.cpp:425
 msgid "Simplify gradient"
 msgstr ""
 
-#: ../src/ui/tools/gradient-tool.cpp:509
+#: ../src/ui/tools/gradient-tool.cpp:498
 msgid "Create default gradient"
 msgstr ""
 
-#: ../src/ui/tools/gradient-tool.cpp:568 ../src/ui/tools/mesh-tool.cpp:731
+#: ../src/ui/tools/gradient-tool.cpp:557 ../src/ui/tools/mesh-tool.cpp:667
 msgid "<b>Draw around</b> handles to select them"
 msgstr ""
 
-#: ../src/ui/tools/gradient-tool.cpp:689
+#: ../src/ui/tools/gradient-tool.cpp:678
 msgid "<b>Ctrl</b>: snap gradient angle"
 msgstr ""
 
-#: ../src/ui/tools/gradient-tool.cpp:690
+#: ../src/ui/tools/gradient-tool.cpp:679
 msgid "<b>Shift</b>: draw gradient around the starting point"
 msgstr ""
 
-#: ../src/ui/tools/gradient-tool.cpp:955 ../src/ui/tools/mesh-tool.cpp:1195
+#: ../src/ui/tools/gradient-tool.cpp:944 ../src/ui/tools/mesh-tool.cpp:1128
 #, c-format
 msgid "<b>Gradient</b> for %d object; with <b>Ctrl</b> to snap angle"
 msgid_plural "<b>Gradient</b> for %d objects; with <b>Ctrl</b> to snap angle"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ui/tools/gradient-tool.cpp:959 ../src/ui/tools/mesh-tool.cpp:1199
+#: ../src/ui/tools/gradient-tool.cpp:948 ../src/ui/tools/mesh-tool.cpp:1132
 msgid "Select <b>objects</b> on which to create gradient."
 msgstr ""
 
@@ -23653,35 +23992,43 @@ msgstr ""
 msgid "Measure end, <b>Shift+Click</b> for position dialog"
 msgstr ""
 
-#: ../src/ui/tools/measure-tool.cpp:740 ../share/extensions/measure.inx.h:2
+#: ../src/ui/tools/measure-tool.cpp:746 ../share/extensions/measure.inx.h:2
 msgid "Measure"
 msgstr ""
 
-#: ../src/ui/tools/measure-tool.cpp:745
+#: ../src/ui/tools/measure-tool.cpp:751
 msgid "Base"
 msgstr ""
 
-#: ../src/ui/tools/measure-tool.cpp:754
+#: ../src/ui/tools/measure-tool.cpp:760
 msgid "Add guides from measure tool"
 msgstr ""
 
-#: ../src/ui/tools/measure-tool.cpp:774
+#: ../src/ui/tools/measure-tool.cpp:780
 msgid "Keep last measure on the canvas, for reference"
 msgstr ""
 
-#: ../src/ui/tools/measure-tool.cpp:794
+#: ../src/ui/tools/measure-tool.cpp:800
 msgid "Convert measure to items"
 msgstr ""
 
-#: ../src/ui/tools/measure-tool.cpp:832
+#: ../src/ui/tools/measure-tool.cpp:838
 msgid "Add global measure line"
 msgstr ""
 
-#: ../src/ui/tools/measure-tool.cpp:1195
+#: ../src/ui/tools/measure-tool.cpp:1197
+msgid "Selected"
+msgstr ""
+
+#: ../src/ui/tools/measure-tool.cpp:1199
+msgid "Not selected"
+msgstr ""
+
+#: ../src/ui/tools/measure-tool.cpp:1210
 msgid "Shift to measure into group"
 msgstr ""
 
-#: ../src/ui/tools/measure-tool.cpp:1385 ../src/ui/tools/measure-tool.cpp:1387
+#: ../src/ui/tools/measure-tool.cpp:1403 ../src/ui/tools/measure-tool.cpp:1405
 #, c-format
 msgid "Crossing %lu"
 msgstr ""
@@ -23709,207 +24056,207 @@ msgid_plural "<b>No</b> mesh handles selected out of %d on %d selected objects"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ui/tools/mesh-tool.cpp:359
+#: ../src/ui/tools/mesh-tool.cpp:297
 msgid "Split mesh row/column"
 msgstr ""
 
-#: ../src/ui/tools/mesh-tool.cpp:452
+#: ../src/ui/tools/mesh-tool.cpp:390
 msgid "Toggled mesh path type."
 msgstr ""
 
-#: ../src/ui/tools/mesh-tool.cpp:457
+#: ../src/ui/tools/mesh-tool.cpp:395
 msgid "Approximated arc for mesh side."
 msgstr ""
 
-#: ../src/ui/tools/mesh-tool.cpp:462
+#: ../src/ui/tools/mesh-tool.cpp:400
 msgid "Toggled mesh tensors."
 msgstr ""
 
-#: ../src/ui/tools/mesh-tool.cpp:467
+#: ../src/ui/tools/mesh-tool.cpp:405
 msgid "Smoothed mesh corner color."
 msgstr ""
 
-#: ../src/ui/tools/mesh-tool.cpp:472
+#: ../src/ui/tools/mesh-tool.cpp:410
 msgid "Picked mesh corner color."
 msgstr ""
 
-#: ../src/ui/tools/mesh-tool.cpp:477
+#: ../src/ui/tools/mesh-tool.cpp:415
 msgid "Inserted new row or column."
 msgstr ""
 
-#: ../src/ui/tools/mesh-tool.cpp:548
+#: ../src/ui/tools/mesh-tool.cpp:486
 msgid "Fit mesh inside bounding box."
 msgstr ""
 
-#: ../src/ui/tools/mesh-tool.cpp:1189
+#: ../src/ui/tools/mesh-tool.cpp:1122
 msgid "Create mesh"
 msgstr ""
 
-#: ../src/ui/tools/node-tool.cpp:643
+#: ../src/ui/tools/node-tool.cpp:647
 msgctxt "Node tool tip"
 msgid ""
 "<b>Shift</b>: drag to add nodes to the selection, click to toggle object "
 "selection"
 msgstr ""
 
-#: ../src/ui/tools/node-tool.cpp:647
+#: ../src/ui/tools/node-tool.cpp:651
 msgctxt "Node tool tip"
 msgid "<b>Shift</b>: drag to add nodes to the selection"
 msgstr ""
 
-#: ../src/ui/tools/node-tool.cpp:676
+#: ../src/ui/tools/node-tool.cpp:680
 #, c-format
 msgid "<b>%u of %u</b> node selected."
 msgid_plural "<b>%u of %u</b> nodes selected."
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ui/tools/node-tool.cpp:683
+#: ../src/ui/tools/node-tool.cpp:687
 #, c-format
 msgctxt "Node tool tip"
 msgid "%s Drag to select nodes, click to edit only this object (more: Shift)"
 msgstr ""
 
-#: ../src/ui/tools/node-tool.cpp:689
+#: ../src/ui/tools/node-tool.cpp:693
 #, c-format
 msgctxt "Node tool tip"
 msgid "%s Drag to select nodes, click clear the selection"
 msgstr ""
 
-#: ../src/ui/tools/node-tool.cpp:698
+#: ../src/ui/tools/node-tool.cpp:702
 msgctxt "Node tool tip"
 msgid "Drag to select nodes, click to edit only this object"
 msgstr ""
 
-#: ../src/ui/tools/node-tool.cpp:701
+#: ../src/ui/tools/node-tool.cpp:705
 msgctxt "Node tool tip"
 msgid "Drag to select nodes, click to clear the selection"
 msgstr ""
 
-#: ../src/ui/tools/node-tool.cpp:706
+#: ../src/ui/tools/node-tool.cpp:710
 msgctxt "Node tool tip"
 msgid "Drag to select objects to edit, click to edit this object (more: Shift)"
 msgstr ""
 
-#: ../src/ui/tools/node-tool.cpp:709
+#: ../src/ui/tools/node-tool.cpp:713
 msgctxt "Node tool tip"
 msgid "Drag to select objects to edit"
 msgstr ""
 
-#: ../src/ui/tools/pen-tool.cpp:211 ../src/ui/tools/pencil-tool.cpp:450
+#: ../src/ui/tools/pen-tool.cpp:214 ../src/ui/tools/pencil-tool.cpp:531
 msgid "Drawing cancelled"
 msgstr ""
 
-#: ../src/ui/tools/pen-tool.cpp:451 ../src/ui/tools/pencil-tool.cpp:191
+#: ../src/ui/tools/pen-tool.cpp:460 ../src/ui/tools/pencil-tool.cpp:223
 msgid "Continuing selected path"
 msgstr ""
 
-#: ../src/ui/tools/pen-tool.cpp:461 ../src/ui/tools/pencil-tool.cpp:199
+#: ../src/ui/tools/pen-tool.cpp:470 ../src/ui/tools/pencil-tool.cpp:231
+#: ../src/ui/tools/pencil-tool.cpp:237
 msgid "Creating new path"
 msgstr ""
 
-#: ../src/ui/tools/pen-tool.cpp:463 ../src/ui/tools/pencil-tool.cpp:202
+#: ../src/ui/tools/pen-tool.cpp:472 ../src/ui/tools/pencil-tool.cpp:240
 msgid "Appending to selected path"
 msgstr ""
 
-#: ../src/ui/tools/pen-tool.cpp:628
+#: ../src/ui/tools/pen-tool.cpp:637
 msgid "<b>Click</b> or <b>click and drag</b> to close and finish the path."
 msgstr ""
 
-#: ../src/ui/tools/pen-tool.cpp:630
+#: ../src/ui/tools/pen-tool.cpp:639
 msgid ""
 "<b>Click</b> or <b>click and drag</b> to close and finish the path. Shift"
 "+Click make a cusp node"
 msgstr ""
 
-#: ../src/ui/tools/pen-tool.cpp:642
+#: ../src/ui/tools/pen-tool.cpp:651
 msgid ""
 "<b>Click</b> or <b>click and drag</b> to continue the path from this point."
 msgstr ""
 
-#: ../src/ui/tools/pen-tool.cpp:644
+#: ../src/ui/tools/pen-tool.cpp:653
 msgid ""
 "<b>Click</b> or <b>click and drag</b> to continue the path from this point. "
 "Shift+Click make a cusp node"
 msgstr ""
 
-#: ../src/ui/tools/pen-tool.cpp:1779
+#: ../src/ui/tools/pen-tool.cpp:1799
+#, c-format
+msgid ""
+"<b>Curve segment</b>: angle %3.2f&#176;; with <b>Shift+Click</b> cusp node,"
+"<b>ALT</b> move previous, <b>Enter</b> or <b>Shift+Enter</b> to finish"
+msgstr ""
+
+#: ../src/ui/tools/pen-tool.cpp:1800
+#, c-format
+msgid ""
+"<b>Line segment</b>: angle %3.2f&#176;; with <b>Shift+Click</b> cusp node,"
+"<b>ALT</b> move previous, <b>Enter</b> or <b>Shift+Enter</b> to finish"
+msgstr ""
+
+#: ../src/ui/tools/pen-tool.cpp:1804
 #, c-format
 msgid ""
 "<b>Curve segment</b>: angle %3.2f&#176;, distance %s; with <b>Ctrl</b> to "
 "snap angle, <b>Enter</b> or <b>Shift+Enter</b> to finish the path"
 msgstr ""
 
-#: ../src/ui/tools/pen-tool.cpp:1780
+#: ../src/ui/tools/pen-tool.cpp:1805
 #, c-format
 msgid ""
 "<b>Line segment</b>: angle %3.2f&#176;, distance %s; with <b>Ctrl</b> to "
 "snap angle, <b>Enter</b> or <b>Shift+Enter</b> to finish the path"
 msgstr ""
 
-#: ../src/ui/tools/pen-tool.cpp:1783
-#, c-format
-msgid ""
-"<b>Curve segment</b>: angle %3.2f&#176;, distance %s; with <b>Shift+Click</"
-"b> make a cusp node, <b>Enter</b> or <b>Shift+Enter</b> to finish the path"
-msgstr ""
-
-#: ../src/ui/tools/pen-tool.cpp:1784
-#, c-format
-msgid ""
-"<b>Line segment</b>: angle %3.2f&#176;, distance %s; with <b>Shift+Click</b> "
-"make a cusp node, <b>Enter</b> or <b>Shift+Enter</b> to finish the path"
-msgstr ""
-
-#: ../src/ui/tools/pen-tool.cpp:1801
+#: ../src/ui/tools/pen-tool.cpp:1823
 #, c-format
 msgid ""
 "<b>Curve handle</b>: angle %3.2f&#176;, length %s; with <b>Ctrl</b> to snap "
 "angle"
 msgstr ""
 
-#: ../src/ui/tools/pen-tool.cpp:1825
+#: ../src/ui/tools/pen-tool.cpp:1847
 #, c-format
 msgid ""
 "<b>Curve handle, symmetric</b>: angle %3.2f&#176;, length %s; with <b>Ctrl</"
 "b> to snap angle, with <b>Shift</b> to move this handle only"
 msgstr ""
 
-#: ../src/ui/tools/pen-tool.cpp:1826
+#: ../src/ui/tools/pen-tool.cpp:1848
 #, c-format
 msgid ""
 "<b>Curve handle</b>: angle %3.2f&#176;, length %s; with <b>Ctrl</b> to snap "
 "angle, with <b>Shift</b> to move this handle only"
 msgstr ""
 
-#: ../src/ui/tools/pen-tool.cpp:1960
+#: ../src/ui/tools/pen-tool.cpp:1990
 msgid "Drawing finished"
 msgstr ""
 
-#: ../src/ui/tools/pencil-tool.cpp:303
+#: ../src/ui/tools/pencil-tool.cpp:356
 msgid "<b>Release</b> here to close and finish the path."
 msgstr ""
 
-#: ../src/ui/tools/pencil-tool.cpp:309
+#: ../src/ui/tools/pencil-tool.cpp:364
 msgid "Drawing a freehand path"
 msgstr ""
 
-#: ../src/ui/tools/pencil-tool.cpp:314
+#: ../src/ui/tools/pencil-tool.cpp:370
 msgid "<b>Drag</b> to continue the path from this point."
 msgstr ""
 
-#. Write curves to object
-#: ../src/ui/tools/pencil-tool.cpp:397
+#: ../src/ui/tools/pencil-tool.cpp:472
 msgid "Finishing freehand"
 msgstr ""
 
-#: ../src/ui/tools/pencil-tool.cpp:499
+#: ../src/ui/tools/pencil-tool.cpp:580
 msgid ""
 "<b>Sketch mode</b>: holding <b>Alt</b> interpolates between sketched paths. "
 "Release <b>Alt</b> to finalize."
 msgstr ""
 
-#: ../src/ui/tools/pencil-tool.cpp:526
+#: ../src/ui/tools/pencil-tool.cpp:607
 msgid "Finishing freehand sketch"
 msgstr ""
 
@@ -23919,35 +24266,35 @@ msgid ""
 "circular"
 msgstr ""
 
-#: ../src/ui/tools/rect-tool.cpp:424
+#: ../src/ui/tools/rect-tool.cpp:425
 #, c-format
 msgid ""
 "<b>Rectangle</b>: %s &#215; %s (constrained to ratio %d:%d); with <b>Shift</"
 "b> to draw around the starting point"
 msgstr ""
 
-#: ../src/ui/tools/rect-tool.cpp:427
+#: ../src/ui/tools/rect-tool.cpp:430
 #, c-format
 msgid ""
 "<b>Rectangle</b>: %s &#215; %s (constrained to golden ratio 1.618 : 1); with "
 "<b>Shift</b> to draw around the starting point"
 msgstr ""
 
-#: ../src/ui/tools/rect-tool.cpp:429
+#: ../src/ui/tools/rect-tool.cpp:434
 #, c-format
 msgid ""
 "<b>Rectangle</b>: %s &#215; %s (constrained to golden ratio 1 : 1.618); with "
 "<b>Shift</b> to draw around the starting point"
 msgstr ""
 
-#: ../src/ui/tools/rect-tool.cpp:433
+#: ../src/ui/tools/rect-tool.cpp:440
 #, c-format
 msgid ""
 "<b>Rectangle</b>: %s &#215; %s; with <b>Ctrl</b> to make square or integer-"
 "ratio rectangle; with <b>Shift</b> to draw around the starting point"
 msgstr ""
 
-#: ../src/ui/tools/rect-tool.cpp:456
+#: ../src/ui/tools/rect-tool.cpp:461
 msgid "Create rectangle"
 msgstr ""
 
@@ -23969,33 +24316,33 @@ msgstr ""
 msgid "Selection canceled."
 msgstr ""
 
-#: ../src/ui/tools/select-tool.cpp:637
+#: ../src/ui/tools/select-tool.cpp:639
 msgid ""
 "<b>Draw over</b> objects to select them; release <b>Alt</b> to switch to "
 "rubberband selection"
 msgstr ""
 
-#: ../src/ui/tools/select-tool.cpp:639
+#: ../src/ui/tools/select-tool.cpp:641
 msgid ""
 "<b>Drag around</b> objects to select them; press <b>Alt</b> to switch to "
 "touch selection"
 msgstr ""
 
-#: ../src/ui/tools/select-tool.cpp:880
+#: ../src/ui/tools/select-tool.cpp:882
 msgid "<b>Ctrl</b>: click to select in groups; drag to move hor/vert"
 msgstr ""
 
-#: ../src/ui/tools/select-tool.cpp:881
+#: ../src/ui/tools/select-tool.cpp:883
 msgid "<b>Shift</b>: click to toggle select; drag for rubberband selection"
 msgstr ""
 
-#: ../src/ui/tools/select-tool.cpp:882
+#: ../src/ui/tools/select-tool.cpp:884
 msgid ""
 "<b>Alt</b>: click to select under; scroll mouse-wheel to cycle-select; drag "
 "to move selected or select by touch"
 msgstr ""
 
-#: ../src/ui/tools/select-tool.cpp:1060
+#: ../src/ui/tools/select-tool.cpp:1062
 msgid "Selected object is not a group. Cannot enter."
 msgstr ""
 
@@ -24013,7 +24360,7 @@ msgid ""
 "<b>Spiral</b>: radius %s, angle %5g&#176;; with <b>Ctrl</b> to snap angle"
 msgstr ""
 
-#: ../src/ui/tools/spiral-tool.cpp:398
+#: ../src/ui/tools/spiral-tool.cpp:397
 msgid "Create spiral"
 msgstr ""
 
@@ -24053,11 +24400,11 @@ msgstr ""
 msgid "<b>Nothing selected!</b> Select objects to spray."
 msgstr ""
 
-#: ../src/ui/tools/spray-tool.cpp:1360 ../src/widgets/spray-toolbar.cpp:360
+#: ../src/ui/tools/spray-tool.cpp:1360 ../src/widgets/spray-toolbar.cpp:362
 msgid "Spray with copies"
 msgstr ""
 
-#: ../src/ui/tools/spray-tool.cpp:1364 ../src/widgets/spray-toolbar.cpp:367
+#: ../src/ui/tools/spray-tool.cpp:1364 ../src/widgets/spray-toolbar.cpp:368
 msgid "Spray with clones"
 msgstr ""
 
@@ -24080,7 +24427,7 @@ msgstr ""
 msgid "<b>Star</b>: radius %s, angle %5g&#176;; with <b>Ctrl</b> to snap angle"
 msgstr ""
 
-#: ../src/ui/tools/star-tool.cpp:424
+#: ../src/ui/tools/star-tool.cpp:422
 msgid "Create star"
 msgstr ""
 
@@ -24110,7 +24457,7 @@ msgstr ""
 msgid "Unicode (<b>Enter</b> to finish): %s: %s"
 msgstr ""
 
-#: ../src/ui/tools/text-tool.cpp:499 ../src/ui/tools/text-tool.cpp:802
+#: ../src/ui/tools/text-tool.cpp:499 ../src/ui/tools/text-tool.cpp:798
 msgid "Unicode (<b>Enter</b> to finish): "
 msgstr ""
 
@@ -24119,93 +24466,93 @@ msgstr ""
 msgid "<b>Flowed text frame</b>: %s &#215; %s"
 msgstr ""
 
-#: ../src/ui/tools/text-tool.cpp:638
+#: ../src/ui/tools/text-tool.cpp:634
 msgid "Type text; <b>Enter</b> to start new line."
 msgstr ""
 
-#: ../src/ui/tools/text-tool.cpp:649
+#: ../src/ui/tools/text-tool.cpp:645
 msgid "Flowed text is created."
 msgstr ""
 
-#: ../src/ui/tools/text-tool.cpp:650
+#: ../src/ui/tools/text-tool.cpp:646
 msgid "Create flowed text"
 msgstr ""
 
-#: ../src/ui/tools/text-tool.cpp:652
+#: ../src/ui/tools/text-tool.cpp:648
 msgid ""
 "The frame is <b>too small</b> for the current font size. Flowed text not "
 "created."
 msgstr ""
 
-#: ../src/ui/tools/text-tool.cpp:788
+#: ../src/ui/tools/text-tool.cpp:784
 msgid "No-break space"
 msgstr ""
 
-#: ../src/ui/tools/text-tool.cpp:789
+#: ../src/ui/tools/text-tool.cpp:785
 msgid "Insert no-break space"
 msgstr ""
 
-#: ../src/ui/tools/text-tool.cpp:825
+#: ../src/ui/tools/text-tool.cpp:821
 msgid "Make bold"
 msgstr ""
 
-#: ../src/ui/tools/text-tool.cpp:842
+#: ../src/ui/tools/text-tool.cpp:838
 msgid "Make italic"
 msgstr ""
 
-#: ../src/ui/tools/text-tool.cpp:880
+#: ../src/ui/tools/text-tool.cpp:876
 msgid "New line"
 msgstr ""
 
-#: ../src/ui/tools/text-tool.cpp:921
+#: ../src/ui/tools/text-tool.cpp:917
 msgid "Backspace"
 msgstr ""
 
-#: ../src/ui/tools/text-tool.cpp:975
+#: ../src/ui/tools/text-tool.cpp:971
 msgid "Kern to the left"
 msgstr ""
 
-#: ../src/ui/tools/text-tool.cpp:999
+#: ../src/ui/tools/text-tool.cpp:995
 msgid "Kern to the right"
 msgstr ""
 
-#: ../src/ui/tools/text-tool.cpp:1023
+#: ../src/ui/tools/text-tool.cpp:1019
 msgid "Kern up"
 msgstr ""
 
-#: ../src/ui/tools/text-tool.cpp:1047
+#: ../src/ui/tools/text-tool.cpp:1043
 msgid "Kern down"
 msgstr ""
 
-#: ../src/ui/tools/text-tool.cpp:1122
+#: ../src/ui/tools/text-tool.cpp:1118
 msgid "Rotate counterclockwise"
 msgstr ""
 
-#: ../src/ui/tools/text-tool.cpp:1142
+#: ../src/ui/tools/text-tool.cpp:1138
 msgid "Rotate clockwise"
 msgstr ""
 
-#: ../src/ui/tools/text-tool.cpp:1158
+#: ../src/ui/tools/text-tool.cpp:1154
 msgid "Contract line spacing"
 msgstr ""
 
-#: ../src/ui/tools/text-tool.cpp:1164
+#: ../src/ui/tools/text-tool.cpp:1160
 msgid "Contract letter spacing"
 msgstr ""
 
-#: ../src/ui/tools/text-tool.cpp:1181
+#: ../src/ui/tools/text-tool.cpp:1177
 msgid "Expand line spacing"
 msgstr ""
 
-#: ../src/ui/tools/text-tool.cpp:1187
+#: ../src/ui/tools/text-tool.cpp:1183
 msgid "Expand letter spacing"
 msgstr ""
 
-#: ../src/ui/tools/text-tool.cpp:1317
+#: ../src/ui/tools/text-tool.cpp:1313
 msgid "Paste text"
 msgstr ""
 
-#: ../src/ui/tools/text-tool.cpp:1619
+#: ../src/ui/tools/text-tool.cpp:1615
 #, c-format
 msgid ""
 "Type or edit flowed text (%d character%s); <b>Enter</b> to start new "
@@ -24216,7 +24563,7 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ui/tools/text-tool.cpp:1621
+#: ../src/ui/tools/text-tool.cpp:1617
 #, c-format
 msgid "Type or edit text (%d character%s); <b>Enter</b> to start new line."
 msgid_plural ""
@@ -24224,11 +24571,11 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/ui/tools/text-tool.cpp:1731
+#: ../src/ui/tools/text-tool.cpp:1727
 msgid "Type text"
 msgstr ""
 
-#: ../src/ui/tools/tool-base.cpp:713
+#: ../src/ui/tools/tool-base.cpp:717
 msgid "<b>Space+mouse move</b> to pan canvas"
 msgstr ""
 
@@ -24300,59 +24647,59 @@ msgid ""
 "%s. Drag or click to <b>increase blur</b>; with Shift to <b>decrease</b>."
 msgstr ""
 
-#: ../src/ui/tools/tweak-tool.cpp:1200
+#: ../src/ui/tools/tweak-tool.cpp:1197
 msgid "<b>Nothing selected!</b> Select objects to tweak."
 msgstr ""
 
-#: ../src/ui/tools/tweak-tool.cpp:1234
+#: ../src/ui/tools/tweak-tool.cpp:1231
 msgid "Move tweak"
 msgstr ""
 
-#: ../src/ui/tools/tweak-tool.cpp:1238
+#: ../src/ui/tools/tweak-tool.cpp:1235
 msgid "Move in/out tweak"
 msgstr ""
 
-#: ../src/ui/tools/tweak-tool.cpp:1242
+#: ../src/ui/tools/tweak-tool.cpp:1239
 msgid "Move jitter tweak"
 msgstr ""
 
-#: ../src/ui/tools/tweak-tool.cpp:1246
+#: ../src/ui/tools/tweak-tool.cpp:1243
 msgid "Scale tweak"
 msgstr ""
 
-#: ../src/ui/tools/tweak-tool.cpp:1250
+#: ../src/ui/tools/tweak-tool.cpp:1247
 msgid "Rotate tweak"
 msgstr ""
 
-#: ../src/ui/tools/tweak-tool.cpp:1254
+#: ../src/ui/tools/tweak-tool.cpp:1251
 msgid "Duplicate/delete tweak"
 msgstr ""
 
-#: ../src/ui/tools/tweak-tool.cpp:1258
+#: ../src/ui/tools/tweak-tool.cpp:1255
 msgid "Push path tweak"
 msgstr ""
 
-#: ../src/ui/tools/tweak-tool.cpp:1262
+#: ../src/ui/tools/tweak-tool.cpp:1259
 msgid "Shrink/grow path tweak"
 msgstr ""
 
-#: ../src/ui/tools/tweak-tool.cpp:1266
+#: ../src/ui/tools/tweak-tool.cpp:1263
 msgid "Attract/repel path tweak"
 msgstr ""
 
-#: ../src/ui/tools/tweak-tool.cpp:1270
+#: ../src/ui/tools/tweak-tool.cpp:1267
 msgid "Roughen path tweak"
 msgstr ""
 
-#: ../src/ui/tools/tweak-tool.cpp:1274
+#: ../src/ui/tools/tweak-tool.cpp:1271
 msgid "Color paint tweak"
 msgstr ""
 
-#: ../src/ui/tools/tweak-tool.cpp:1278
+#: ../src/ui/tools/tweak-tool.cpp:1275
 msgid "Color jitter tweak"
 msgstr ""
 
-#: ../src/ui/tools/tweak-tool.cpp:1282
+#: ../src/ui/tools/tweak-tool.cpp:1279
 msgid "Blur tweak"
 msgstr ""
 
@@ -24361,18 +24708,18 @@ msgid "Hexadecimal RGBA value of the color"
 msgstr ""
 
 #: ../src/ui/widget/color-icc-selector.cpp:154
-#: ../src/ui/widget/color-scales.cpp:355
+#: ../src/ui/widget/color-scales.cpp:366
 msgid "_R:"
 msgstr ""
 
 #. TYPE_RGB_16
 #: ../src/ui/widget/color-icc-selector.cpp:155
-#: ../src/ui/widget/color-scales.cpp:358
+#: ../src/ui/widget/color-scales.cpp:369
 msgid "_G:"
 msgstr ""
 
 #: ../src/ui/widget/color-icc-selector.cpp:156
-#: ../src/ui/widget/color-scales.cpp:361
+#: ../src/ui/widget/color-scales.cpp:372
 msgid "_B:"
 msgstr ""
 
@@ -24384,26 +24731,26 @@ msgstr ""
 #. TYPE_GRAY_16
 #: ../src/ui/widget/color-icc-selector.cpp:160
 #: ../src/ui/widget/color-icc-selector.cpp:164
-#: ../src/ui/widget/color-scales.cpp:381
+#: ../src/ui/widget/color-scales.cpp:393 ../src/ui/widget/color-scales.cpp:429
 msgid "_H:"
 msgstr ""
 
 #. TYPE_HSV_16
 #: ../src/ui/widget/color-icc-selector.cpp:161
 #: ../src/ui/widget/color-icc-selector.cpp:166
-#: ../src/ui/widget/color-scales.cpp:384
+#: ../src/ui/widget/color-scales.cpp:398 ../src/ui/widget/color-scales.cpp:434
 msgid "_S:"
 msgstr ""
 
 #. TYPE_HLS_16
 #: ../src/ui/widget/color-icc-selector.cpp:165
-#: ../src/ui/widget/color-scales.cpp:387
+#: ../src/ui/widget/color-scales.cpp:402
 msgid "_L:"
 msgstr ""
 
 #: ../src/ui/widget/color-icc-selector.cpp:168
 #: ../src/ui/widget/color-icc-selector.cpp:173
-#: ../src/ui/widget/color-scales.cpp:409
+#: ../src/ui/widget/color-scales.cpp:464
 msgid "_C:"
 msgstr ""
 
@@ -24411,18 +24758,18 @@ msgstr ""
 #. TYPE_CMY_16
 #: ../src/ui/widget/color-icc-selector.cpp:169
 #: ../src/ui/widget/color-icc-selector.cpp:174
-#: ../src/ui/widget/color-scales.cpp:412
+#: ../src/ui/widget/color-scales.cpp:467
 msgid "_M:"
 msgstr ""
 
 #: ../src/ui/widget/color-icc-selector.cpp:170
 #: ../src/ui/widget/color-icc-selector.cpp:175
-#: ../src/ui/widget/color-scales.cpp:415
+#: ../src/ui/widget/color-scales.cpp:470
 msgid "_Y:"
 msgstr ""
 
 #: ../src/ui/widget/color-icc-selector.cpp:171
-#: ../src/ui/widget/color-scales.cpp:418
+#: ../src/ui/widget/color-scales.cpp:473
 msgid "_K:"
 msgstr ""
 
@@ -24440,40 +24787,41 @@ msgstr ""
 
 #. Label
 #: ../src/ui/widget/color-icc-selector.cpp:469
-#: ../src/ui/widget/color-scales.cpp:364 ../src/ui/widget/color-scales.cpp:390
-#: ../src/ui/widget/color-scales.cpp:421
-#: ../src/ui/widget/color-wheel-selector.cpp:64
+#: ../src/ui/widget/color-scales.cpp:375 ../src/ui/widget/color-scales.cpp:406
+#: ../src/ui/widget/color-scales.cpp:442 ../src/ui/widget/color-scales.cpp:476
+#: ../src/ui/widget/color-wheel-selector.cpp:66
 msgid "_A:"
 msgstr ""
 
 #: ../src/ui/widget/color-icc-selector.cpp:481
 #: ../src/ui/widget/color-icc-selector.cpp:492
-#: ../src/ui/widget/color-scales.cpp:365 ../src/ui/widget/color-scales.cpp:366
-#: ../src/ui/widget/color-scales.cpp:391 ../src/ui/widget/color-scales.cpp:392
-#: ../src/ui/widget/color-scales.cpp:422 ../src/ui/widget/color-scales.cpp:423
-#: ../src/ui/widget/color-wheel-selector.cpp:87
-#: ../src/ui/widget/color-wheel-selector.cpp:109
+#: ../src/ui/widget/color-scales.cpp:376 ../src/ui/widget/color-scales.cpp:377
+#: ../src/ui/widget/color-scales.cpp:407 ../src/ui/widget/color-scales.cpp:408
+#: ../src/ui/widget/color-scales.cpp:443 ../src/ui/widget/color-scales.cpp:444
+#: ../src/ui/widget/color-scales.cpp:477 ../src/ui/widget/color-scales.cpp:478
+#: ../src/ui/widget/color-wheel-selector.cpp:89
+#: ../src/ui/widget/color-wheel-selector.cpp:111
 msgid "Alpha (opacity)"
 msgstr ""
 
-#: ../src/ui/widget/color-notebook.cpp:155
+#: ../src/ui/widget/color-notebook.cpp:160
 msgid "Color Managed"
 msgstr ""
 
-#: ../src/ui/widget/color-notebook.cpp:162
+#: ../src/ui/widget/color-notebook.cpp:167
 msgid "Out of gamut!"
 msgstr ""
 
-#: ../src/ui/widget/color-notebook.cpp:169
+#: ../src/ui/widget/color-notebook.cpp:174
 msgid "Too much ink!"
 msgstr ""
 
-#: ../src/ui/widget/color-notebook.cpp:180 ../src/verbs.cpp:2927
+#: ../src/ui/widget/color-notebook.cpp:185 ../src/verbs.cpp:2961
 msgid "Pick colors from image"
 msgstr ""
 
 #. Create RGBA entry and color preview
-#: ../src/ui/widget/color-notebook.cpp:185
+#: ../src/ui/widget/color-notebook.cpp:190
 msgid "RGBA_:"
 msgstr ""
 
@@ -24489,12 +24837,27 @@ msgstr ""
 msgid "CMYK"
 msgstr ""
 
-#: ../src/ui/widget/filter-effect-chooser.cpp:22
-msgid "_Blur:"
+#: ../src/ui/widget/color-scales.cpp:43
+msgid "HSV"
+msgstr ""
+
+#: ../src/ui/widget/color-scales.cpp:438
+msgid "_V:"
+msgstr ""
+
+#: ../src/ui/widget/color-scales.cpp:439 ../src/ui/widget/color-scales.cpp:440
+#: ../src/widgets/sp-xmlview-attr-list.cpp:55
+msgid "Value"
 msgstr ""
 
 #: ../src/ui/widget/filter-effect-chooser.cpp:25
 msgid "Blur (%)"
+msgstr ""
+
+#: ../src/ui/widget/filter-effect-chooser.cpp:26
+#: ../src/ui/widget/selected-style.cpp:1066
+#: ../src/ui/widget/selected-style.cpp:1067
+msgid "Opacity (%)"
 msgstr ""
 
 #: ../src/ui/widget/font-variants.cpp:30
@@ -24793,19 +25156,13 @@ msgstr ""
 msgid "Document license updated"
 msgstr ""
 
-#: ../src/ui/widget/object-composite-settings.cpp:39
-#: ../src/ui/widget/selected-style.cpp:1057
-#: ../src/ui/widget/selected-style.cpp:1058
-msgid "Opacity (%)"
+#: ../src/ui/widget/object-composite-settings.cpp:139
+msgid "Change blur/blend filter"
 msgstr ""
 
-#: ../src/ui/widget/object-composite-settings.cpp:152
-msgid "Change blur"
-msgstr ""
-
-#: ../src/ui/widget/object-composite-settings.cpp:192
-#: ../src/ui/widget/selected-style.cpp:881
-#: ../src/ui/widget/selected-style.cpp:1175
+#: ../src/ui/widget/object-composite-settings.cpp:174
+#: ../src/ui/widget/selected-style.cpp:890
+#: ../src/ui/widget/selected-style.cpp:1184
 msgid "Change opacity"
 msgstr ""
 
@@ -24822,70 +25179,78 @@ msgid "Height of paper"
 msgstr ""
 
 #: ../src/ui/widget/page-sizer.cpp:222
-msgid "T_op margin:"
+msgid "Loc_k margins"
 msgstr ""
 
 #: ../src/ui/widget/page-sizer.cpp:222
+msgid "Lock margins"
+msgstr ""
+
+#: ../src/ui/widget/page-sizer.cpp:224
+msgid "T_op margin:"
+msgstr ""
+
+#: ../src/ui/widget/page-sizer.cpp:224
 msgid "Top margin"
 msgstr ""
 
-#: ../src/ui/widget/page-sizer.cpp:223
+#: ../src/ui/widget/page-sizer.cpp:225
 msgid "L_eft:"
 msgstr ""
 
-#: ../src/ui/widget/page-sizer.cpp:223
+#: ../src/ui/widget/page-sizer.cpp:225
 msgid "Left margin"
 msgstr ""
 
-#: ../src/ui/widget/page-sizer.cpp:224
+#: ../src/ui/widget/page-sizer.cpp:226
 msgid "Ri_ght:"
 msgstr ""
 
-#: ../src/ui/widget/page-sizer.cpp:224
+#: ../src/ui/widget/page-sizer.cpp:226
 msgid "Right margin"
 msgstr ""
 
-#: ../src/ui/widget/page-sizer.cpp:225
+#: ../src/ui/widget/page-sizer.cpp:227
 msgid "Botto_m:"
 msgstr ""
 
-#: ../src/ui/widget/page-sizer.cpp:225
+#: ../src/ui/widget/page-sizer.cpp:227
 msgid "Bottom margin"
 msgstr ""
 
-#: ../src/ui/widget/page-sizer.cpp:227
+#: ../src/ui/widget/page-sizer.cpp:229
 msgid "Scale _x:"
 msgstr ""
 
-#: ../src/ui/widget/page-sizer.cpp:227
+#: ../src/ui/widget/page-sizer.cpp:229
 msgid "Scale X"
 msgstr ""
 
-#: ../src/ui/widget/page-sizer.cpp:228
+#: ../src/ui/widget/page-sizer.cpp:230
 msgid "Scale _y:"
 msgstr ""
 
-#: ../src/ui/widget/page-sizer.cpp:228
+#: ../src/ui/widget/page-sizer.cpp:230
 msgid ""
 "While SVG allows non-uniform scaling it is recommended to use only uniform "
 "scaling in Inkscape. To set a non-uniform scaling, set the 'viewBox' "
 "directly."
 msgstr ""
 
-#: ../src/ui/widget/page-sizer.cpp:306
+#: ../src/ui/widget/page-sizer.cpp:307
 msgid "Orientation:"
 msgstr ""
 
-#: ../src/ui/widget/page-sizer.cpp:309
+#: ../src/ui/widget/page-sizer.cpp:310
 msgid "_Landscape"
 msgstr ""
 
-#: ../src/ui/widget/page-sizer.cpp:314
+#: ../src/ui/widget/page-sizer.cpp:315
 msgid "_Portrait"
 msgstr ""
 
 #. ## Set up custom size frame
-#: ../src/ui/widget/page-sizer.cpp:333
+#: ../src/ui/widget/page-sizer.cpp:334
 msgid "Custom size"
 msgstr ""
 
@@ -24893,131 +25258,41 @@ msgstr ""
 msgid "Resi_ze page to content..."
 msgstr ""
 
-#: ../src/ui/widget/page-sizer.cpp:403
+#: ../src/ui/widget/page-sizer.cpp:417
 msgid "_Resize page to drawing or selection (Ctrl+Shift+R)"
 msgstr ""
 
-#: ../src/ui/widget/page-sizer.cpp:404
+#: ../src/ui/widget/page-sizer.cpp:418
 msgid ""
 "Resize the page to fit the current selection, or the entire drawing if there "
 "is no selection"
 msgstr ""
 
-#: ../src/ui/widget/page-sizer.cpp:424
+#: ../src/ui/widget/page-sizer.cpp:438
 msgid "_Viewbox..."
 msgstr ""
 
-#: ../src/ui/widget/page-sizer.cpp:520
+#: ../src/ui/widget/page-sizer.cpp:538
 msgid "Set page size"
 msgstr ""
 
-#: ../src/ui/widget/page-sizer.cpp:766
+#: ../src/ui/widget/page-sizer.cpp:784
 msgid "User units per "
 msgstr ""
 
-#: ../src/ui/widget/page-sizer.cpp:862
+#: ../src/ui/widget/page-sizer.cpp:880
 msgid "Set page scale"
 msgstr ""
 
-#: ../src/ui/widget/page-sizer.cpp:888
+#: ../src/ui/widget/page-sizer.cpp:906
 msgid "Set 'viewBox'"
 msgstr ""
 
-#: ../src/ui/widget/panel.cpp:111
-msgid "List"
-msgstr ""
-
-#: ../src/ui/widget/panel.cpp:134
-msgctxt "Swatches"
-msgid "Size"
-msgstr ""
-
-#: ../src/ui/widget/panel.cpp:138
-msgctxt "Swatches height"
-msgid "Tiny"
-msgstr ""
-
-#: ../src/ui/widget/panel.cpp:139
-msgctxt "Swatches height"
-msgid "Small"
-msgstr ""
-
-#: ../src/ui/widget/panel.cpp:140
-msgctxt "Swatches height"
-msgid "Medium"
-msgstr ""
-
-#: ../src/ui/widget/panel.cpp:141
-msgctxt "Swatches height"
-msgid "Large"
-msgstr ""
-
-#: ../src/ui/widget/panel.cpp:142
-msgctxt "Swatches height"
-msgid "Huge"
-msgstr ""
-
-#: ../src/ui/widget/panel.cpp:164
-msgctxt "Swatches"
-msgid "Width"
-msgstr ""
-
-#: ../src/ui/widget/panel.cpp:168
-msgctxt "Swatches width"
-msgid "Narrower"
-msgstr ""
-
-#: ../src/ui/widget/panel.cpp:169
-msgctxt "Swatches width"
-msgid "Narrow"
-msgstr ""
-
-#: ../src/ui/widget/panel.cpp:170
-msgctxt "Swatches width"
-msgid "Medium"
-msgstr ""
-
-#: ../src/ui/widget/panel.cpp:171
-msgctxt "Swatches width"
-msgid "Wide"
-msgstr ""
-
-#: ../src/ui/widget/panel.cpp:172
-msgctxt "Swatches width"
-msgid "Wider"
-msgstr ""
-
-#: ../src/ui/widget/panel.cpp:202
-msgctxt "Swatches"
-msgid "Border"
-msgstr ""
-
-#: ../src/ui/widget/panel.cpp:206
-msgctxt "Swatches border"
-msgid "None"
-msgstr ""
-
-#: ../src/ui/widget/panel.cpp:207
-msgctxt "Swatches border"
-msgid "Solid"
-msgstr ""
-
-#: ../src/ui/widget/panel.cpp:208
-msgctxt "Swatches border"
-msgid "Wide"
-msgstr ""
-
-#. TRANSLATORS: "Wrap" indicates how colour swatches are displayed
-#: ../src/ui/widget/panel.cpp:239
-msgctxt "Swatches"
-msgid "Wrap"
-msgstr ""
-
-#: ../src/ui/widget/preferences-widget.cpp:709
+#: ../src/ui/widget/preferences-widget.cpp:711
 msgid "_Browse..."
 msgstr ""
 
-#: ../src/ui/widget/preferences-widget.cpp:795
+#: ../src/ui/widget/preferences-widget.cpp:797
 msgid "Select a bitmap editor"
 msgstr ""
 
@@ -25061,295 +25336,294 @@ msgid ""
 "will be rendered exactly as displayed."
 msgstr ""
 
-#: ../src/ui/widget/selected-style.cpp:122
+#: ../src/ui/widget/selected-style.cpp:121
 #: ../src/ui/widget/style-swatch.cpp:115
 msgid "Fill:"
 msgstr ""
 
-#: ../src/ui/widget/selected-style.cpp:124
+#: ../src/ui/widget/selected-style.cpp:123
 msgid "O:"
 msgstr ""
 
-#: ../src/ui/widget/selected-style.cpp:183
+#: ../src/ui/widget/selected-style.cpp:181
 msgid "N/A"
 msgstr ""
 
-#: ../src/ui/widget/selected-style.cpp:186
-#: ../src/ui/widget/selected-style.cpp:1050
-#: ../src/ui/widget/selected-style.cpp:1051
-#: ../src/widgets/gradient-toolbar.cpp:163
+#: ../src/ui/widget/selected-style.cpp:184
+#: ../src/ui/widget/selected-style.cpp:1059
+#: ../src/ui/widget/selected-style.cpp:1060
 msgid "Nothing selected"
 msgstr ""
 
-#: ../src/ui/widget/selected-style.cpp:189
+#: ../src/ui/widget/selected-style.cpp:187
 msgctxt "Fill"
 msgid "<i>None</i>"
 msgstr ""
 
-#: ../src/ui/widget/selected-style.cpp:191
+#: ../src/ui/widget/selected-style.cpp:189
 msgctxt "Stroke"
 msgid "<i>None</i>"
 msgstr ""
 
-#: ../src/ui/widget/selected-style.cpp:195
+#: ../src/ui/widget/selected-style.cpp:193
 #: ../src/ui/widget/style-swatch.cpp:316
 msgctxt "Fill and stroke"
 msgid "No fill"
 msgstr ""
 
-#: ../src/ui/widget/selected-style.cpp:195
+#: ../src/ui/widget/selected-style.cpp:193
 #: ../src/ui/widget/style-swatch.cpp:316
 msgctxt "Fill and stroke"
 msgid "No stroke"
 msgstr ""
 
-#: ../src/ui/widget/selected-style.cpp:197
-#: ../src/ui/widget/style-swatch.cpp:295 ../src/widgets/paint-selector.cpp:219
+#: ../src/ui/widget/selected-style.cpp:195
+#: ../src/ui/widget/style-swatch.cpp:295 ../src/widgets/paint-selector.cpp:221
 msgid "Pattern"
 msgstr ""
 
-#: ../src/ui/widget/selected-style.cpp:200
+#: ../src/ui/widget/selected-style.cpp:198
 #: ../src/ui/widget/style-swatch.cpp:297
 msgid "Pattern fill"
 msgstr ""
 
-#: ../src/ui/widget/selected-style.cpp:200
+#: ../src/ui/widget/selected-style.cpp:198
 #: ../src/ui/widget/style-swatch.cpp:297
 msgid "Pattern stroke"
 msgstr ""
 
-#: ../src/ui/widget/selected-style.cpp:202
+#: ../src/ui/widget/selected-style.cpp:200
 msgid "<b>L</b>"
 msgstr ""
 
-#: ../src/ui/widget/selected-style.cpp:205
+#: ../src/ui/widget/selected-style.cpp:203
 #: ../src/ui/widget/style-swatch.cpp:289
 msgid "Linear gradient fill"
 msgstr ""
 
-#: ../src/ui/widget/selected-style.cpp:205
+#: ../src/ui/widget/selected-style.cpp:203
 #: ../src/ui/widget/style-swatch.cpp:289
 msgid "Linear gradient stroke"
 msgstr ""
 
-#: ../src/ui/widget/selected-style.cpp:212
+#: ../src/ui/widget/selected-style.cpp:210
 msgid "<b>R</b>"
 msgstr ""
 
-#: ../src/ui/widget/selected-style.cpp:215
+#: ../src/ui/widget/selected-style.cpp:213
 #: ../src/ui/widget/style-swatch.cpp:293
 msgid "Radial gradient fill"
 msgstr ""
 
-#: ../src/ui/widget/selected-style.cpp:215
+#: ../src/ui/widget/selected-style.cpp:213
 #: ../src/ui/widget/style-swatch.cpp:293
 msgid "Radial gradient stroke"
 msgstr ""
 
-#: ../src/ui/widget/selected-style.cpp:223
+#: ../src/ui/widget/selected-style.cpp:221
 msgid "<b>M</b>"
 msgstr ""
 
-#: ../src/ui/widget/selected-style.cpp:226
+#: ../src/ui/widget/selected-style.cpp:224
 msgid "Mesh gradient fill"
 msgstr ""
 
-#: ../src/ui/widget/selected-style.cpp:226
+#: ../src/ui/widget/selected-style.cpp:224
 msgid "Mesh gradient stroke"
 msgstr ""
 
-#: ../src/ui/widget/selected-style.cpp:234
+#: ../src/ui/widget/selected-style.cpp:232
 msgid "Different"
 msgstr ""
 
-#: ../src/ui/widget/selected-style.cpp:237
+#: ../src/ui/widget/selected-style.cpp:235
 msgid "Different fills"
 msgstr ""
 
-#: ../src/ui/widget/selected-style.cpp:237
+#: ../src/ui/widget/selected-style.cpp:235
 msgid "Different strokes"
 msgstr ""
 
-#: ../src/ui/widget/selected-style.cpp:239
+#: ../src/ui/widget/selected-style.cpp:237
 #: ../src/ui/widget/style-swatch.cpp:319
 msgid "<b>Unset</b>"
 msgstr ""
 
 #. TRANSLATORS COMMENT: unset is a verb here
-#: ../src/ui/widget/selected-style.cpp:242
-#: ../src/ui/widget/selected-style.cpp:300
-#: ../src/ui/widget/selected-style.cpp:562
+#: ../src/ui/widget/selected-style.cpp:240
+#: ../src/ui/widget/selected-style.cpp:298
+#: ../src/ui/widget/selected-style.cpp:559
 #: ../src/ui/widget/style-swatch.cpp:321 ../src/widgets/fill-style.cpp:811
 msgid "Unset fill"
 msgstr ""
 
-#: ../src/ui/widget/selected-style.cpp:242
-#: ../src/ui/widget/selected-style.cpp:300
-#: ../src/ui/widget/selected-style.cpp:578
+#: ../src/ui/widget/selected-style.cpp:240
+#: ../src/ui/widget/selected-style.cpp:298
+#: ../src/ui/widget/selected-style.cpp:575
 #: ../src/ui/widget/style-swatch.cpp:321 ../src/widgets/fill-style.cpp:811
 msgid "Unset stroke"
 msgstr ""
 
-#: ../src/ui/widget/selected-style.cpp:245
+#: ../src/ui/widget/selected-style.cpp:243
 msgid "Flat color fill"
 msgstr ""
 
-#: ../src/ui/widget/selected-style.cpp:245
+#: ../src/ui/widget/selected-style.cpp:243
 msgid "Flat color stroke"
 msgstr ""
 
 #. TRANSLATOR COMMENT: A means "Averaged"
-#: ../src/ui/widget/selected-style.cpp:248
+#: ../src/ui/widget/selected-style.cpp:246
 msgid "<b>a</b>"
 msgstr ""
 
-#: ../src/ui/widget/selected-style.cpp:251
+#: ../src/ui/widget/selected-style.cpp:249
 msgid "Fill is averaged over selected objects"
 msgstr ""
 
-#: ../src/ui/widget/selected-style.cpp:251
+#: ../src/ui/widget/selected-style.cpp:249
 msgid "Stroke is averaged over selected objects"
 msgstr ""
 
 #. TRANSLATOR COMMENT: M means "Multiple"
-#: ../src/ui/widget/selected-style.cpp:254
+#: ../src/ui/widget/selected-style.cpp:252
 msgid "<b>m</b>"
 msgstr ""
 
-#: ../src/ui/widget/selected-style.cpp:257
+#: ../src/ui/widget/selected-style.cpp:255
 msgid "Multiple selected objects have the same fill"
 msgstr ""
 
-#: ../src/ui/widget/selected-style.cpp:257
+#: ../src/ui/widget/selected-style.cpp:255
 msgid "Multiple selected objects have the same stroke"
 msgstr ""
 
-#: ../src/ui/widget/selected-style.cpp:259
+#: ../src/ui/widget/selected-style.cpp:257
 msgid "Edit fill..."
 msgstr ""
 
-#: ../src/ui/widget/selected-style.cpp:259
+#: ../src/ui/widget/selected-style.cpp:257
 msgid "Edit stroke..."
 msgstr ""
 
-#: ../src/ui/widget/selected-style.cpp:263
+#: ../src/ui/widget/selected-style.cpp:261
 msgid "Last set color"
 msgstr ""
 
-#: ../src/ui/widget/selected-style.cpp:267
+#: ../src/ui/widget/selected-style.cpp:265
 msgid "Last selected color"
 msgstr ""
 
-#: ../src/ui/widget/selected-style.cpp:283
+#: ../src/ui/widget/selected-style.cpp:281
 msgid "Copy color"
 msgstr ""
 
-#: ../src/ui/widget/selected-style.cpp:287
+#: ../src/ui/widget/selected-style.cpp:285
 msgid "Paste color"
 msgstr ""
 
-#: ../src/ui/widget/selected-style.cpp:291 ../src/verbs.cpp:2688
+#: ../src/ui/widget/selected-style.cpp:289 ../src/verbs.cpp:2718
 msgid "Swap fill and stroke"
 msgstr ""
 
-#: ../src/ui/widget/selected-style.cpp:295
-#: ../src/ui/widget/selected-style.cpp:587
-#: ../src/ui/widget/selected-style.cpp:596
+#: ../src/ui/widget/selected-style.cpp:293
+#: ../src/ui/widget/selected-style.cpp:584
+#: ../src/ui/widget/selected-style.cpp:593
 msgid "Make fill opaque"
 msgstr ""
 
-#: ../src/ui/widget/selected-style.cpp:295
+#: ../src/ui/widget/selected-style.cpp:293
 msgid "Make stroke opaque"
 msgstr ""
 
-#: ../src/ui/widget/selected-style.cpp:304
-#: ../src/ui/widget/selected-style.cpp:544 ../src/widgets/fill-style.cpp:510
+#: ../src/ui/widget/selected-style.cpp:302
+#: ../src/ui/widget/selected-style.cpp:541 ../src/widgets/fill-style.cpp:510
 msgid "Remove fill"
 msgstr ""
 
-#: ../src/ui/widget/selected-style.cpp:304
-#: ../src/ui/widget/selected-style.cpp:553 ../src/widgets/fill-style.cpp:510
+#: ../src/ui/widget/selected-style.cpp:302
+#: ../src/ui/widget/selected-style.cpp:550 ../src/widgets/fill-style.cpp:510
 msgid "Remove stroke"
 msgstr ""
 
-#: ../src/ui/widget/selected-style.cpp:608
+#: ../src/ui/widget/selected-style.cpp:605
 msgid "Apply last set color to fill"
 msgstr ""
 
-#: ../src/ui/widget/selected-style.cpp:620
+#: ../src/ui/widget/selected-style.cpp:617
 msgid "Apply last set color to stroke"
 msgstr ""
 
-#: ../src/ui/widget/selected-style.cpp:631
+#: ../src/ui/widget/selected-style.cpp:628
 msgid "Apply last selected color to fill"
 msgstr ""
 
-#: ../src/ui/widget/selected-style.cpp:642
+#: ../src/ui/widget/selected-style.cpp:639
 msgid "Apply last selected color to stroke"
 msgstr ""
 
-#: ../src/ui/widget/selected-style.cpp:668
+#: ../src/ui/widget/selected-style.cpp:665
 msgid "Invert fill"
 msgstr ""
 
-#: ../src/ui/widget/selected-style.cpp:692
+#: ../src/ui/widget/selected-style.cpp:689
 msgid "Invert stroke"
 msgstr ""
 
-#: ../src/ui/widget/selected-style.cpp:704
+#: ../src/ui/widget/selected-style.cpp:701
 msgid "White fill"
 msgstr ""
 
-#: ../src/ui/widget/selected-style.cpp:716
+#: ../src/ui/widget/selected-style.cpp:713
 msgid "White stroke"
 msgstr ""
 
-#: ../src/ui/widget/selected-style.cpp:728
+#: ../src/ui/widget/selected-style.cpp:725
 msgid "Black fill"
 msgstr ""
 
-#: ../src/ui/widget/selected-style.cpp:740
+#: ../src/ui/widget/selected-style.cpp:737
 msgid "Black stroke"
 msgstr ""
 
-#: ../src/ui/widget/selected-style.cpp:783
+#: ../src/ui/widget/selected-style.cpp:780
 msgid "Paste fill"
 msgstr ""
 
-#: ../src/ui/widget/selected-style.cpp:801
+#: ../src/ui/widget/selected-style.cpp:798
 msgid "Paste stroke"
 msgstr ""
 
-#: ../src/ui/widget/selected-style.cpp:908
+#: ../src/ui/widget/selected-style.cpp:917
 msgid "Change stroke width"
 msgstr ""
 
-#: ../src/ui/widget/selected-style.cpp:1011
+#: ../src/ui/widget/selected-style.cpp:1020
 msgid ", drag to adjust"
 msgstr ""
 
-#: ../src/ui/widget/selected-style.cpp:1092
+#: ../src/ui/widget/selected-style.cpp:1101
 #, c-format
 msgid "Stroke width: %.5g%s%s"
 msgstr ""
 
-#: ../src/ui/widget/selected-style.cpp:1096
+#: ../src/ui/widget/selected-style.cpp:1105
 msgid " (averaged)"
 msgstr ""
 
-#: ../src/ui/widget/selected-style.cpp:1122
+#: ../src/ui/widget/selected-style.cpp:1131
 msgid "0 (transparent)"
 msgstr ""
 
-#: ../src/ui/widget/selected-style.cpp:1146
+#: ../src/ui/widget/selected-style.cpp:1155
 msgid "100% (opaque)"
 msgstr ""
 
-#: ../src/ui/widget/selected-style.cpp:1312
+#: ../src/ui/widget/selected-style.cpp:1321
 msgid "Adjust alpha"
 msgstr ""
 
-#: ../src/ui/widget/selected-style.cpp:1314
+#: ../src/ui/widget/selected-style.cpp:1323
 #, c-format
 msgid ""
 "Adjusting <b>alpha</b>: was %.3g, now <b>%.3g</b> (diff %.3g); with <b>Ctrl</"
@@ -25357,11 +25631,11 @@ msgid ""
 "modifiers to adjust hue"
 msgstr ""
 
-#: ../src/ui/widget/selected-style.cpp:1318
+#: ../src/ui/widget/selected-style.cpp:1327
 msgid "Adjust saturation"
 msgstr ""
 
-#: ../src/ui/widget/selected-style.cpp:1320
+#: ../src/ui/widget/selected-style.cpp:1329
 #, c-format
 msgid ""
 "Adjusting <b>saturation</b>: was %.3g, now <b>%.3g</b> (diff %.3g); with "
@@ -25369,11 +25643,11 @@ msgid ""
 "modifiers to adjust hue"
 msgstr ""
 
-#: ../src/ui/widget/selected-style.cpp:1324
+#: ../src/ui/widget/selected-style.cpp:1333
 msgid "Adjust lightness"
 msgstr ""
 
-#: ../src/ui/widget/selected-style.cpp:1326
+#: ../src/ui/widget/selected-style.cpp:1335
 #, c-format
 msgid ""
 "Adjusting <b>lightness</b>: was %.3g, now <b>%.3g</b> (diff %.3g); with "
@@ -25381,11 +25655,11 @@ msgid ""
 "modifiers to adjust hue"
 msgstr ""
 
-#: ../src/ui/widget/selected-style.cpp:1330
+#: ../src/ui/widget/selected-style.cpp:1339
 msgid "Adjust hue"
 msgstr ""
 
-#: ../src/ui/widget/selected-style.cpp:1332
+#: ../src/ui/widget/selected-style.cpp:1341
 #, c-format
 msgid ""
 "Adjusting <b>hue</b>: was %.3g, now <b>%.3g</b> (diff %.3g); with <b>Shift</"
@@ -25393,18 +25667,18 @@ msgid ""
 "to adjust lightness"
 msgstr ""
 
-#: ../src/ui/widget/selected-style.cpp:1442
-#: ../src/ui/widget/selected-style.cpp:1456
+#: ../src/ui/widget/selected-style.cpp:1451
+#: ../src/ui/widget/selected-style.cpp:1465
 msgid "Adjust stroke width"
 msgstr ""
 
-#: ../src/ui/widget/selected-style.cpp:1443
+#: ../src/ui/widget/selected-style.cpp:1452
 #, c-format
 msgid "Adjusting <b>stroke width</b>: was %.3g, now <b>%.3g</b> (diff %.3g)"
 msgstr ""
 
 #. TRANSLATORS: "Link" means to _link_ two sliders together
-#: ../src/ui/widget/spin-scale.cpp:123 ../src/ui/widget/spin-slider.cpp:114
+#: ../src/ui/widget/spin-scale.cpp:121 ../src/ui/widget/spin-slider.cpp:115
 msgctxt "Sliders"
 msgid "Link"
 msgstr ""
@@ -25489,2539 +25763,2590 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../src/verbs.cpp:132
+#: ../src/verbs.cpp:135
 msgid "File"
 msgstr ""
 
-#: ../src/verbs.cpp:227 ../share/extensions/interp_att_g.inx.h:24
+#: ../src/verbs.cpp:230 ../share/extensions/interp_att_g.inx.h:27
 msgid "Tag"
 msgstr ""
 
-#: ../src/verbs.cpp:246
+#: ../src/verbs.cpp:249
 msgid "Context"
 msgstr ""
 
-#: ../src/verbs.cpp:265 ../src/verbs.cpp:2430
+#: ../src/verbs.cpp:268 ../src/verbs.cpp:2460
 #: ../share/extensions/jessyInk_view.inx.h:1
 #: ../share/extensions/polyhedron_3d.inx.h:26
 msgid "View"
 msgstr ""
 
-#: ../src/verbs.cpp:285
+#: ../src/verbs.cpp:288
 msgid "Dialog"
 msgstr ""
 
-#: ../src/verbs.cpp:1323
+#: ../src/verbs.cpp:1345
 msgid "Switch to next layer"
 msgstr ""
 
-#: ../src/verbs.cpp:1324
+#: ../src/verbs.cpp:1346
 msgid "Switched to next layer."
 msgstr ""
 
-#: ../src/verbs.cpp:1326
+#: ../src/verbs.cpp:1348
 msgid "Cannot go past last layer."
 msgstr ""
 
-#: ../src/verbs.cpp:1335
+#: ../src/verbs.cpp:1357
 msgid "Switch to previous layer"
 msgstr ""
 
-#: ../src/verbs.cpp:1336
+#: ../src/verbs.cpp:1358
 msgid "Switched to previous layer."
 msgstr ""
 
-#: ../src/verbs.cpp:1338
+#: ../src/verbs.cpp:1360
 msgid "Cannot go before first layer."
 msgstr ""
 
-#: ../src/verbs.cpp:1359 ../src/verbs.cpp:1426 ../src/verbs.cpp:1462
-#: ../src/verbs.cpp:1468 ../src/verbs.cpp:1492 ../src/verbs.cpp:1507
+#: ../src/verbs.cpp:1381 ../src/verbs.cpp:1448 ../src/verbs.cpp:1484
+#: ../src/verbs.cpp:1490 ../src/verbs.cpp:1514 ../src/verbs.cpp:1529
 msgid "No current layer."
 msgstr ""
 
-#: ../src/verbs.cpp:1388 ../src/verbs.cpp:1392
+#: ../src/verbs.cpp:1410 ../src/verbs.cpp:1414
 #, c-format
 msgid "Raised layer <b>%s</b>."
 msgstr ""
 
-#: ../src/verbs.cpp:1389
+#: ../src/verbs.cpp:1411
 msgid "Layer to top"
 msgstr ""
 
-#: ../src/verbs.cpp:1393
+#: ../src/verbs.cpp:1415
 msgid "Raise layer"
 msgstr ""
 
-#: ../src/verbs.cpp:1396 ../src/verbs.cpp:1400
+#: ../src/verbs.cpp:1418 ../src/verbs.cpp:1422
 #, c-format
 msgid "Lowered layer <b>%s</b>."
 msgstr ""
 
-#: ../src/verbs.cpp:1397
+#: ../src/verbs.cpp:1419
 msgid "Layer to bottom"
 msgstr ""
 
-#: ../src/verbs.cpp:1401
+#: ../src/verbs.cpp:1423
 msgid "Lower layer"
 msgstr ""
 
-#: ../src/verbs.cpp:1410
+#: ../src/verbs.cpp:1432
 msgid "Cannot move layer any further."
 msgstr ""
 
-#: ../src/verbs.cpp:1421
+#: ../src/verbs.cpp:1443
 msgid "Duplicate layer"
 msgstr ""
 
 #. TRANSLATORS: this means "The layer has been duplicated."
-#: ../src/verbs.cpp:1424
+#: ../src/verbs.cpp:1446
 msgid "Duplicated layer."
 msgstr ""
 
-#: ../src/verbs.cpp:1457
+#: ../src/verbs.cpp:1479
 msgid "Delete layer"
 msgstr ""
 
 #. TRANSLATORS: this means "The layer has been deleted."
-#: ../src/verbs.cpp:1460
+#: ../src/verbs.cpp:1482
 msgid "Deleted layer."
 msgstr ""
 
-#: ../src/verbs.cpp:1477
+#: ../src/verbs.cpp:1499
 msgid "Show all layers"
 msgstr ""
 
-#: ../src/verbs.cpp:1482
+#: ../src/verbs.cpp:1504
 msgid "Hide all layers"
 msgstr ""
 
-#: ../src/verbs.cpp:1487
+#: ../src/verbs.cpp:1509
 msgid "Lock all layers"
 msgstr ""
 
-#: ../src/verbs.cpp:1501
+#: ../src/verbs.cpp:1523
 msgid "Unlock all layers"
 msgstr ""
 
-#: ../src/verbs.cpp:1585
+#: ../src/verbs.cpp:1607
 msgid "Flip horizontally"
 msgstr ""
 
-#: ../src/verbs.cpp:1590
+#: ../src/verbs.cpp:1612
 msgid "Flip vertically"
 msgstr ""
 
-#: ../src/verbs.cpp:1638
+#: ../src/verbs.cpp:1668
 #, c-format
 msgid "Set %d"
 msgstr ""
 
-#: ../src/verbs.cpp:1647 ../src/verbs.cpp:2890
+#: ../src/verbs.cpp:1677 ../src/verbs.cpp:2924
 msgid "Create new selection set"
 msgstr ""
 
 #. TRANSLATORS: If you have translated the tutorial-basic.en.svgz file to your language,
 #. then translate this string as "tutorial-basic.LANG.svgz" (where LANG is your language
 #. code); otherwise leave as "tutorial-basic.svg".
-#: ../src/verbs.cpp:2308
+#: ../src/verbs.cpp:2338
 msgid "tutorial-basic.svg"
 msgstr ""
 
 #. TRANSLATORS: See "tutorial-basic.svg" comment.
-#: ../src/verbs.cpp:2312
+#: ../src/verbs.cpp:2342
 msgid "tutorial-shapes.svg"
 msgstr ""
 
 #. TRANSLATORS: See "tutorial-basic.svg" comment.
-#: ../src/verbs.cpp:2316
+#: ../src/verbs.cpp:2346
 msgid "tutorial-advanced.svg"
 msgstr ""
 
 #. TRANSLATORS: See "tutorial-basic.svg" comment.
-#: ../src/verbs.cpp:2322
+#: ../src/verbs.cpp:2352
 msgid "tutorial-tracing.svg"
 msgstr ""
 
-#: ../src/verbs.cpp:2327
+#: ../src/verbs.cpp:2357
 msgid "tutorial-tracing-pixelart.svg"
 msgstr ""
 
 #. TRANSLATORS: See "tutorial-basic.svg" comment.
-#: ../src/verbs.cpp:2331
+#: ../src/verbs.cpp:2361
 msgid "tutorial-calligraphy.svg"
 msgstr ""
 
 #. TRANSLATORS: See "tutorial-basic.svg" comment.
-#: ../src/verbs.cpp:2335
+#: ../src/verbs.cpp:2365
 msgid "tutorial-interpolate.svg"
 msgstr ""
 
 #. TRANSLATORS: See "tutorial-basic.svg" comment.
-#: ../src/verbs.cpp:2339
+#: ../src/verbs.cpp:2369
 msgid "tutorial-elements.svg"
 msgstr ""
 
 #. TRANSLATORS: See "tutorial-basic.svg" comment.
-#: ../src/verbs.cpp:2343
+#: ../src/verbs.cpp:2373
 msgid "tutorial-tips.svg"
 msgstr ""
 
-#: ../src/verbs.cpp:2529 ../src/verbs.cpp:3194
+#: ../src/verbs.cpp:2559 ../src/verbs.cpp:3228
 msgid "Unlock all objects in the current layer"
 msgstr ""
 
-#: ../src/verbs.cpp:2533 ../src/verbs.cpp:3196
+#: ../src/verbs.cpp:2563 ../src/verbs.cpp:3230
 msgid "Unlock all objects in all layers"
 msgstr ""
 
-#: ../src/verbs.cpp:2537 ../src/verbs.cpp:3198
+#: ../src/verbs.cpp:2567 ../src/verbs.cpp:3232
 msgid "Unhide all objects in the current layer"
 msgstr ""
 
-#: ../src/verbs.cpp:2541 ../src/verbs.cpp:3200
+#: ../src/verbs.cpp:2571 ../src/verbs.cpp:3234
 msgid "Unhide all objects in all layers"
 msgstr ""
 
-#: ../src/verbs.cpp:2556
+#: ../src/verbs.cpp:2586
 msgctxt "Verb"
 msgid "None"
 msgstr ""
 
-#: ../src/verbs.cpp:2556
+#: ../src/verbs.cpp:2586
 msgid "Does nothing"
 msgstr ""
 
-#: ../src/verbs.cpp:2559
+#: ../src/verbs.cpp:2589
 msgid "Create new document from the default template"
 msgstr ""
 
-#: ../src/verbs.cpp:2561
+#: ../src/verbs.cpp:2591
 msgid "_Open..."
 msgstr ""
 
-#: ../src/verbs.cpp:2562
+#: ../src/verbs.cpp:2592
 msgid "Open an existing document"
 msgstr ""
 
-#: ../src/verbs.cpp:2563
+#: ../src/verbs.cpp:2593
 msgid "Re_vert"
 msgstr ""
 
-#: ../src/verbs.cpp:2564
+#: ../src/verbs.cpp:2594
 msgid "Revert to the last saved version of document (changes will be lost)"
 msgstr ""
 
-#: ../src/verbs.cpp:2565
+#: ../src/verbs.cpp:2595
 msgid "Save document"
 msgstr ""
 
-#: ../src/verbs.cpp:2567
+#: ../src/verbs.cpp:2597
 msgid "Save _As..."
 msgstr ""
 
-#: ../src/verbs.cpp:2568
+#: ../src/verbs.cpp:2598
 msgid "Save document under a new name"
 msgstr ""
 
-#: ../src/verbs.cpp:2569
+#: ../src/verbs.cpp:2599
 msgid "Save a Cop_y..."
 msgstr ""
 
-#: ../src/verbs.cpp:2570
+#: ../src/verbs.cpp:2600
 msgid "Save a copy of the document under a new name"
 msgstr ""
 
-#: ../src/verbs.cpp:2571
+#: ../src/verbs.cpp:2601
 msgid "Save template ..."
 msgstr ""
 
-#: ../src/verbs.cpp:2572
+#: ../src/verbs.cpp:2602
 msgid "Save a copy of the document as template"
 msgstr ""
 
-#: ../src/verbs.cpp:2573
+#: ../src/verbs.cpp:2603
 msgid "_Print..."
 msgstr ""
 
-#: ../src/verbs.cpp:2573
+#: ../src/verbs.cpp:2603
 msgid "Print document"
 msgstr ""
 
 #. TRANSLATORS: "Vacuum Defs" means "Clean up defs" (so as to remove unused definitions)
-#: ../src/verbs.cpp:2576
+#: ../src/verbs.cpp:2606
 msgid "Clean _up document"
 msgstr ""
 
-#: ../src/verbs.cpp:2576
+#: ../src/verbs.cpp:2606
 msgid ""
 "Remove unused definitions (such as gradients or clipping paths) from the &lt;"
 "defs&gt; of the document"
 msgstr ""
 
-#: ../src/verbs.cpp:2578
+#: ../src/verbs.cpp:2608
 msgid "_Import..."
 msgstr ""
 
-#: ../src/verbs.cpp:2579
+#: ../src/verbs.cpp:2609
 msgid "Import a bitmap or SVG image into this document"
 msgstr ""
 
 #. new FileVerb(SP_VERB_FILE_EXPORT, "FileExport", N_("_Export Bitmap..."), N_("Export this document or a selection as a bitmap image"), INKSCAPE_ICON("document-export")),
-#: ../src/verbs.cpp:2581
+#: ../src/verbs.cpp:2611
 msgid "Import Clip Art..."
 msgstr ""
 
-#: ../src/verbs.cpp:2582
+#: ../src/verbs.cpp:2612
 msgid "Import clipart from Open Clip Art Library"
 msgstr ""
 
 #. new FileVerb(SP_VERB_FILE_EXPORT_TO_OCAL, "FileExportToOCAL", N_("Export To Open Clip Art Library"), N_("Export this document to Open Clip Art Library"), INKSCAPE_ICON_DOCUMENT_EXPORT_OCAL),
-#: ../src/verbs.cpp:2584
+#: ../src/verbs.cpp:2614
 msgid "N_ext Window"
 msgstr ""
 
-#: ../src/verbs.cpp:2585
+#: ../src/verbs.cpp:2615
 msgid "Switch to the next document window"
 msgstr ""
 
-#: ../src/verbs.cpp:2586
+#: ../src/verbs.cpp:2616
 msgid "P_revious Window"
 msgstr ""
 
-#: ../src/verbs.cpp:2587
+#: ../src/verbs.cpp:2617
 msgid "Switch to the previous document window"
 msgstr ""
 
-#: ../src/verbs.cpp:2589
+#: ../src/verbs.cpp:2619
 msgid "Close this document window"
 msgstr ""
 
-#: ../src/verbs.cpp:2590
+#: ../src/verbs.cpp:2620
 msgid "_Quit"
 msgstr ""
 
-#: ../src/verbs.cpp:2590
+#: ../src/verbs.cpp:2620
 msgid "Quit Inkscape"
 msgstr ""
 
-#: ../src/verbs.cpp:2591
+#: ../src/verbs.cpp:2621
 msgid "New from _Template..."
 msgstr ""
 
-#: ../src/verbs.cpp:2592
+#: ../src/verbs.cpp:2622
 msgid "Create new project from template"
 msgstr ""
 
-#: ../src/verbs.cpp:2595
+#: ../src/verbs.cpp:2625
 msgid "Undo last action"
 msgstr ""
 
-#: ../src/verbs.cpp:2598
+#: ../src/verbs.cpp:2628
 msgid "Do again the last undone action"
 msgstr ""
 
-#: ../src/verbs.cpp:2599
+#: ../src/verbs.cpp:2629
 msgid "Cu_t"
 msgstr ""
 
-#: ../src/verbs.cpp:2600
+#: ../src/verbs.cpp:2630
 msgid "Cut selection to clipboard"
 msgstr ""
 
-#: ../src/verbs.cpp:2601
+#: ../src/verbs.cpp:2631
 msgid "_Copy"
 msgstr ""
 
-#: ../src/verbs.cpp:2602
+#: ../src/verbs.cpp:2632
 msgid "Copy selection to clipboard"
 msgstr ""
 
-#: ../src/verbs.cpp:2603
+#: ../src/verbs.cpp:2633
 msgid "_Paste"
 msgstr ""
 
-#: ../src/verbs.cpp:2604
+#: ../src/verbs.cpp:2634
 msgid "Paste objects from clipboard to mouse point, or paste text"
 msgstr ""
 
-#: ../src/verbs.cpp:2605
+#: ../src/verbs.cpp:2635
 msgid "Paste _Style"
 msgstr ""
 
-#: ../src/verbs.cpp:2606
+#: ../src/verbs.cpp:2636
 msgid "Apply the style of the copied object to selection"
 msgstr ""
 
-#: ../src/verbs.cpp:2607 ../share/ui/menus.xml.h:3
+#: ../src/verbs.cpp:2637 ../share/ui/menus.xml.h:3
 msgid "Paste Si_ze"
 msgstr ""
 
-#: ../src/verbs.cpp:2608
+#: ../src/verbs.cpp:2638
 msgid "Scale selection to match the size of the copied object"
 msgstr ""
 
-#: ../src/verbs.cpp:2609
+#: ../src/verbs.cpp:2639
 msgid "Paste _Width"
 msgstr ""
 
-#: ../src/verbs.cpp:2610
+#: ../src/verbs.cpp:2640
 msgid "Scale selection horizontally to match the width of the copied object"
 msgstr ""
 
-#: ../src/verbs.cpp:2611
+#: ../src/verbs.cpp:2641
 msgid "Paste _Height"
 msgstr ""
 
-#: ../src/verbs.cpp:2612
+#: ../src/verbs.cpp:2642
 msgid "Scale selection vertically to match the height of the copied object"
 msgstr ""
 
-#: ../src/verbs.cpp:2613
+#: ../src/verbs.cpp:2643
 msgid "Paste Size Separately"
 msgstr ""
 
-#: ../src/verbs.cpp:2614
+#: ../src/verbs.cpp:2644
 msgid "Scale each selected object to match the size of the copied object"
 msgstr ""
 
-#: ../src/verbs.cpp:2615
+#: ../src/verbs.cpp:2645
 msgid "Paste Width Separately"
 msgstr ""
 
-#: ../src/verbs.cpp:2616
+#: ../src/verbs.cpp:2646
 msgid ""
 "Scale each selected object horizontally to match the width of the copied "
 "object"
 msgstr ""
 
-#: ../src/verbs.cpp:2617
+#: ../src/verbs.cpp:2647
 msgid "Paste Height Separately"
 msgstr ""
 
-#: ../src/verbs.cpp:2618
+#: ../src/verbs.cpp:2648
 msgid ""
 "Scale each selected object vertically to match the height of the copied "
 "object"
 msgstr ""
 
-#: ../src/verbs.cpp:2619
+#: ../src/verbs.cpp:2649
 msgid "Paste _In Place"
 msgstr ""
 
-#: ../src/verbs.cpp:2620
+#: ../src/verbs.cpp:2650
 msgid "Paste objects from clipboard to the original location"
 msgstr ""
 
-#: ../src/verbs.cpp:2621
+#: ../src/verbs.cpp:2651
 msgid "Paste Path _Effect"
 msgstr ""
 
-#: ../src/verbs.cpp:2622
+#: ../src/verbs.cpp:2652
 msgid "Apply the path effect of the copied object to selection"
 msgstr ""
 
-#: ../src/verbs.cpp:2623
+#: ../src/verbs.cpp:2653
 msgid "Remove Path _Effect"
 msgstr ""
 
-#: ../src/verbs.cpp:2624
+#: ../src/verbs.cpp:2654
 msgid "Remove any path effects from selected objects"
 msgstr ""
 
-#: ../src/verbs.cpp:2625
+#: ../src/verbs.cpp:2655
 msgid "_Remove Filters"
 msgstr ""
 
-#: ../src/verbs.cpp:2626
+#: ../src/verbs.cpp:2656
 msgid "Remove any filters from selected objects"
 msgstr ""
 
-#: ../src/verbs.cpp:2628
+#: ../src/verbs.cpp:2658
 msgid "Delete selection"
 msgstr ""
 
-#: ../src/verbs.cpp:2629
+#: ../src/verbs.cpp:2659
 msgid "Duplic_ate"
 msgstr ""
 
-#: ../src/verbs.cpp:2630
+#: ../src/verbs.cpp:2660
 msgid "Duplicate selected objects"
 msgstr ""
 
-#: ../src/verbs.cpp:2631
+#: ../src/verbs.cpp:2661
 msgid "Create Clo_ne"
 msgstr ""
 
-#: ../src/verbs.cpp:2632
+#: ../src/verbs.cpp:2662
 msgid "Create a clone (a copy linked to the original) of selected object"
 msgstr ""
 
-#: ../src/verbs.cpp:2633
+#: ../src/verbs.cpp:2663
 msgid "Unlin_k Clone"
 msgstr ""
 
-#: ../src/verbs.cpp:2634
+#: ../src/verbs.cpp:2664
 msgid ""
 "Cut the selected clones' links to the originals, turning them into "
 "standalone objects"
 msgstr ""
 
-#: ../src/verbs.cpp:2635
+#: ../src/verbs.cpp:2665
 msgid "Unlink Clones _recursively"
 msgstr ""
 
-#: ../src/verbs.cpp:2636
+#: ../src/verbs.cpp:2666
 msgid "Unlink all clones in the selection, even if they are in groups."
 msgstr ""
 
-#: ../src/verbs.cpp:2637
+#: ../src/verbs.cpp:2667
 msgid "Relink to Copied"
 msgstr ""
 
-#: ../src/verbs.cpp:2638
+#: ../src/verbs.cpp:2668
 msgid "Relink the selected clones to the object currently on the clipboard"
 msgstr ""
 
-#: ../src/verbs.cpp:2639
+#: ../src/verbs.cpp:2669
 msgid "Select _Original"
 msgstr ""
 
-#: ../src/verbs.cpp:2640
+#: ../src/verbs.cpp:2670
 msgid "Select the object to which the selected clone is linked"
 msgstr ""
 
-#: ../src/verbs.cpp:2641
+#: ../src/verbs.cpp:2671
 msgid "Clone original path (LPE)"
 msgstr ""
 
-#: ../src/verbs.cpp:2642
+#: ../src/verbs.cpp:2672
 msgid ""
 "Creates a new path, applies the Clone original LPE, and refers it to the "
 "selected path"
 msgstr ""
 
-#: ../src/verbs.cpp:2643
+#: ../src/verbs.cpp:2673
 msgid "Objects to _Marker"
 msgstr ""
 
-#: ../src/verbs.cpp:2644
+#: ../src/verbs.cpp:2674
 msgid "Convert selection to a line marker"
 msgstr ""
 
-#: ../src/verbs.cpp:2645
+#: ../src/verbs.cpp:2675
 msgid "Objects to Gu_ides"
 msgstr ""
 
-#: ../src/verbs.cpp:2646
+#: ../src/verbs.cpp:2676
 msgid ""
 "Convert selected objects to a collection of guidelines aligned with their "
 "edges"
 msgstr ""
 
-#: ../src/verbs.cpp:2647
+#: ../src/verbs.cpp:2677
 msgid "Objects to Patter_n"
 msgstr ""
 
-#: ../src/verbs.cpp:2648
+#: ../src/verbs.cpp:2678
 msgid "Convert selection to a rectangle with tiled pattern fill"
 msgstr ""
 
-#: ../src/verbs.cpp:2649
+#: ../src/verbs.cpp:2679
 msgid "Pattern to _Objects"
 msgstr ""
 
-#: ../src/verbs.cpp:2650
+#: ../src/verbs.cpp:2680
 msgid "Extract objects from a tiled pattern fill"
 msgstr ""
 
-#: ../src/verbs.cpp:2651
+#: ../src/verbs.cpp:2681
 msgid "Group to Symbol"
 msgstr ""
 
-#: ../src/verbs.cpp:2652
+#: ../src/verbs.cpp:2682
 msgid "Convert group to a symbol"
 msgstr ""
 
-#: ../src/verbs.cpp:2653
+#: ../src/verbs.cpp:2683
 msgid "Symbol to Group"
 msgstr ""
 
-#: ../src/verbs.cpp:2654
+#: ../src/verbs.cpp:2684
 msgid "Extract group from a symbol"
 msgstr ""
 
-#: ../src/verbs.cpp:2655
+#: ../src/verbs.cpp:2685
 msgid "Clea_r All"
 msgstr ""
 
-#: ../src/verbs.cpp:2656
+#: ../src/verbs.cpp:2686
 msgid "Delete all objects from document"
 msgstr ""
 
-#: ../src/verbs.cpp:2657
+#: ../src/verbs.cpp:2687
 msgid "Select Al_l"
 msgstr ""
 
-#: ../src/verbs.cpp:2658
+#: ../src/verbs.cpp:2688
 msgid "Select all objects or all nodes"
 msgstr ""
 
-#: ../src/verbs.cpp:2659
+#: ../src/verbs.cpp:2689
 msgid "Select All in All La_yers"
 msgstr ""
 
-#: ../src/verbs.cpp:2660
+#: ../src/verbs.cpp:2690
 msgid "Select all objects in all visible and unlocked layers"
 msgstr ""
 
-#: ../src/verbs.cpp:2661
+#: ../src/verbs.cpp:2691
 msgid "Fill _and Stroke"
 msgstr ""
 
-#: ../src/verbs.cpp:2662
+#: ../src/verbs.cpp:2692
 msgid ""
 "Select all objects with the same fill and stroke as the selected objects"
 msgstr ""
 
-#: ../src/verbs.cpp:2663
+#: ../src/verbs.cpp:2693
 msgid "_Fill Color"
 msgstr ""
 
-#: ../src/verbs.cpp:2664
+#: ../src/verbs.cpp:2694
 msgid "Select all objects with the same fill as the selected objects"
 msgstr ""
 
-#: ../src/verbs.cpp:2665
+#: ../src/verbs.cpp:2695
 msgid "_Stroke Color"
 msgstr ""
 
-#: ../src/verbs.cpp:2666
+#: ../src/verbs.cpp:2696
 msgid "Select all objects with the same stroke as the selected objects"
 msgstr ""
 
-#: ../src/verbs.cpp:2667
+#: ../src/verbs.cpp:2697
 msgid "Stroke St_yle"
 msgstr ""
 
-#: ../src/verbs.cpp:2668
+#: ../src/verbs.cpp:2698
 msgid ""
 "Select all objects with the same stroke style (width, dash, markers) as the "
 "selected objects"
 msgstr ""
 
-#: ../src/verbs.cpp:2669
+#: ../src/verbs.cpp:2699
 msgid "_Object Type"
 msgstr ""
 
-#: ../src/verbs.cpp:2670
+#: ../src/verbs.cpp:2700
 msgid ""
 "Select all objects with the same object type (rect, arc, text, path, bitmap "
 "etc) as the selected objects"
 msgstr ""
 
-#: ../src/verbs.cpp:2671
+#: ../src/verbs.cpp:2701
 msgid "In_vert Selection"
 msgstr ""
 
-#: ../src/verbs.cpp:2672
+#: ../src/verbs.cpp:2702
 msgid "Invert selection (unselect what is selected and select everything else)"
 msgstr ""
 
-#: ../src/verbs.cpp:2673
+#: ../src/verbs.cpp:2703
 msgid "Invert in All Layers"
 msgstr ""
 
-#: ../src/verbs.cpp:2674
+#: ../src/verbs.cpp:2704
 msgid "Invert selection in all visible and unlocked layers"
 msgstr ""
 
-#: ../src/verbs.cpp:2675
+#: ../src/verbs.cpp:2705
 msgid "Select Next"
 msgstr ""
 
-#: ../src/verbs.cpp:2676
+#: ../src/verbs.cpp:2706
 msgid "Select next object or node"
 msgstr ""
 
-#: ../src/verbs.cpp:2677
+#: ../src/verbs.cpp:2707
 msgid "Select Previous"
 msgstr ""
 
-#: ../src/verbs.cpp:2678
+#: ../src/verbs.cpp:2708
 msgid "Select previous object or node"
 msgstr ""
 
-#: ../src/verbs.cpp:2679
+#: ../src/verbs.cpp:2709
 msgid "D_eselect"
 msgstr ""
 
-#: ../src/verbs.cpp:2680
+#: ../src/verbs.cpp:2710
 msgid "Deselect any selected objects or nodes"
 msgstr ""
 
-#: ../src/verbs.cpp:2682
+#: ../src/verbs.cpp:2712
 msgid "Delete all the guides in the document"
 msgstr ""
 
-#: ../src/verbs.cpp:2683
+#: ../src/verbs.cpp:2713
 msgid "Lock All Guides"
 msgstr ""
 
-#: ../src/verbs.cpp:2683 ../src/widgets/desktop-widget.cpp:363
+#: ../src/verbs.cpp:2713 ../src/widgets/desktop-widget.cpp:377
 msgid "Toggle lock of all guides in the document"
 msgstr ""
 
-#: ../src/verbs.cpp:2684
+#: ../src/verbs.cpp:2714
 msgid "Create _Guides Around the Page"
 msgstr ""
 
-#: ../src/verbs.cpp:2685
+#: ../src/verbs.cpp:2715
 msgid "Create four guides aligned with the page borders"
 msgstr ""
 
-#: ../src/verbs.cpp:2686
+#: ../src/verbs.cpp:2716
 msgid "Next path effect parameter"
 msgstr ""
 
-#: ../src/verbs.cpp:2687
+#: ../src/verbs.cpp:2717
 msgid "Show next editable path effect parameter"
 msgstr ""
 
 #. Selection
-#: ../src/verbs.cpp:2692
+#: ../src/verbs.cpp:2722
 msgid "Raise to _Top"
 msgstr ""
 
-#: ../src/verbs.cpp:2693
+#: ../src/verbs.cpp:2723
 msgid "Raise selection to top"
 msgstr ""
 
-#: ../src/verbs.cpp:2694
+#: ../src/verbs.cpp:2724
 msgid "Lower to _Bottom"
 msgstr ""
 
-#: ../src/verbs.cpp:2695
+#: ../src/verbs.cpp:2725
 msgid "Lower selection to bottom"
 msgstr ""
 
-#: ../src/verbs.cpp:2696
+#: ../src/verbs.cpp:2726
 msgid "_Raise"
 msgstr ""
 
-#: ../src/verbs.cpp:2697
+#: ../src/verbs.cpp:2727
 msgid "Raise selection one step"
 msgstr ""
 
-#: ../src/verbs.cpp:2698
+#: ../src/verbs.cpp:2728
 msgid "_Lower"
 msgstr ""
 
-#: ../src/verbs.cpp:2699
+#: ../src/verbs.cpp:2729
 msgid "Lower selection one step"
 msgstr ""
 
-#: ../src/verbs.cpp:2702
+#: ../src/verbs.cpp:2732
 msgid "_Stack up"
 msgstr ""
 
-#: ../src/verbs.cpp:2703
+#: ../src/verbs.cpp:2733
 msgid "Stack selection one step up"
 msgstr ""
 
-#: ../src/verbs.cpp:2704
+#: ../src/verbs.cpp:2734
 msgid "_Stack down"
 msgstr ""
 
-#: ../src/verbs.cpp:2705
+#: ../src/verbs.cpp:2735
 msgid "Stack selection one step down"
 msgstr ""
 
-#: ../src/verbs.cpp:2709
+#: ../src/verbs.cpp:2739
 msgid "Group selected objects"
 msgstr ""
 
-#: ../src/verbs.cpp:2711
+#: ../src/verbs.cpp:2741
 msgid "Ungroup selected groups"
 msgstr ""
 
-#: ../src/verbs.cpp:2712
+#: ../src/verbs.cpp:2742
 msgid "_Pop selected objects out of group"
 msgstr ""
 
-#: ../src/verbs.cpp:2713
+#: ../src/verbs.cpp:2743
 msgid "Pop selected objects out of group"
 msgstr ""
 
-#: ../src/verbs.cpp:2715
+#: ../src/verbs.cpp:2745
 msgid "_Put on Path"
 msgstr ""
 
-#: ../src/verbs.cpp:2717
+#: ../src/verbs.cpp:2747
 msgid "_Remove from Path"
 msgstr ""
 
-#: ../src/verbs.cpp:2719
+#: ../src/verbs.cpp:2749
 msgid "Remove Manual _Kerns"
 msgstr ""
 
 #. TRANSLATORS: "glyph": An image used in the visual representation of characters;
 #. roughly speaking, how a character looks. A font is a set of glyphs.
-#: ../src/verbs.cpp:2722
+#: ../src/verbs.cpp:2752
 msgid "Remove all manual kerns and glyph rotations from a text object"
 msgstr ""
 
-#: ../src/verbs.cpp:2724
+#: ../src/verbs.cpp:2754
 msgid "_Union"
 msgstr ""
 
-#: ../src/verbs.cpp:2725
+#: ../src/verbs.cpp:2755
 msgid "Create union of selected paths"
 msgstr ""
 
-#: ../src/verbs.cpp:2726
+#: ../src/verbs.cpp:2756
 msgid "_Intersection"
 msgstr ""
 
-#: ../src/verbs.cpp:2727
+#: ../src/verbs.cpp:2757
 msgid "Create intersection of selected paths"
 msgstr ""
 
-#: ../src/verbs.cpp:2728
+#: ../src/verbs.cpp:2758
 msgid "_Difference"
 msgstr ""
 
-#: ../src/verbs.cpp:2729
+#: ../src/verbs.cpp:2759
 msgid "Create difference of selected paths (bottom minus top)"
 msgstr ""
 
-#: ../src/verbs.cpp:2730
+#: ../src/verbs.cpp:2760
 msgid "E_xclusion"
 msgstr ""
 
-#: ../src/verbs.cpp:2731
+#: ../src/verbs.cpp:2761
 msgid ""
 "Create exclusive OR of selected paths (those parts that belong to only one "
 "path)"
 msgstr ""
 
-#: ../src/verbs.cpp:2732
+#: ../src/verbs.cpp:2762
 msgid "Di_vision"
 msgstr ""
 
-#: ../src/verbs.cpp:2733
+#: ../src/verbs.cpp:2763
 msgid "Cut the bottom path into pieces"
 msgstr ""
 
 #. TRANSLATORS: "to cut a path" is not the same as "to break a path apart" - see the
 #. Advanced tutorial for more info
-#: ../src/verbs.cpp:2736
+#: ../src/verbs.cpp:2766
 msgid "Cut _Path"
 msgstr ""
 
-#: ../src/verbs.cpp:2737
+#: ../src/verbs.cpp:2767
 msgid "Cut the bottom path's stroke into pieces, removing fill"
 msgstr ""
 
-#: ../src/verbs.cpp:2738
+#: ../src/verbs.cpp:2768
 msgid "_Grow"
 msgstr ""
 
-#: ../src/verbs.cpp:2739
+#: ../src/verbs.cpp:2769
 msgid "Make selected objects bigger"
 msgstr ""
 
-#: ../src/verbs.cpp:2740
+#: ../src/verbs.cpp:2770
 msgid "_Grow on screen"
 msgstr ""
 
-#: ../src/verbs.cpp:2741
+#: ../src/verbs.cpp:2771
 msgid "Make selected objects bigger relative to screen"
 msgstr ""
 
-#: ../src/verbs.cpp:2742
+#: ../src/verbs.cpp:2772
 msgid "_Double size"
 msgstr ""
 
-#: ../src/verbs.cpp:2743
+#: ../src/verbs.cpp:2773
 msgid "Double the size of selected objects"
 msgstr ""
 
-#: ../src/verbs.cpp:2744
+#: ../src/verbs.cpp:2774
 msgid "_Shrink"
 msgstr ""
 
-#: ../src/verbs.cpp:2745
+#: ../src/verbs.cpp:2775
 msgid "Make selected objects smaller"
 msgstr ""
 
-#: ../src/verbs.cpp:2746
+#: ../src/verbs.cpp:2776
 msgid "_Shrink on screen"
 msgstr ""
 
-#: ../src/verbs.cpp:2747
+#: ../src/verbs.cpp:2777
 msgid "Make selected objects smaller relative to screen"
 msgstr ""
 
-#: ../src/verbs.cpp:2748
+#: ../src/verbs.cpp:2778
 msgid "_Halve size"
 msgstr ""
 
-#: ../src/verbs.cpp:2749
+#: ../src/verbs.cpp:2779
 msgid "Halve the size of selected objects"
 msgstr ""
 
 #. TRANSLATORS: "outset": expand a shape by offsetting the object's path,
 #. i.e. by displacing it perpendicular to the path in each point.
 #. See also the Advanced Tutorial for explanation.
-#: ../src/verbs.cpp:2753
+#: ../src/verbs.cpp:2783
 msgid "Outs_et"
 msgstr ""
 
-#: ../src/verbs.cpp:2754
+#: ../src/verbs.cpp:2784
 msgid "Outset selected paths"
 msgstr ""
 
-#: ../src/verbs.cpp:2756
+#: ../src/verbs.cpp:2786
 msgid "O_utset Path by 1 px"
 msgstr ""
 
-#: ../src/verbs.cpp:2757
+#: ../src/verbs.cpp:2787
 msgid "Outset selected paths by 1 px"
 msgstr ""
 
-#: ../src/verbs.cpp:2759
+#: ../src/verbs.cpp:2789
 msgid "O_utset Path by 10 px"
 msgstr ""
 
-#: ../src/verbs.cpp:2760
+#: ../src/verbs.cpp:2790
 msgid "Outset selected paths by 10 px"
 msgstr ""
 
 #. TRANSLATORS: "inset": contract a shape by offsetting the object's path,
 #. i.e. by displacing it perpendicular to the path in each point.
 #. See also the Advanced Tutorial for explanation.
-#: ../src/verbs.cpp:2764
+#: ../src/verbs.cpp:2794
 msgid "I_nset"
 msgstr ""
 
-#: ../src/verbs.cpp:2765
+#: ../src/verbs.cpp:2795
 msgid "Inset selected paths"
 msgstr ""
 
-#: ../src/verbs.cpp:2767
+#: ../src/verbs.cpp:2797
 msgid "I_nset Path by 1 px"
 msgstr ""
 
-#: ../src/verbs.cpp:2768
+#: ../src/verbs.cpp:2798
 msgid "Inset selected paths by 1 px"
 msgstr ""
 
-#: ../src/verbs.cpp:2770
+#: ../src/verbs.cpp:2800
 msgid "I_nset Path by 10 px"
 msgstr ""
 
-#: ../src/verbs.cpp:2771
+#: ../src/verbs.cpp:2801
 msgid "Inset selected paths by 10 px"
 msgstr ""
 
-#: ../src/verbs.cpp:2773
+#: ../src/verbs.cpp:2803
 msgid "D_ynamic Offset"
 msgstr ""
 
-#: ../src/verbs.cpp:2773
+#: ../src/verbs.cpp:2803
 msgid "Create a dynamic offset object"
 msgstr ""
 
-#: ../src/verbs.cpp:2775
+#: ../src/verbs.cpp:2805
 msgid "_Linked Offset"
 msgstr ""
 
-#: ../src/verbs.cpp:2776
+#: ../src/verbs.cpp:2806
 msgid "Create a dynamic offset object linked to the original path"
 msgstr ""
 
-#: ../src/verbs.cpp:2778
+#: ../src/verbs.cpp:2808
 msgid "_Stroke to Path"
 msgstr ""
 
-#: ../src/verbs.cpp:2779
+#: ../src/verbs.cpp:2809
 msgid "Convert selected object's stroke to paths"
 msgstr ""
 
-#: ../src/verbs.cpp:2780
+#: ../src/verbs.cpp:2810
 msgid "_Stroke to Path Legacy"
 msgstr ""
 
-#: ../src/verbs.cpp:2781
+#: ../src/verbs.cpp:2811
 msgid "Convert selected object's stroke to paths legacy mode"
 msgstr ""
 
-#: ../src/verbs.cpp:2782
+#: ../src/verbs.cpp:2812
 msgid "Si_mplify"
 msgstr ""
 
-#: ../src/verbs.cpp:2783
+#: ../src/verbs.cpp:2813
 msgid "Simplify selected paths (remove extra nodes)"
 msgstr ""
 
-#: ../src/verbs.cpp:2784
+#: ../src/verbs.cpp:2814
 msgid "_Reverse"
 msgstr ""
 
-#: ../src/verbs.cpp:2785
+#: ../src/verbs.cpp:2815
 msgid "Reverse the direction of selected paths (useful for flipping markers)"
 msgstr ""
 
-#: ../src/verbs.cpp:2790
+#: ../src/verbs.cpp:2820
 msgid "Create one or more paths from a bitmap by tracing it"
 msgstr ""
 
-#: ../src/verbs.cpp:2793
+#: ../src/verbs.cpp:2823
 msgid "Trace Pixel Art..."
 msgstr ""
 
-#: ../src/verbs.cpp:2794
+#: ../src/verbs.cpp:2824
 msgid "Create paths using Kopf-Lischinski algorithm to vectorize pixel art"
 msgstr ""
 
-#: ../src/verbs.cpp:2795
+#: ../src/verbs.cpp:2825
 msgid "Make a _Bitmap Copy"
 msgstr ""
 
-#: ../src/verbs.cpp:2796
+#: ../src/verbs.cpp:2826
 msgid "Export selection to a bitmap and insert it into document"
 msgstr ""
 
-#: ../src/verbs.cpp:2797
+#: ../src/verbs.cpp:2827
 msgid "_Combine"
 msgstr ""
 
-#: ../src/verbs.cpp:2798
+#: ../src/verbs.cpp:2828
 msgid "Combine several paths into one"
 msgstr ""
 
 #. TRANSLATORS: "to cut a path" is not the same as "to break a path apart" - see the
 #. Advanced tutorial for more info
-#: ../src/verbs.cpp:2801
+#: ../src/verbs.cpp:2831
 msgid "Break _Apart"
 msgstr ""
 
-#: ../src/verbs.cpp:2802
+#: ../src/verbs.cpp:2832
 msgid "Break selected paths into subpaths"
 msgstr ""
 
-#: ../src/verbs.cpp:2803
+#: ../src/verbs.cpp:2833
 msgid "_Arrange..."
 msgstr ""
 
-#: ../src/verbs.cpp:2804
+#: ../src/verbs.cpp:2834
 msgid "Arrange selected objects in a table or circle"
 msgstr ""
 
 #. Layer
-#: ../src/verbs.cpp:2806
+#: ../src/verbs.cpp:2836
 msgid "_Add Layer..."
 msgstr ""
 
-#: ../src/verbs.cpp:2807
+#: ../src/verbs.cpp:2837
 msgid "Create a new layer"
 msgstr ""
 
-#: ../src/verbs.cpp:2808
+#: ../src/verbs.cpp:2838
 msgid "Re_name Layer..."
 msgstr ""
 
-#: ../src/verbs.cpp:2809
+#: ../src/verbs.cpp:2839
 msgid "Rename the current layer"
 msgstr ""
 
-#: ../src/verbs.cpp:2810
+#: ../src/verbs.cpp:2840
 msgid "Switch to Layer Abov_e"
 msgstr ""
 
-#: ../src/verbs.cpp:2811
+#: ../src/verbs.cpp:2841
 msgid "Switch to the layer above the current"
 msgstr ""
 
-#: ../src/verbs.cpp:2812
+#: ../src/verbs.cpp:2842
 msgid "Switch to Layer Belo_w"
 msgstr ""
 
-#: ../src/verbs.cpp:2813
+#: ../src/verbs.cpp:2843
 msgid "Switch to the layer below the current"
 msgstr ""
 
-#: ../src/verbs.cpp:2814
+#: ../src/verbs.cpp:2844
 msgid "Move Selection to Layer Abo_ve"
 msgstr ""
 
-#: ../src/verbs.cpp:2815
+#: ../src/verbs.cpp:2845
 msgid "Move selection to the layer above the current"
 msgstr ""
 
-#: ../src/verbs.cpp:2816
+#: ../src/verbs.cpp:2846
 msgid "Move Selection to Layer Bel_ow"
 msgstr ""
 
-#: ../src/verbs.cpp:2817
+#: ../src/verbs.cpp:2847
 msgid "Move selection to the layer below the current"
 msgstr ""
 
-#: ../src/verbs.cpp:2818
+#: ../src/verbs.cpp:2848
 msgid "Move Selection to Layer..."
 msgstr ""
 
-#: ../src/verbs.cpp:2820
+#: ../src/verbs.cpp:2850
 msgid "Layer to _Top"
 msgstr ""
 
-#: ../src/verbs.cpp:2821
+#: ../src/verbs.cpp:2851
 msgid "Raise the current layer to the top"
 msgstr ""
 
-#: ../src/verbs.cpp:2822
+#: ../src/verbs.cpp:2852
 msgid "Layer to _Bottom"
 msgstr ""
 
-#: ../src/verbs.cpp:2823
+#: ../src/verbs.cpp:2853
 msgid "Lower the current layer to the bottom"
 msgstr ""
 
-#: ../src/verbs.cpp:2824
+#: ../src/verbs.cpp:2854
 msgid "_Raise Layer"
 msgstr ""
 
-#: ../src/verbs.cpp:2825
+#: ../src/verbs.cpp:2855
 msgid "Raise the current layer"
 msgstr ""
 
-#: ../src/verbs.cpp:2826
+#: ../src/verbs.cpp:2856
 msgid "_Lower Layer"
 msgstr ""
 
-#: ../src/verbs.cpp:2827
+#: ../src/verbs.cpp:2857
 msgid "Lower the current layer"
 msgstr ""
 
-#: ../src/verbs.cpp:2828
+#: ../src/verbs.cpp:2858
 msgid "D_uplicate Current Layer"
 msgstr ""
 
-#: ../src/verbs.cpp:2829
+#: ../src/verbs.cpp:2859
 msgid "Duplicate an existing layer"
 msgstr ""
 
-#: ../src/verbs.cpp:2830
+#: ../src/verbs.cpp:2860
 msgid "_Delete Current Layer"
 msgstr ""
 
-#: ../src/verbs.cpp:2831
+#: ../src/verbs.cpp:2861
 msgid "Delete the current layer"
 msgstr ""
 
-#: ../src/verbs.cpp:2832
+#: ../src/verbs.cpp:2862
 msgid "_Show/hide other layers"
 msgstr ""
 
-#: ../src/verbs.cpp:2833
+#: ../src/verbs.cpp:2863
 msgid "Solo the current layer"
 msgstr ""
 
-#: ../src/verbs.cpp:2834
+#: ../src/verbs.cpp:2864
 msgid "_Show all layers"
 msgstr ""
 
-#: ../src/verbs.cpp:2835
+#: ../src/verbs.cpp:2865
 msgid "Show all the layers"
 msgstr ""
 
-#: ../src/verbs.cpp:2836
+#: ../src/verbs.cpp:2866
 msgid "_Hide all layers"
 msgstr ""
 
-#: ../src/verbs.cpp:2837
+#: ../src/verbs.cpp:2867
 msgid "Hide all the layers"
 msgstr ""
 
-#: ../src/verbs.cpp:2838
+#: ../src/verbs.cpp:2868
 msgid "_Lock all layers"
 msgstr ""
 
-#: ../src/verbs.cpp:2839
+#: ../src/verbs.cpp:2869
 msgid "Lock all the layers"
 msgstr ""
 
-#: ../src/verbs.cpp:2840
+#: ../src/verbs.cpp:2870
 msgid "Lock/Unlock _other layers"
 msgstr ""
 
-#: ../src/verbs.cpp:2841
+#: ../src/verbs.cpp:2871
 msgid "Lock all the other layers"
 msgstr ""
 
-#: ../src/verbs.cpp:2842
+#: ../src/verbs.cpp:2872
 msgid "_Unlock all layers"
 msgstr ""
 
-#: ../src/verbs.cpp:2843
+#: ../src/verbs.cpp:2873
 msgid "Unlock all the layers"
 msgstr ""
 
-#: ../src/verbs.cpp:2844
+#: ../src/verbs.cpp:2874
 msgid "_Lock/Unlock Current Layer"
 msgstr ""
 
-#: ../src/verbs.cpp:2845
+#: ../src/verbs.cpp:2875
 msgid "Toggle lock on current layer"
 msgstr ""
 
-#: ../src/verbs.cpp:2846
+#: ../src/verbs.cpp:2876
 msgid "_Show/hide Current Layer"
 msgstr ""
 
-#: ../src/verbs.cpp:2847
+#: ../src/verbs.cpp:2877
 msgid "Toggle visibility of current layer"
 msgstr ""
 
 #. Object
-#: ../src/verbs.cpp:2850
+#: ../src/verbs.cpp:2880
 msgid "Rotate _90° CW"
 msgstr ""
 
 #. This is shared between tooltips and statusbar, so they
 #. must use UTF-8, not HTML entities for special characters.
-#: ../src/verbs.cpp:2853
+#: ../src/verbs.cpp:2883
 msgid "Rotate selection 90° clockwise"
 msgstr ""
 
-#: ../src/verbs.cpp:2854
+#: ../src/verbs.cpp:2884
 msgid "Rotate 9_0° CCW"
 msgstr ""
 
 #. This is shared between tooltips and statusbar, so they
 #. must use UTF-8, not HTML entities for special characters.
-#: ../src/verbs.cpp:2857
+#: ../src/verbs.cpp:2887
 msgid "Rotate selection 90° counter-clockwise"
 msgstr ""
 
-#: ../src/verbs.cpp:2858
+#: ../src/verbs.cpp:2888
 msgid "Remove _Transformations"
 msgstr ""
 
-#: ../src/verbs.cpp:2859
+#: ../src/verbs.cpp:2889
 msgid "Remove transformations from object"
 msgstr ""
 
-#: ../src/verbs.cpp:2860
+#: ../src/verbs.cpp:2890
 msgid "_Object to Path"
 msgstr ""
 
-#: ../src/verbs.cpp:2861
+#: ../src/verbs.cpp:2891
 msgid "Convert selected object to path"
 msgstr ""
 
-#: ../src/verbs.cpp:2862
+#: ../src/verbs.cpp:2892
 msgid "_Flow into Frame"
 msgstr ""
 
-#: ../src/verbs.cpp:2863
+#: ../src/verbs.cpp:2893
 msgid ""
 "Put text into a frame (path or shape), creating a flowed text linked to the "
 "frame object"
 msgstr ""
 
-#: ../src/verbs.cpp:2864
+#: ../src/verbs.cpp:2894
 msgid "_Unflow"
 msgstr ""
 
-#: ../src/verbs.cpp:2865
+#: ../src/verbs.cpp:2895
 msgid "Remove text from frame (creates a single-line text object)"
 msgstr ""
 
-#: ../src/verbs.cpp:2866
+#: ../src/verbs.cpp:2896
 msgid "_Convert to Text"
 msgstr ""
 
-#: ../src/verbs.cpp:2867
+#: ../src/verbs.cpp:2897
 msgid "Convert flowed text to regular text object (preserves appearance)"
 msgstr ""
 
-#: ../src/verbs.cpp:2869
+#: ../src/verbs.cpp:2899
 msgid "Flip _Horizontal"
 msgstr ""
 
-#: ../src/verbs.cpp:2869
+#: ../src/verbs.cpp:2899
 msgid "Flip selected objects horizontally"
 msgstr ""
 
-#: ../src/verbs.cpp:2872
+#: ../src/verbs.cpp:2902
 msgid "Flip _Vertical"
 msgstr ""
 
-#: ../src/verbs.cpp:2872
+#: ../src/verbs.cpp:2902
 msgid "Flip selected objects vertically"
 msgstr ""
 
-#: ../src/verbs.cpp:2875
+#: ../src/verbs.cpp:2905
 msgid "Apply mask to selection (using the topmost object as mask)"
 msgstr ""
 
-#: ../src/verbs.cpp:2876 ../src/verbs.cpp:2884 ../share/ui/menus.xml.h:2
+#: ../src/verbs.cpp:2906 ../src/verbs.cpp:2914
+msgid "_Set Inverse (LPE)"
+msgstr ""
+
+#: ../src/verbs.cpp:2907
+msgid "Apply inverse mask to selection (using the topmost object as mask)"
+msgstr ""
+
+#: ../src/verbs.cpp:2908 ../src/verbs.cpp:2918 ../share/ui/menus.xml.h:2
 msgid "_Edit"
 msgstr ""
 
-#: ../src/verbs.cpp:2877
+#: ../src/verbs.cpp:2909
 msgid "Edit mask"
 msgstr ""
 
-#: ../src/verbs.cpp:2878 ../src/verbs.cpp:2886
+#: ../src/verbs.cpp:2910 ../src/verbs.cpp:2920
 msgid "_Release"
 msgstr ""
 
-#: ../src/verbs.cpp:2879
+#: ../src/verbs.cpp:2911
 msgid "Remove mask from selection"
 msgstr ""
 
-#: ../src/verbs.cpp:2881
+#: ../src/verbs.cpp:2913
 msgid ""
 "Apply clipping path to selection (using the topmost object as clipping path)"
 msgstr ""
 
-#: ../src/verbs.cpp:2882
+#: ../src/verbs.cpp:2915
+msgid ""
+"Apply inverse clipping path to selection (using the topmost object as "
+"clipping path)"
+msgstr ""
+
+#: ../src/verbs.cpp:2916
 msgid "Create Cl_ip Group"
 msgstr ""
 
-#: ../src/verbs.cpp:2883
+#: ../src/verbs.cpp:2917
 msgid "Creates a clip group using the selected objects as a base"
 msgstr ""
 
-#: ../src/verbs.cpp:2885
+#: ../src/verbs.cpp:2919
 msgid "Edit clipping path"
 msgstr ""
 
-#: ../src/verbs.cpp:2887
+#: ../src/verbs.cpp:2921
 msgid "Remove clipping path from selection"
 msgstr ""
 
 #. Tools
-#: ../src/verbs.cpp:2892
+#: ../src/verbs.cpp:2926
 msgctxt "ContextVerb"
 msgid "Select"
 msgstr ""
 
-#: ../src/verbs.cpp:2893
+#: ../src/verbs.cpp:2927
 msgid "Select and transform objects"
-msgstr ""
-
-#: ../src/verbs.cpp:2894
-msgctxt "ContextVerb"
-msgid "Node Edit"
-msgstr ""
-
-#: ../src/verbs.cpp:2895
-msgid "Edit paths by nodes"
-msgstr ""
-
-#: ../src/verbs.cpp:2896
-msgctxt "ContextVerb"
-msgid "Tweak"
-msgstr ""
-
-#: ../src/verbs.cpp:2897
-msgid "Tweak objects by sculpting or painting"
-msgstr ""
-
-#: ../src/verbs.cpp:2898
-msgctxt "ContextVerb"
-msgid "Spray"
-msgstr ""
-
-#: ../src/verbs.cpp:2899
-msgid "Spray objects by sculpting or painting"
-msgstr ""
-
-#: ../src/verbs.cpp:2900
-msgctxt "ContextVerb"
-msgid "Rectangle"
-msgstr ""
-
-#: ../src/verbs.cpp:2901
-msgid "Create rectangles and squares"
-msgstr ""
-
-#: ../src/verbs.cpp:2902
-msgctxt "ContextVerb"
-msgid "3D Box"
-msgstr ""
-
-#: ../src/verbs.cpp:2903
-msgid "Create 3D boxes"
-msgstr ""
-
-#: ../src/verbs.cpp:2904
-msgctxt "ContextVerb"
-msgid "Ellipse"
-msgstr ""
-
-#: ../src/verbs.cpp:2905
-msgid "Create circles, ellipses, and arcs"
-msgstr ""
-
-#: ../src/verbs.cpp:2906
-msgctxt "ContextVerb"
-msgid "Star"
-msgstr ""
-
-#: ../src/verbs.cpp:2907
-msgid "Create stars and polygons"
-msgstr ""
-
-#: ../src/verbs.cpp:2908
-msgctxt "ContextVerb"
-msgid "Spiral"
-msgstr ""
-
-#: ../src/verbs.cpp:2909
-msgid "Create spirals"
-msgstr ""
-
-#: ../src/verbs.cpp:2910
-msgctxt "ContextVerb"
-msgid "Pencil"
-msgstr ""
-
-#: ../src/verbs.cpp:2911
-msgid "Draw freehand lines"
-msgstr ""
-
-#: ../src/verbs.cpp:2912
-msgctxt "ContextVerb"
-msgid "Pen"
-msgstr ""
-
-#: ../src/verbs.cpp:2913
-msgid "Draw Bezier curves and straight lines"
-msgstr ""
-
-#: ../src/verbs.cpp:2914
-msgctxt "ContextVerb"
-msgid "Calligraphy"
-msgstr ""
-
-#: ../src/verbs.cpp:2915
-msgid "Draw calligraphic or brush strokes"
-msgstr ""
-
-#: ../src/verbs.cpp:2917
-msgid "Create and edit text objects"
-msgstr ""
-
-#: ../src/verbs.cpp:2918
-msgctxt "ContextVerb"
-msgid "Gradient"
-msgstr ""
-
-#: ../src/verbs.cpp:2919
-msgid "Create and edit gradients"
-msgstr ""
-
-#: ../src/verbs.cpp:2920
-msgctxt "ContextVerb"
-msgid "Mesh"
-msgstr ""
-
-#: ../src/verbs.cpp:2921
-msgid "Create and edit meshes"
-msgstr ""
-
-#: ../src/verbs.cpp:2922
-msgctxt "ContextVerb"
-msgid "Zoom"
-msgstr ""
-
-#: ../src/verbs.cpp:2923
-msgid "Zoom in or out"
-msgstr ""
-
-#: ../src/verbs.cpp:2925
-msgid "Measurement tool"
-msgstr ""
-
-#: ../src/verbs.cpp:2926
-msgctxt "ContextVerb"
-msgid "Dropper"
 msgstr ""
 
 #: ../src/verbs.cpp:2928
 msgctxt "ContextVerb"
-msgid "Connector"
+msgid "Node Edit"
 msgstr ""
 
 #: ../src/verbs.cpp:2929
-msgid "Create diagram connectors"
+msgid "Edit paths by nodes"
+msgstr ""
+
+#: ../src/verbs.cpp:2930
+msgctxt "ContextVerb"
+msgid "Tweak"
+msgstr ""
+
+#: ../src/verbs.cpp:2931
+msgid "Tweak objects by sculpting or painting"
 msgstr ""
 
 #: ../src/verbs.cpp:2932
 msgctxt "ContextVerb"
-msgid "Paint Bucket"
+msgid "Spray"
 msgstr ""
 
 #: ../src/verbs.cpp:2933
-msgid "Fill bounded areas"
+msgid "Spray objects by sculpting or painting"
+msgstr ""
+
+#: ../src/verbs.cpp:2934
+msgctxt "ContextVerb"
+msgid "Rectangle"
+msgstr ""
+
+#: ../src/verbs.cpp:2935
+msgid "Create rectangles and squares"
 msgstr ""
 
 #: ../src/verbs.cpp:2936
 msgctxt "ContextVerb"
-msgid "LPE Edit"
+msgid "3D Box"
 msgstr ""
 
 #: ../src/verbs.cpp:2937
-msgid "Edit Path Effect parameters"
+msgid "Create 3D boxes"
 msgstr ""
 
 #: ../src/verbs.cpp:2938
 msgctxt "ContextVerb"
-msgid "Eraser"
+msgid "Ellipse"
 msgstr ""
 
 #: ../src/verbs.cpp:2939
-msgid "Erase existing paths"
+msgid "Create circles, ellipses, and arcs"
 msgstr ""
 
 #: ../src/verbs.cpp:2940
 msgctxt "ContextVerb"
-msgid "LPE Tool"
+msgid "Star"
 msgstr ""
 
 #: ../src/verbs.cpp:2941
+msgid "Create stars and polygons"
+msgstr ""
+
+#: ../src/verbs.cpp:2942
+msgctxt "ContextVerb"
+msgid "Spiral"
+msgstr ""
+
+#: ../src/verbs.cpp:2943
+msgid "Create spirals"
+msgstr ""
+
+#: ../src/verbs.cpp:2944
+msgctxt "ContextVerb"
+msgid "Pencil"
+msgstr ""
+
+#: ../src/verbs.cpp:2945
+msgid "Draw freehand lines"
+msgstr ""
+
+#: ../src/verbs.cpp:2946
+msgctxt "ContextVerb"
+msgid "Pen"
+msgstr ""
+
+#: ../src/verbs.cpp:2947
+msgid "Draw Bezier curves and straight lines"
+msgstr ""
+
+#: ../src/verbs.cpp:2948
+msgctxt "ContextVerb"
+msgid "Calligraphy"
+msgstr ""
+
+#: ../src/verbs.cpp:2949
+msgid "Draw calligraphic or brush strokes"
+msgstr ""
+
+#: ../src/verbs.cpp:2951
+msgid "Create and edit text objects"
+msgstr ""
+
+#: ../src/verbs.cpp:2952
+msgctxt "ContextVerb"
+msgid "Gradient"
+msgstr ""
+
+#: ../src/verbs.cpp:2953
+msgid "Create and edit gradients"
+msgstr ""
+
+#: ../src/verbs.cpp:2954
+msgctxt "ContextVerb"
+msgid "Mesh"
+msgstr ""
+
+#: ../src/verbs.cpp:2955
+msgid "Create and edit meshes"
+msgstr ""
+
+#: ../src/verbs.cpp:2956
+msgctxt "ContextVerb"
+msgid "Zoom"
+msgstr ""
+
+#: ../src/verbs.cpp:2957
+msgid "Zoom in or out"
+msgstr ""
+
+#: ../src/verbs.cpp:2959
+msgid "Measurement tool"
+msgstr ""
+
+#: ../src/verbs.cpp:2960
+msgctxt "ContextVerb"
+msgid "Dropper"
+msgstr ""
+
+#: ../src/verbs.cpp:2962
+msgctxt "ContextVerb"
+msgid "Connector"
+msgstr ""
+
+#: ../src/verbs.cpp:2963
+msgid "Create diagram connectors"
+msgstr ""
+
+#: ../src/verbs.cpp:2966
+msgctxt "ContextVerb"
+msgid "Paint Bucket"
+msgstr ""
+
+#: ../src/verbs.cpp:2967
+msgid "Fill bounded areas"
+msgstr ""
+
+#: ../src/verbs.cpp:2970
+msgctxt "ContextVerb"
+msgid "LPE Edit"
+msgstr ""
+
+#: ../src/verbs.cpp:2971
+msgid "Edit Path Effect parameters"
+msgstr ""
+
+#: ../src/verbs.cpp:2972
+msgctxt "ContextVerb"
+msgid "Eraser"
+msgstr ""
+
+#: ../src/verbs.cpp:2973
+msgid "Erase existing paths"
+msgstr ""
+
+#: ../src/verbs.cpp:2974
+msgctxt "ContextVerb"
+msgid "LPE Tool"
+msgstr ""
+
+#: ../src/verbs.cpp:2975
 msgid "Do geometric constructions"
 msgstr ""
 
 #. Tool prefs
-#: ../src/verbs.cpp:2943
+#: ../src/verbs.cpp:2977
 msgid "Selector Preferences"
 msgstr ""
 
-#: ../src/verbs.cpp:2944
+#: ../src/verbs.cpp:2978
 msgid "Open Preferences for the Selector tool"
 msgstr ""
 
-#: ../src/verbs.cpp:2945
+#: ../src/verbs.cpp:2979
 msgid "Node Tool Preferences"
 msgstr ""
 
-#: ../src/verbs.cpp:2946
+#: ../src/verbs.cpp:2980
 msgid "Open Preferences for the Node tool"
 msgstr ""
 
-#: ../src/verbs.cpp:2947
+#: ../src/verbs.cpp:2981
 msgid "Tweak Tool Preferences"
 msgstr ""
 
-#: ../src/verbs.cpp:2948
+#: ../src/verbs.cpp:2982
 msgid "Open Preferences for the Tweak tool"
 msgstr ""
 
-#: ../src/verbs.cpp:2949
+#: ../src/verbs.cpp:2983
 msgid "Spray Tool Preferences"
 msgstr ""
 
-#: ../src/verbs.cpp:2950
+#: ../src/verbs.cpp:2984
 msgid "Open Preferences for the Spray tool"
 msgstr ""
 
-#: ../src/verbs.cpp:2951
+#: ../src/verbs.cpp:2985
 msgid "Rectangle Preferences"
 msgstr ""
 
-#: ../src/verbs.cpp:2952
+#: ../src/verbs.cpp:2986
 msgid "Open Preferences for the Rectangle tool"
 msgstr ""
 
-#: ../src/verbs.cpp:2953
+#: ../src/verbs.cpp:2987
 msgid "3D Box Preferences"
 msgstr ""
 
-#: ../src/verbs.cpp:2954
+#: ../src/verbs.cpp:2988
 msgid "Open Preferences for the 3D Box tool"
 msgstr ""
 
-#: ../src/verbs.cpp:2955
+#: ../src/verbs.cpp:2989
 msgid "Ellipse Preferences"
 msgstr ""
 
-#: ../src/verbs.cpp:2956
+#: ../src/verbs.cpp:2990
 msgid "Open Preferences for the Ellipse tool"
 msgstr ""
 
-#: ../src/verbs.cpp:2957
+#: ../src/verbs.cpp:2991
 msgid "Star Preferences"
 msgstr ""
 
-#: ../src/verbs.cpp:2958
+#: ../src/verbs.cpp:2992
 msgid "Open Preferences for the Star tool"
 msgstr ""
 
-#: ../src/verbs.cpp:2959
+#: ../src/verbs.cpp:2993
 msgid "Spiral Preferences"
 msgstr ""
 
-#: ../src/verbs.cpp:2960
+#: ../src/verbs.cpp:2994
 msgid "Open Preferences for the Spiral tool"
 msgstr ""
 
-#: ../src/verbs.cpp:2961
+#: ../src/verbs.cpp:2995
 msgid "Pencil Preferences"
 msgstr ""
 
-#: ../src/verbs.cpp:2962
+#: ../src/verbs.cpp:2996
 msgid "Open Preferences for the Pencil tool"
 msgstr ""
 
-#: ../src/verbs.cpp:2963
+#: ../src/verbs.cpp:2997
 msgid "Pen Preferences"
 msgstr ""
 
-#: ../src/verbs.cpp:2964
+#: ../src/verbs.cpp:2998
 msgid "Open Preferences for the Pen tool"
 msgstr ""
 
-#: ../src/verbs.cpp:2965
+#: ../src/verbs.cpp:2999
 msgid "Calligraphic Preferences"
 msgstr ""
 
-#: ../src/verbs.cpp:2966
+#: ../src/verbs.cpp:3000
 msgid "Open Preferences for the Calligraphy tool"
 msgstr ""
 
-#: ../src/verbs.cpp:2967
+#: ../src/verbs.cpp:3001
 msgid "Text Preferences"
 msgstr ""
 
-#: ../src/verbs.cpp:2968
+#: ../src/verbs.cpp:3002
 msgid "Open Preferences for the Text tool"
 msgstr ""
 
-#: ../src/verbs.cpp:2969
+#: ../src/verbs.cpp:3003
 msgid "Gradient Preferences"
 msgstr ""
 
-#: ../src/verbs.cpp:2970
+#: ../src/verbs.cpp:3004
 msgid "Open Preferences for the Gradient tool"
 msgstr ""
 
-#: ../src/verbs.cpp:2971
+#: ../src/verbs.cpp:3005
 msgid "Mesh Preferences"
 msgstr ""
 
-#: ../src/verbs.cpp:2972
+#: ../src/verbs.cpp:3006
 msgid "Open Preferences for the Mesh tool"
 msgstr ""
 
-#: ../src/verbs.cpp:2973
+#: ../src/verbs.cpp:3007
 msgid "Zoom Preferences"
 msgstr ""
 
-#: ../src/verbs.cpp:2974
+#: ../src/verbs.cpp:3008
 msgid "Open Preferences for the Zoom tool"
 msgstr ""
 
-#: ../src/verbs.cpp:2975
+#: ../src/verbs.cpp:3009
 msgid "Measure Preferences"
 msgstr ""
 
-#: ../src/verbs.cpp:2976
+#: ../src/verbs.cpp:3010
 msgid "Open Preferences for the Measure tool"
 msgstr ""
 
-#: ../src/verbs.cpp:2977
+#: ../src/verbs.cpp:3011
 msgid "Dropper Preferences"
 msgstr ""
 
-#: ../src/verbs.cpp:2978
+#: ../src/verbs.cpp:3012
 msgid "Open Preferences for the Dropper tool"
 msgstr ""
 
-#: ../src/verbs.cpp:2979
+#: ../src/verbs.cpp:3013
 msgid "Connector Preferences"
 msgstr ""
 
-#: ../src/verbs.cpp:2980
+#: ../src/verbs.cpp:3014
 msgid "Open Preferences for the Connector tool"
 msgstr ""
 
-#: ../src/verbs.cpp:2983
+#: ../src/verbs.cpp:3017
 msgid "Paint Bucket Preferences"
 msgstr ""
 
-#: ../src/verbs.cpp:2984
+#: ../src/verbs.cpp:3018
 msgid "Open Preferences for the Paint Bucket tool"
 msgstr ""
 
-#: ../src/verbs.cpp:2987
+#: ../src/verbs.cpp:3021
 msgid "Eraser Preferences"
 msgstr ""
 
-#: ../src/verbs.cpp:2988
+#: ../src/verbs.cpp:3022
 msgid "Open Preferences for the Eraser tool"
 msgstr ""
 
-#: ../src/verbs.cpp:2989
+#: ../src/verbs.cpp:3023
 msgid "LPE Tool Preferences"
 msgstr ""
 
-#: ../src/verbs.cpp:2990
+#: ../src/verbs.cpp:3024
 msgid "Open Preferences for the LPETool tool"
 msgstr ""
 
 #. Zoom
-#: ../src/verbs.cpp:2993
+#: ../src/verbs.cpp:3027
 msgid "Zoom In"
 msgstr ""
 
-#: ../src/verbs.cpp:2993
+#: ../src/verbs.cpp:3027
 msgid "Zoom in"
 msgstr ""
 
-#: ../src/verbs.cpp:2994
+#: ../src/verbs.cpp:3028
 msgid "Zoom Out"
 msgstr ""
 
-#: ../src/verbs.cpp:2994
+#: ../src/verbs.cpp:3028
 msgid "Zoom out"
 msgstr ""
 
-#: ../src/verbs.cpp:2995
+#: ../src/verbs.cpp:3029
 msgid "Nex_t Zoom"
 msgstr ""
 
-#: ../src/verbs.cpp:2995
+#: ../src/verbs.cpp:3029
 msgid "Next zoom (from the history of zooms)"
 msgstr ""
 
-#: ../src/verbs.cpp:2997
+#: ../src/verbs.cpp:3031
 msgid "Pre_vious Zoom"
 msgstr ""
 
-#: ../src/verbs.cpp:2997
+#: ../src/verbs.cpp:3031
 msgid "Previous zoom (from the history of zooms)"
 msgstr ""
 
-#: ../src/verbs.cpp:2999
+#: ../src/verbs.cpp:3033
 msgid "Zoom 1:_1"
 msgstr ""
 
-#: ../src/verbs.cpp:2999
+#: ../src/verbs.cpp:3033
 msgid "Zoom to 1:1"
 msgstr ""
 
-#: ../src/verbs.cpp:3001
+#: ../src/verbs.cpp:3035
 msgid "Zoom 1:_2"
 msgstr ""
 
-#: ../src/verbs.cpp:3001
+#: ../src/verbs.cpp:3035
 msgid "Zoom to 1:2"
 msgstr ""
 
-#: ../src/verbs.cpp:3003
+#: ../src/verbs.cpp:3037
 msgid "_Zoom 2:1"
 msgstr ""
 
-#: ../src/verbs.cpp:3003
+#: ../src/verbs.cpp:3037
 msgid "Zoom to 2:1"
 msgstr ""
 
-#: ../src/verbs.cpp:3006
+#: ../src/verbs.cpp:3040
 msgid "Zoom to fit page in window"
 msgstr ""
 
-#: ../src/verbs.cpp:3007
+#: ../src/verbs.cpp:3041
 msgid "Page _Width"
 msgstr ""
 
-#: ../src/verbs.cpp:3008
+#: ../src/verbs.cpp:3042
 msgid "Zoom to fit page width in window"
 msgstr ""
 
-#: ../src/verbs.cpp:3010
+#: ../src/verbs.cpp:3044
 msgid "Zoom to fit drawing in window"
 msgstr ""
 
-#: ../src/verbs.cpp:3012
+#: ../src/verbs.cpp:3046
 msgid "Zoom to fit selection in window"
 msgstr ""
 
-#: ../src/verbs.cpp:3014
+#: ../src/verbs.cpp:3048
 msgid "Rotate Clockwise"
 msgstr ""
 
-#: ../src/verbs.cpp:3014
+#: ../src/verbs.cpp:3048
 msgid "Rotate canvas clockwise"
 msgstr ""
 
-#: ../src/verbs.cpp:3015
+#: ../src/verbs.cpp:3049
 msgid "Rotate Counter-Clockwise"
 msgstr ""
 
-#: ../src/verbs.cpp:3015
+#: ../src/verbs.cpp:3049
 msgid "Rotate canvas counter-clockwise"
 msgstr ""
 
-#: ../src/verbs.cpp:3016
-msgid "Rotate Zero"
+#: ../src/verbs.cpp:3050
+msgid "Reset Rotation"
 msgstr ""
 
-#: ../src/verbs.cpp:3016
+#: ../src/verbs.cpp:3050
 msgid "Reset canvas rotation to zero"
 msgstr ""
 
-#: ../src/verbs.cpp:3018
-msgid "Flip Horizontal"
+#: ../src/verbs.cpp:3052
+msgid "Flip Horizontally"
 msgstr ""
 
-#: ../src/verbs.cpp:3018
+#: ../src/verbs.cpp:3052
 msgid "Flip canvas horizontally"
 msgstr ""
 
-#: ../src/verbs.cpp:3019
-msgid "Flip Vertical"
+#: ../src/verbs.cpp:3053
+msgid "Flip Vertically"
 msgstr ""
 
-#: ../src/verbs.cpp:3019
+#: ../src/verbs.cpp:3053
 msgid "Flip canvas vertically"
 msgstr ""
 
-#: ../src/verbs.cpp:3020
-msgid "Flip None"
+#: ../src/verbs.cpp:3054
+msgid "Reset Flip"
 msgstr ""
 
-#: ../src/verbs.cpp:3020
+#: ../src/verbs.cpp:3054
 msgid "Undo any flip"
 msgstr ""
 
 #. WHY ARE THE FOLLOWING ZoomVerbs???
 #. View
-#: ../src/verbs.cpp:3026
+#: ../src/verbs.cpp:3060
 msgid "_Rulers"
 msgstr ""
 
-#: ../src/verbs.cpp:3026
+#: ../src/verbs.cpp:3060
 msgid "Show or hide the canvas rulers"
 msgstr ""
 
-#: ../src/verbs.cpp:3027
+#: ../src/verbs.cpp:3061
 msgid "Scroll_bars"
 msgstr ""
 
-#: ../src/verbs.cpp:3027
+#: ../src/verbs.cpp:3061
 msgid "Show or hide the canvas scrollbars"
 msgstr ""
 
-#: ../src/verbs.cpp:3028
+#: ../src/verbs.cpp:3062
 msgid "Page _Grid"
 msgstr ""
 
-#: ../src/verbs.cpp:3028
+#: ../src/verbs.cpp:3062
 msgid "Show or hide the page grid"
 msgstr ""
 
-#: ../src/verbs.cpp:3029
+#: ../src/verbs.cpp:3063
 msgid "G_uides"
 msgstr ""
 
-#: ../src/verbs.cpp:3029
+#: ../src/verbs.cpp:3063
 msgid "Show or hide guides (drag from a ruler to create a guide)"
 msgstr ""
 
-#: ../src/verbs.cpp:3030
+#: ../src/verbs.cpp:3064
 msgid "Enable snapping"
 msgstr ""
 
-#: ../src/verbs.cpp:3031
+#: ../src/verbs.cpp:3065
 msgid "_Commands Bar"
 msgstr ""
 
-#: ../src/verbs.cpp:3031
+#: ../src/verbs.cpp:3065
 msgid "Show or hide the Commands bar (under the menu)"
 msgstr ""
 
-#: ../src/verbs.cpp:3032
+#: ../src/verbs.cpp:3066
 msgid "Sn_ap Controls Bar"
 msgstr ""
 
-#: ../src/verbs.cpp:3032
+#: ../src/verbs.cpp:3066
 msgid "Show or hide the snapping controls"
 msgstr ""
 
-#: ../src/verbs.cpp:3033
+#: ../src/verbs.cpp:3067
 msgid "T_ool Controls Bar"
 msgstr ""
 
-#: ../src/verbs.cpp:3033
+#: ../src/verbs.cpp:3067
 msgid "Show or hide the Tool Controls bar"
 msgstr ""
 
-#: ../src/verbs.cpp:3034
+#: ../src/verbs.cpp:3068
 msgid "_Toolbox"
 msgstr ""
 
-#: ../src/verbs.cpp:3034
+#: ../src/verbs.cpp:3068
 msgid "Show or hide the main toolbox (on the left)"
 msgstr ""
 
-#: ../src/verbs.cpp:3035
+#: ../src/verbs.cpp:3069
 msgid "_Palette"
 msgstr ""
 
-#: ../src/verbs.cpp:3035
+#: ../src/verbs.cpp:3069
 msgid "Show or hide the color palette"
 msgstr ""
 
-#: ../src/verbs.cpp:3036
+#: ../src/verbs.cpp:3070
 msgid "_Statusbar"
 msgstr ""
 
-#: ../src/verbs.cpp:3036
+#: ../src/verbs.cpp:3070
 msgid "Show or hide the statusbar (at the bottom of the window)"
 msgstr ""
 
-#: ../src/verbs.cpp:3038
+#: ../src/verbs.cpp:3072
 msgid "_Fullscreen"
 msgstr ""
 
-#: ../src/verbs.cpp:3038 ../src/verbs.cpp:3040
+#: ../src/verbs.cpp:3072 ../src/verbs.cpp:3074
 msgid "Stretch this document window to full screen"
 msgstr ""
 
-#: ../src/verbs.cpp:3040
+#: ../src/verbs.cpp:3074
 msgid "Fullscreen & Focus Mode"
 msgstr ""
 
-#: ../src/verbs.cpp:3042
+#: ../src/verbs.cpp:3076
 msgid "Toggle _Focus Mode"
 msgstr ""
 
-#: ../src/verbs.cpp:3042
+#: ../src/verbs.cpp:3076
 msgid "Remove excess toolbars to focus on drawing"
 msgstr ""
 
-#: ../src/verbs.cpp:3044
+#: ../src/verbs.cpp:3078
 msgid "Duplic_ate Window"
 msgstr ""
 
-#: ../src/verbs.cpp:3044
+#: ../src/verbs.cpp:3078
 msgid "Open a new window with the same document"
 msgstr ""
 
-#: ../src/verbs.cpp:3046
+#: ../src/verbs.cpp:3080
 msgid "_New View Preview"
 msgstr ""
 
-#: ../src/verbs.cpp:3047
+#: ../src/verbs.cpp:3081
 msgid "New View Preview"
 msgstr ""
 
 #. "view_new_preview"
-#: ../src/verbs.cpp:3049 ../src/verbs.cpp:3057
+#: ../src/verbs.cpp:3083 ../src/verbs.cpp:3091
 msgid "_Normal"
 msgstr ""
 
-#: ../src/verbs.cpp:3050
+#: ../src/verbs.cpp:3084
 msgid "Switch to normal display mode"
 msgstr ""
 
-#: ../src/verbs.cpp:3051
+#: ../src/verbs.cpp:3085
 msgid "No _Filters"
 msgstr ""
 
-#: ../src/verbs.cpp:3052
+#: ../src/verbs.cpp:3086
 msgid "Switch to normal display without filters"
 msgstr ""
 
-#: ../src/verbs.cpp:3053
+#: ../src/verbs.cpp:3087
 msgid "_Outline"
 msgstr ""
 
-#: ../src/verbs.cpp:3054
+#: ../src/verbs.cpp:3088
 msgid "Switch to outline (wireframe) display mode"
 msgstr ""
 
 #. new ZoomVerb(SP_VERB_VIEW_COLOR_MODE_PRINT_COLORS_PREVIEW, "ViewColorModePrintColorsPreview", N_("_Print Colors Preview"),
 #. N_("Switch to print colors preview mode"), NULL),
-#: ../src/verbs.cpp:3055 ../src/verbs.cpp:3063
+#: ../src/verbs.cpp:3089 ../src/verbs.cpp:3097
 msgid "_Toggle"
 msgstr ""
 
-#: ../src/verbs.cpp:3056
+#: ../src/verbs.cpp:3090
 msgid "Toggle between normal and outline display modes"
 msgstr ""
 
-#: ../src/verbs.cpp:3058
+#: ../src/verbs.cpp:3092
 msgid "Switch to normal color display mode"
 msgstr ""
 
-#: ../src/verbs.cpp:3059
+#: ../src/verbs.cpp:3093
 msgid "_Grayscale"
 msgstr ""
 
-#: ../src/verbs.cpp:3060
+#: ../src/verbs.cpp:3094
 msgid "Switch to grayscale display mode"
 msgstr ""
 
-#: ../src/verbs.cpp:3064
+#: ../src/verbs.cpp:3098
 msgid "Toggle between normal and grayscale color display modes"
 msgstr ""
 
-#: ../src/verbs.cpp:3066
+#: ../src/verbs.cpp:3100
 msgid "Color-managed view"
 msgstr ""
 
-#: ../src/verbs.cpp:3067
+#: ../src/verbs.cpp:3101
 msgid "Toggle color-managed display for this document window"
 msgstr ""
 
-#: ../src/verbs.cpp:3069
+#: ../src/verbs.cpp:3103
 msgid "Ico_n Preview..."
 msgstr ""
 
-#: ../src/verbs.cpp:3070
+#: ../src/verbs.cpp:3104
 msgid "Open a window to preview objects at different icon resolutions"
 msgstr ""
 
 #. Dialogs
-#: ../src/verbs.cpp:3073
+#: ../src/verbs.cpp:3107
 msgid "Prototype..."
 msgstr ""
 
-#: ../src/verbs.cpp:3074
+#: ../src/verbs.cpp:3108
 msgid "Prototype Dialog"
 msgstr ""
 
-#: ../src/verbs.cpp:3075
+#: ../src/verbs.cpp:3109
 msgid "P_references..."
 msgstr ""
 
-#: ../src/verbs.cpp:3076
+#: ../src/verbs.cpp:3110
 msgid "Edit global Inkscape preferences"
 msgstr ""
 
-#: ../src/verbs.cpp:3077
+#: ../src/verbs.cpp:3111
 msgid "_Document Properties..."
 msgstr ""
 
-#: ../src/verbs.cpp:3078
+#: ../src/verbs.cpp:3112
 msgid "Edit properties of this document (to be saved with the document)"
 msgstr ""
 
-#: ../src/verbs.cpp:3079
+#: ../src/verbs.cpp:3113
 msgid "Document _Metadata..."
 msgstr ""
 
-#: ../src/verbs.cpp:3080
+#: ../src/verbs.cpp:3114
 msgid "Edit document metadata (to be saved with the document)"
 msgstr ""
 
-#: ../src/verbs.cpp:3082
+#: ../src/verbs.cpp:3116
 msgid ""
 "Edit objects' colors, gradients, arrowheads, and other fill and stroke "
 "properties..."
 msgstr ""
 
 #. FIXME: Probably better to either use something from the icon naming spec or ship our own "select-font" icon
-#: ../src/verbs.cpp:3084
+#: ../src/verbs.cpp:3118
 msgid "Gl_yphs..."
 msgstr ""
 
-#: ../src/verbs.cpp:3085
+#: ../src/verbs.cpp:3119
 msgid "Select characters from a glyphs palette"
 msgstr ""
 
 #. FIXME: Probably better to either use something from the icon naming spec or ship our own "select-color" icon
 #. TRANSLATORS: "Swatches" means: color samples
-#: ../src/verbs.cpp:3088
+#: ../src/verbs.cpp:3122
 msgid "S_watches..."
 msgstr ""
 
-#: ../src/verbs.cpp:3089
+#: ../src/verbs.cpp:3123
 msgid "Select colors from a swatches palette"
 msgstr ""
 
-#: ../src/verbs.cpp:3090
+#: ../src/verbs.cpp:3124
 msgid "S_ymbols..."
 msgstr ""
 
-#: ../src/verbs.cpp:3091
+#: ../src/verbs.cpp:3125
 msgid "Select symbol from a symbols palette"
 msgstr ""
 
-#: ../src/verbs.cpp:3092
+#: ../src/verbs.cpp:3126
 msgid "Transfor_m..."
 msgstr ""
 
-#: ../src/verbs.cpp:3093
+#: ../src/verbs.cpp:3127
 msgid "Precisely control objects' transformations"
 msgstr ""
 
-#: ../src/verbs.cpp:3094
+#: ../src/verbs.cpp:3128
 msgid "_Align and Distribute..."
 msgstr ""
 
-#: ../src/verbs.cpp:3095
+#: ../src/verbs.cpp:3129
 msgid "Align and distribute objects"
 msgstr ""
 
-#: ../src/verbs.cpp:3096
+#: ../src/verbs.cpp:3130
 msgid "_Spray options..."
 msgstr ""
 
-#: ../src/verbs.cpp:3097
+#: ../src/verbs.cpp:3131
 msgid "Some options for the spray"
 msgstr ""
 
-#: ../src/verbs.cpp:3098
+#: ../src/verbs.cpp:3132
 msgid "Undo _History..."
 msgstr ""
 
-#: ../src/verbs.cpp:3099
+#: ../src/verbs.cpp:3133
 msgid "Undo History"
 msgstr ""
 
-#: ../src/verbs.cpp:3101
+#: ../src/verbs.cpp:3135
 msgid "View and select font family, font size and other text properties"
 msgstr ""
 
-#: ../src/verbs.cpp:3102
+#: ../src/verbs.cpp:3136
 msgid "_XML Editor..."
 msgstr ""
 
-#: ../src/verbs.cpp:3103
+#: ../src/verbs.cpp:3137
 msgid "View and edit the XML tree of the document"
 msgstr ""
 
-#: ../src/verbs.cpp:3104
+#: ../src/verbs.cpp:3138
 msgid "_Find/Replace..."
 msgstr ""
 
-#: ../src/verbs.cpp:3105
+#: ../src/verbs.cpp:3139
 msgid "Find objects in document"
 msgstr ""
 
-#: ../src/verbs.cpp:3106
+#: ../src/verbs.cpp:3140
 msgid "Find and _Replace Text..."
 msgstr ""
 
-#: ../src/verbs.cpp:3107
+#: ../src/verbs.cpp:3141
 msgid "Find and replace text in document"
 msgstr ""
 
-#: ../src/verbs.cpp:3109
+#: ../src/verbs.cpp:3143
 msgid "Check spelling of text in document"
 msgstr ""
 
-#: ../src/verbs.cpp:3110
+#: ../src/verbs.cpp:3144
 msgid "_Messages..."
 msgstr ""
 
-#: ../src/verbs.cpp:3111
+#: ../src/verbs.cpp:3145
 msgid "View debug messages"
 msgstr ""
 
-#: ../src/verbs.cpp:3112
+#: ../src/verbs.cpp:3146
 msgid "Show/Hide D_ialogs"
 msgstr ""
 
-#: ../src/verbs.cpp:3113
+#: ../src/verbs.cpp:3147
 msgid "Show or hide all open dialogs"
 msgstr ""
 
-#: ../src/verbs.cpp:3114
+#: ../src/verbs.cpp:3148
 msgid "Create Tiled Clones..."
 msgstr ""
 
-#: ../src/verbs.cpp:3115
+#: ../src/verbs.cpp:3149
 msgid ""
 "Create multiple clones of selected object, arranging them into a pattern or "
 "scattering"
 msgstr ""
 
-#: ../src/verbs.cpp:3116
+#: ../src/verbs.cpp:3150
 msgid "_Object attributes..."
 msgstr ""
 
-#: ../src/verbs.cpp:3117
+#: ../src/verbs.cpp:3151
 msgid "Edit the object attributes..."
 msgstr ""
 
-#: ../src/verbs.cpp:3119
+#: ../src/verbs.cpp:3153
 msgid "Edit the ID, locked and visible status, and other object properties"
 msgstr ""
 
-#: ../src/verbs.cpp:3120
+#: ../src/verbs.cpp:3154
 msgid "_Input Devices..."
 msgstr ""
 
-#: ../src/verbs.cpp:3121
+#: ../src/verbs.cpp:3155
 msgid "Configure extended input devices, such as a graphics tablet"
 msgstr ""
 
-#: ../src/verbs.cpp:3122
+#: ../src/verbs.cpp:3156
 msgid "_Extensions..."
 msgstr ""
 
-#: ../src/verbs.cpp:3123
+#: ../src/verbs.cpp:3157
 msgid "Query information about extensions"
 msgstr ""
 
-#: ../src/verbs.cpp:3124
+#: ../src/verbs.cpp:3158
 msgid "Layer_s..."
 msgstr ""
 
-#: ../src/verbs.cpp:3125
+#: ../src/verbs.cpp:3159
 msgid "View Layers"
 msgstr ""
 
-#: ../src/verbs.cpp:3126
+#: ../src/verbs.cpp:3160
 msgid "Object_s..."
 msgstr ""
 
-#: ../src/verbs.cpp:3127
+#: ../src/verbs.cpp:3161
 msgid "View Objects"
 msgstr ""
 
-#: ../src/verbs.cpp:3128
+#: ../src/verbs.cpp:3162
 msgid "Selection se_ts..."
 msgstr ""
 
-#: ../src/verbs.cpp:3129
+#: ../src/verbs.cpp:3163
 msgid "View Tags"
 msgstr ""
 
-#: ../src/verbs.cpp:3130
+#: ../src/verbs.cpp:3164
 msgid "Style Dialog..."
 msgstr ""
 
-#: ../src/verbs.cpp:3131
+#: ../src/verbs.cpp:3165
 msgid "View Style Dialog"
 msgstr ""
 
-#: ../src/verbs.cpp:3132
+#: ../src/verbs.cpp:3166
 msgid "Css Dialog..."
 msgstr ""
 
-#: ../src/verbs.cpp:3133
+#: ../src/verbs.cpp:3167
 msgid "View Css Dialog"
 msgstr ""
 
-#: ../src/verbs.cpp:3134
+#: ../src/verbs.cpp:3168
 msgid "Path E_ffects ..."
 msgstr ""
 
-#: ../src/verbs.cpp:3135
+#: ../src/verbs.cpp:3169
 msgid "Manage, edit, and apply path effects"
 msgstr ""
 
-#: ../src/verbs.cpp:3136
+#: ../src/verbs.cpp:3170
 msgid "Filter _Editor..."
 msgstr ""
 
-#: ../src/verbs.cpp:3137
+#: ../src/verbs.cpp:3171
 msgid "Manage, edit, and apply SVG filters"
 msgstr ""
 
-#: ../src/verbs.cpp:3138
+#: ../src/verbs.cpp:3172
 msgid "SVG Font Editor..."
 msgstr ""
 
-#: ../src/verbs.cpp:3139
+#: ../src/verbs.cpp:3173
 msgid "Edit SVG fonts"
 msgstr ""
 
-#: ../src/verbs.cpp:3140
+#: ../src/verbs.cpp:3174
 msgid "Print Colors..."
 msgstr ""
 
-#: ../src/verbs.cpp:3141
+#: ../src/verbs.cpp:3175
 msgid ""
 "Select which color separations to render in Print Colors Preview rendermode"
 msgstr ""
 
-#: ../src/verbs.cpp:3142
+#: ../src/verbs.cpp:3176
 msgid "_Export PNG Image..."
 msgstr ""
 
-#: ../src/verbs.cpp:3143
+#: ../src/verbs.cpp:3177
 msgid "Export this document or a selection as a PNG image"
 msgstr ""
 
 #. Help
-#: ../src/verbs.cpp:3145
+#: ../src/verbs.cpp:3179
 msgid "About E_xtensions"
 msgstr ""
 
-#: ../src/verbs.cpp:3146
+#: ../src/verbs.cpp:3180
 msgid "Information on Inkscape extensions"
 msgstr ""
 
-#: ../src/verbs.cpp:3147
+#: ../src/verbs.cpp:3181
 msgid "About _Memory"
 msgstr ""
 
-#: ../src/verbs.cpp:3148
+#: ../src/verbs.cpp:3182
 msgid "Memory usage information"
 msgstr ""
 
-#: ../src/verbs.cpp:3149
+#: ../src/verbs.cpp:3183
 msgid "_About Inkscape"
 msgstr ""
 
-#: ../src/verbs.cpp:3150
+#: ../src/verbs.cpp:3184
 msgid "Inkscape version, authors, license"
 msgstr ""
 
 #. new HelpVerb(SP_VERB_SHOW_LICENSE, "ShowLicense", N_("_License"),
 #. N_("Distribution terms"), /*"show_license"*/"inkscape_options"),
 #. Tutorials
-#: ../src/verbs.cpp:3155
+#: ../src/verbs.cpp:3189
 msgid "Inkscape: _Basic"
 msgstr ""
 
-#: ../src/verbs.cpp:3156
+#: ../src/verbs.cpp:3190
 msgid "Getting started with Inkscape"
 msgstr ""
 
 #. "tutorial_basic"
-#: ../src/verbs.cpp:3157
+#: ../src/verbs.cpp:3191
 msgid "Inkscape: _Shapes"
 msgstr ""
 
-#: ../src/verbs.cpp:3158
+#: ../src/verbs.cpp:3192
 msgid "Using shape tools to create and edit shapes"
 msgstr ""
 
-#: ../src/verbs.cpp:3159
+#: ../src/verbs.cpp:3193
 msgid "Inkscape: _Advanced"
 msgstr ""
 
-#: ../src/verbs.cpp:3160
+#: ../src/verbs.cpp:3194
 msgid "Advanced Inkscape topics"
 msgstr ""
 
 #. TRANSLATORS: "to trace" means "to convert a bitmap to vector graphics" (to vectorize)
-#: ../src/verbs.cpp:3164
+#: ../src/verbs.cpp:3198
 msgid "Inkscape: T_racing"
 msgstr ""
 
-#: ../src/verbs.cpp:3165
+#: ../src/verbs.cpp:3199
 msgid "Using bitmap tracing"
 msgstr ""
 
-#: ../src/verbs.cpp:3168
+#: ../src/verbs.cpp:3202
 msgid "Inkscape: Tracing Pixel Art"
 msgstr ""
 
-#: ../src/verbs.cpp:3169
+#: ../src/verbs.cpp:3203
 msgid "Using Trace Pixel Art dialog"
 msgstr ""
 
-#: ../src/verbs.cpp:3170
+#: ../src/verbs.cpp:3204
 msgid "Inkscape: _Calligraphy"
 msgstr ""
 
-#: ../src/verbs.cpp:3171
+#: ../src/verbs.cpp:3205
 msgid "Using the Calligraphy pen tool"
 msgstr ""
 
-#: ../src/verbs.cpp:3172
+#: ../src/verbs.cpp:3206
 msgid "Inkscape: _Interpolate"
 msgstr ""
 
-#: ../src/verbs.cpp:3173
+#: ../src/verbs.cpp:3207
 msgid "Using the interpolate extension"
 msgstr ""
 
 #. "tutorial_interpolate"
-#: ../src/verbs.cpp:3174
+#: ../src/verbs.cpp:3208
 msgid "_Elements of Design"
 msgstr ""
 
-#: ../src/verbs.cpp:3175
+#: ../src/verbs.cpp:3209
 msgid "Principles of design in the tutorial form"
 msgstr ""
 
 #. "tutorial_design"
-#: ../src/verbs.cpp:3176
+#: ../src/verbs.cpp:3210
 msgid "_Tips and Tricks"
 msgstr ""
 
-#: ../src/verbs.cpp:3177
+#: ../src/verbs.cpp:3211
 msgid "Miscellaneous tips and tricks"
 msgstr ""
 
 #. "tutorial_tips"
 #. Effect -- renamed Extension
-#: ../src/verbs.cpp:3180
+#: ../src/verbs.cpp:3214
 msgid "Previous Exte_nsion"
 msgstr ""
 
-#: ../src/verbs.cpp:3181
+#: ../src/verbs.cpp:3215
 msgid "Repeat the last extension with the same settings"
 msgstr ""
 
-#: ../src/verbs.cpp:3182
+#: ../src/verbs.cpp:3216
 msgid "_Previous Extension Settings..."
 msgstr ""
 
-#: ../src/verbs.cpp:3183
+#: ../src/verbs.cpp:3217
 msgid "Repeat the last extension with new settings"
 msgstr ""
 
-#: ../src/verbs.cpp:3187
+#: ../src/verbs.cpp:3221
 msgid "Fit the page to the current selection"
 msgstr ""
 
-#: ../src/verbs.cpp:3189
+#: ../src/verbs.cpp:3223
 msgid "Fit the page to the drawing"
 msgstr ""
 
-#: ../src/verbs.cpp:3190
+#: ../src/verbs.cpp:3224
 msgid "_Resize Page to Selection"
 msgstr ""
 
-#: ../src/verbs.cpp:3191
+#: ../src/verbs.cpp:3225
 msgid ""
 "Fit the page to the current selection or the drawing if there is no selection"
 msgstr ""
 
-#: ../src/verbs.cpp:3195
+#: ../src/verbs.cpp:3229
 msgid "Unlock All in All Layers"
 msgstr ""
 
-#: ../src/verbs.cpp:3197
+#: ../src/verbs.cpp:3231
 msgid "Unhide All"
 msgstr ""
 
-#: ../src/verbs.cpp:3199
+#: ../src/verbs.cpp:3233
 msgid "Unhide All in All Layers"
 msgstr ""
 
-#: ../src/verbs.cpp:3203
+#: ../src/verbs.cpp:3237
 msgid "Link an ICC color profile"
 msgstr ""
 
-#: ../src/verbs.cpp:3204
+#: ../src/verbs.cpp:3238
 msgid "Remove Color Profile"
 msgstr ""
 
-#: ../src/verbs.cpp:3205
+#: ../src/verbs.cpp:3239
 msgid "Remove a linked ICC color profile"
 msgstr ""
 
-#: ../src/verbs.cpp:3208
+#: ../src/verbs.cpp:3242
 msgid "Add External Script"
 msgstr ""
 
-#: ../src/verbs.cpp:3208
+#: ../src/verbs.cpp:3242
 msgid "Add an external script"
 msgstr ""
 
-#: ../src/verbs.cpp:3210
+#: ../src/verbs.cpp:3244
 msgid "Add Embedded Script"
 msgstr ""
 
-#: ../src/verbs.cpp:3210
+#: ../src/verbs.cpp:3244
 msgid "Add an embedded script"
 msgstr ""
 
-#: ../src/verbs.cpp:3212
+#: ../src/verbs.cpp:3246
 msgid "Edit Embedded Script"
 msgstr ""
 
-#: ../src/verbs.cpp:3212
+#: ../src/verbs.cpp:3246
 msgid "Edit an embedded script"
 msgstr ""
 
-#: ../src/verbs.cpp:3214
+#: ../src/verbs.cpp:3248
 msgid "Remove External Script"
 msgstr ""
 
-#: ../src/verbs.cpp:3214
+#: ../src/verbs.cpp:3248
 msgid "Remove an external script"
 msgstr ""
 
-#: ../src/verbs.cpp:3216
+#: ../src/verbs.cpp:3250
 msgid "Remove Embedded Script"
 msgstr ""
 
-#: ../src/verbs.cpp:3216
+#: ../src/verbs.cpp:3250
 msgid "Remove an embedded script"
 msgstr ""
 
-#: ../src/verbs.cpp:3238 ../src/verbs.cpp:3239
+#: ../src/verbs.cpp:3272 ../src/verbs.cpp:3273
 msgid "Center on horizontal and vertical axis"
 msgstr ""
 
-#: ../src/widgets/arc-toolbar.cpp:128
+#: ../src/widgets/arc-toolbar.cpp:140
+msgid "Change arc"
+msgstr ""
+
+#: ../src/widgets/arc-toolbar.cpp:206
 msgid "Arc: Change start/end"
 msgstr ""
 
-#: ../src/widgets/arc-toolbar.cpp:198
+#: ../src/widgets/arc-toolbar.cpp:274
 msgid "Arc: Changed arc type"
 msgstr ""
 
-#: ../src/widgets/arc-toolbar.cpp:295 ../src/widgets/arc-toolbar.cpp:325
-#: ../src/widgets/rect-toolbar.cpp:256 ../src/widgets/rect-toolbar.cpp:295
-#: ../src/widgets/spiral-toolbar.cpp:207 ../src/widgets/spiral-toolbar.cpp:231
-#: ../src/widgets/star-toolbar.cpp:380 ../src/widgets/star-toolbar.cpp:442
+#: ../src/widgets/arc-toolbar.cpp:409 ../src/widgets/arc-toolbar.cpp:448
+#: ../src/widgets/rect-toolbar.cpp:262 ../src/widgets/rect-toolbar.cpp:301
+#: ../src/widgets/spiral-toolbar.cpp:213 ../src/widgets/spiral-toolbar.cpp:237
+#: ../src/widgets/star-toolbar.cpp:380 ../src/widgets/star-toolbar.cpp:454
 msgid "<b>New:</b>"
 msgstr ""
 
 #. FIXME: implement averaging of all parameters for multiple selected
 #. gtk_label_set_markup(GTK_LABEL(l), _("<b>Average:</b>"));
-#: ../src/widgets/arc-toolbar.cpp:298 ../src/widgets/arc-toolbar.cpp:309
-#: ../src/widgets/rect-toolbar.cpp:264 ../src/widgets/rect-toolbar.cpp:282
-#: ../src/widgets/spiral-toolbar.cpp:209 ../src/widgets/spiral-toolbar.cpp:220
+#: ../src/widgets/arc-toolbar.cpp:412 ../src/widgets/arc-toolbar.cpp:429
+#: ../src/widgets/rect-toolbar.cpp:270 ../src/widgets/rect-toolbar.cpp:288
+#: ../src/widgets/spiral-toolbar.cpp:215 ../src/widgets/spiral-toolbar.cpp:226
 #: ../src/widgets/star-toolbar.cpp:382
 msgid "<b>Change:</b>"
 msgstr ""
 
-#: ../src/widgets/arc-toolbar.cpp:334
+#: ../src/widgets/arc-toolbar.cpp:459 ../src/widgets/rect-toolbar.cpp:353
+msgid "Horizontal radius"
+msgstr ""
+
+#: ../src/widgets/arc-toolbar.cpp:459 ../src/widgets/rect-toolbar.cpp:353
+msgid "Rx:"
+msgstr ""
+
+#: ../src/widgets/arc-toolbar.cpp:459
+msgid "Horizontal radius of the circle, ellipse, or arc"
+msgstr ""
+
+#: ../src/widgets/arc-toolbar.cpp:476 ../src/widgets/rect-toolbar.cpp:368
+msgid "Vertical radius"
+msgstr ""
+
+#: ../src/widgets/arc-toolbar.cpp:476 ../src/widgets/rect-toolbar.cpp:368
+msgid "Ry:"
+msgstr ""
+
+#: ../src/widgets/arc-toolbar.cpp:476
+msgid "Vertical radius of the circle, ellipse, or arc"
+msgstr ""
+
+#. Add the units menu.
+#: ../src/widgets/arc-toolbar.cpp:490 ../src/widgets/lpe-toolbar.cpp:380
+#: ../src/widgets/node-toolbar.cpp:611
+#: ../src/widgets/paintbucket-toolbar.cpp:166
+#: ../src/widgets/rect-toolbar.cpp:380 ../src/widgets/select-toolbar.cpp:520
+#: ../src/widgets/text-toolbar.cpp:2322
+msgid "Units"
+msgstr ""
+
+#: ../src/widgets/arc-toolbar.cpp:497
 msgid "Start:"
 msgstr ""
 
-#: ../src/widgets/arc-toolbar.cpp:335
+#: ../src/widgets/arc-toolbar.cpp:498
 msgid "The angle (in degrees) from the horizontal to the arc's start point"
 msgstr ""
 
-#: ../src/widgets/arc-toolbar.cpp:347
+#: ../src/widgets/arc-toolbar.cpp:510
 msgid "End:"
 msgstr ""
 
-#: ../src/widgets/arc-toolbar.cpp:348
+#: ../src/widgets/arc-toolbar.cpp:511
 msgid "The angle (in degrees) from the horizontal to the arc's end point"
 msgstr ""
 
-#: ../src/widgets/arc-toolbar.cpp:365
+#: ../src/widgets/arc-toolbar.cpp:530
 msgid "Switch to slice (closed shape with two radii)"
 msgstr ""
 
-#: ../src/widgets/arc-toolbar.cpp:371
+#: ../src/widgets/arc-toolbar.cpp:535
 msgid "Arc (Open)"
 msgstr ""
 
-#: ../src/widgets/arc-toolbar.cpp:372
+#: ../src/widgets/arc-toolbar.cpp:536
 msgid "Switch to arc (unclosed shape)"
 msgstr ""
 
-#: ../src/widgets/arc-toolbar.cpp:379
+#: ../src/widgets/arc-toolbar.cpp:542
 msgid "Switch to chord (closed shape)"
 msgstr ""
 
-#: ../src/widgets/arc-toolbar.cpp:402
+#: ../src/widgets/arc-toolbar.cpp:567
 msgid "Make whole"
 msgstr ""
 
-#: ../src/widgets/arc-toolbar.cpp:403
+#: ../src/widgets/arc-toolbar.cpp:568
 msgid "Make the shape a whole ellipse, not arc or segment"
 msgstr ""
 
@@ -28088,307 +28413,307 @@ msgstr ""
 msgid "Toggle VP in Z direction between 'finite' and 'infinite' (=parallel)"
 msgstr ""
 
-#. gint preset_index = ege_select_one_action_get_active( sel );
-#: ../src/widgets/calligraphy-toolbar.cpp:218
-#: ../src/widgets/calligraphy-toolbar.cpp:262
-#: ../src/widgets/calligraphy-toolbar.cpp:267
+#: ../src/widgets/calligraphy-toolbar.cpp:216
+#: ../src/widgets/calligraphy-toolbar.cpp:257
 msgid "No preset"
 msgstr ""
 
 #. Width
-#: ../src/widgets/calligraphy-toolbar.cpp:427
-#: ../src/widgets/eraser-toolbar.cpp:184
+#: ../src/widgets/calligraphy-toolbar.cpp:398
+#: ../src/widgets/eraser-toolbar.cpp:188
 msgid "(hairline)"
 msgstr ""
 
 #. Mean
 #. Rotation
 #. Scale
-#: ../src/widgets/calligraphy-toolbar.cpp:427
-#: ../src/widgets/calligraphy-toolbar.cpp:460
-#: ../src/widgets/eraser-toolbar.cpp:184 ../src/widgets/pencil-toolbar.cpp:374
+#: ../src/widgets/calligraphy-toolbar.cpp:398
+#: ../src/widgets/calligraphy-toolbar.cpp:431
+#: ../src/widgets/eraser-toolbar.cpp:188 ../src/widgets/pencil-toolbar.cpp:532
 #: ../src/widgets/spray-toolbar.cpp:294 ../src/widgets/spray-toolbar.cpp:323
-#: ../src/widgets/spray-toolbar.cpp:339 ../src/widgets/spray-toolbar.cpp:408
-#: ../src/widgets/spray-toolbar.cpp:438 ../src/widgets/spray-toolbar.cpp:456
-#: ../src/widgets/spray-toolbar.cpp:605 ../src/widgets/tweak-toolbar.cpp:125
+#: ../src/widgets/spray-toolbar.cpp:339 ../src/widgets/spray-toolbar.cpp:406
+#: ../src/widgets/spray-toolbar.cpp:436 ../src/widgets/spray-toolbar.cpp:454
+#: ../src/widgets/spray-toolbar.cpp:603 ../src/widgets/tweak-toolbar.cpp:125
 #: ../src/widgets/tweak-toolbar.cpp:142 ../src/widgets/tweak-toolbar.cpp:350
 msgid "(default)"
 msgstr ""
 
-#: ../src/widgets/calligraphy-toolbar.cpp:427
-#: ../src/widgets/eraser-toolbar.cpp:184
+#: ../src/widgets/calligraphy-toolbar.cpp:398
+#: ../src/widgets/eraser-toolbar.cpp:188
 msgid "(broad stroke)"
 msgstr ""
 
-#: ../src/widgets/calligraphy-toolbar.cpp:430
-#: ../src/widgets/eraser-toolbar.cpp:187
+#: ../src/widgets/calligraphy-toolbar.cpp:401
+#: ../src/widgets/eraser-toolbar.cpp:191
 msgid "Pen Width"
 msgstr ""
 
-#: ../src/widgets/calligraphy-toolbar.cpp:431
+#: ../src/widgets/calligraphy-toolbar.cpp:402
 msgid "The width of the calligraphic pen (relative to the visible canvas area)"
 msgstr ""
 
 #. Thinning
-#: ../src/widgets/calligraphy-toolbar.cpp:444
-#: ../src/widgets/eraser-toolbar.cpp:214
+#: ../src/widgets/calligraphy-toolbar.cpp:415
+#: ../src/widgets/eraser-toolbar.cpp:221
 msgid "(speed blows up stroke)"
 msgstr ""
 
-#: ../src/widgets/calligraphy-toolbar.cpp:444
-#: ../src/widgets/eraser-toolbar.cpp:214
+#: ../src/widgets/calligraphy-toolbar.cpp:415
+#: ../src/widgets/eraser-toolbar.cpp:221
 msgid "(slight widening)"
 msgstr ""
 
-#: ../src/widgets/calligraphy-toolbar.cpp:444
-#: ../src/widgets/eraser-toolbar.cpp:214
+#: ../src/widgets/calligraphy-toolbar.cpp:415
+#: ../src/widgets/eraser-toolbar.cpp:221
 msgid "(constant width)"
 msgstr ""
 
-#: ../src/widgets/calligraphy-toolbar.cpp:444
-#: ../src/widgets/eraser-toolbar.cpp:214
+#: ../src/widgets/calligraphy-toolbar.cpp:415
+#: ../src/widgets/eraser-toolbar.cpp:221
 msgid "(slight thinning, default)"
 msgstr ""
 
-#: ../src/widgets/calligraphy-toolbar.cpp:444
-#: ../src/widgets/eraser-toolbar.cpp:214
+#: ../src/widgets/calligraphy-toolbar.cpp:415
+#: ../src/widgets/eraser-toolbar.cpp:221
 msgid "(speed deflates stroke)"
 msgstr ""
 
-#: ../src/widgets/calligraphy-toolbar.cpp:447
+#: ../src/widgets/calligraphy-toolbar.cpp:418
 msgid "Stroke Thinning"
 msgstr ""
 
-#: ../src/widgets/calligraphy-toolbar.cpp:447
-#: ../src/widgets/eraser-toolbar.cpp:217
+#: ../src/widgets/calligraphy-toolbar.cpp:418
+#: ../src/widgets/eraser-toolbar.cpp:224
 msgid "Thinning:"
 msgstr ""
 
-#: ../src/widgets/calligraphy-toolbar.cpp:448
-#: ../src/widgets/eraser-toolbar.cpp:218
+#: ../src/widgets/calligraphy-toolbar.cpp:419
+#: ../src/widgets/eraser-toolbar.cpp:225
 msgid ""
 "How much velocity thins the stroke (> 0 makes fast strokes thinner, < 0 "
 "makes them broader, 0 makes width independent of velocity)"
 msgstr ""
 
 #. Angle
-#: ../src/widgets/calligraphy-toolbar.cpp:460
+#: ../src/widgets/calligraphy-toolbar.cpp:431
 msgid "(left edge up)"
 msgstr ""
 
-#: ../src/widgets/calligraphy-toolbar.cpp:460
+#: ../src/widgets/calligraphy-toolbar.cpp:431
 msgid "(horizontal)"
 msgstr ""
 
-#: ../src/widgets/calligraphy-toolbar.cpp:460
+#: ../src/widgets/calligraphy-toolbar.cpp:431
 msgid "(right edge up)"
 msgstr ""
 
-#: ../src/widgets/calligraphy-toolbar.cpp:463
+#: ../src/widgets/calligraphy-toolbar.cpp:434
 msgid "Pen Angle"
 msgstr ""
 
-#: ../src/widgets/calligraphy-toolbar.cpp:463
+#: ../src/widgets/calligraphy-toolbar.cpp:434
 #: ../share/extensions/motion.inx.h:3 ../share/extensions/restack.inx.h:5
 msgid "Angle:"
 msgstr ""
 
-#: ../src/widgets/calligraphy-toolbar.cpp:464
+#: ../src/widgets/calligraphy-toolbar.cpp:435
 msgid ""
 "The angle of the pen's nib (in degrees; 0 = horizontal; has no effect if "
 "fixation = 0)"
 msgstr ""
 
 #. Fixation
-#: ../src/widgets/calligraphy-toolbar.cpp:478
+#: ../src/widgets/calligraphy-toolbar.cpp:449
 msgid "(perpendicular to stroke, \"brush\")"
 msgstr ""
 
-#: ../src/widgets/calligraphy-toolbar.cpp:478
+#: ../src/widgets/calligraphy-toolbar.cpp:449
 msgid "(almost fixed, default)"
 msgstr ""
 
-#: ../src/widgets/calligraphy-toolbar.cpp:478
+#: ../src/widgets/calligraphy-toolbar.cpp:449
 msgid "(fixed by Angle, \"pen\")"
 msgstr ""
 
-#: ../src/widgets/calligraphy-toolbar.cpp:481
+#: ../src/widgets/calligraphy-toolbar.cpp:452
 msgid "Fixation"
 msgstr ""
 
-#: ../src/widgets/calligraphy-toolbar.cpp:481
+#: ../src/widgets/calligraphy-toolbar.cpp:452
 msgid "Fixation:"
 msgstr ""
 
-#: ../src/widgets/calligraphy-toolbar.cpp:482
+#: ../src/widgets/calligraphy-toolbar.cpp:453
 msgid ""
 "Angle behavior (0 = nib always perpendicular to stroke direction, 100 = "
 "fixed angle)"
 msgstr ""
 
 #. Cap Rounding
-#: ../src/widgets/calligraphy-toolbar.cpp:494
-#: ../src/widgets/eraser-toolbar.cpp:230
+#: ../src/widgets/calligraphy-toolbar.cpp:465
+#: ../src/widgets/eraser-toolbar.cpp:239
 msgid "(blunt caps, default)"
 msgstr ""
 
-#: ../src/widgets/calligraphy-toolbar.cpp:494
-#: ../src/widgets/eraser-toolbar.cpp:230
+#: ../src/widgets/calligraphy-toolbar.cpp:465
+#: ../src/widgets/eraser-toolbar.cpp:239
 msgid "(slightly bulging)"
 msgstr ""
 
-#: ../src/widgets/calligraphy-toolbar.cpp:494
-#: ../src/widgets/eraser-toolbar.cpp:230
+#: ../src/widgets/calligraphy-toolbar.cpp:465
+#: ../src/widgets/eraser-toolbar.cpp:239
 msgid "(approximately round)"
 msgstr ""
 
-#: ../src/widgets/calligraphy-toolbar.cpp:494
-#: ../src/widgets/eraser-toolbar.cpp:230
+#: ../src/widgets/calligraphy-toolbar.cpp:465
+#: ../src/widgets/eraser-toolbar.cpp:239
 msgid "(long protruding caps)"
 msgstr ""
 
-#: ../src/widgets/calligraphy-toolbar.cpp:498
+#: ../src/widgets/calligraphy-toolbar.cpp:469
 msgid "Cap rounding"
 msgstr ""
 
-#: ../src/widgets/calligraphy-toolbar.cpp:498
-#: ../src/widgets/eraser-toolbar.cpp:234
+#: ../src/widgets/calligraphy-toolbar.cpp:469
+#: ../src/widgets/eraser-toolbar.cpp:243
 msgid "Caps:"
 msgstr ""
 
-#: ../src/widgets/calligraphy-toolbar.cpp:499
-#: ../src/widgets/eraser-toolbar.cpp:235
+#: ../src/widgets/calligraphy-toolbar.cpp:470
+#: ../src/widgets/eraser-toolbar.cpp:244
 msgid ""
 "Increase to make caps at the ends of strokes protrude more (0 = no caps, 1 = "
 "round caps)"
 msgstr ""
 
 #. Tremor
-#: ../src/widgets/calligraphy-toolbar.cpp:511
-#: ../src/widgets/eraser-toolbar.cpp:248
+#: ../src/widgets/calligraphy-toolbar.cpp:482
+#: ../src/widgets/eraser-toolbar.cpp:258
 msgid "(smooth line)"
 msgstr ""
 
-#: ../src/widgets/calligraphy-toolbar.cpp:511
-#: ../src/widgets/eraser-toolbar.cpp:248
+#: ../src/widgets/calligraphy-toolbar.cpp:482
+#: ../src/widgets/eraser-toolbar.cpp:258
 msgid "(slight tremor)"
 msgstr ""
 
-#: ../src/widgets/calligraphy-toolbar.cpp:511
-#: ../src/widgets/eraser-toolbar.cpp:248
+#: ../src/widgets/calligraphy-toolbar.cpp:482
+#: ../src/widgets/eraser-toolbar.cpp:258
 msgid "(noticeable tremor)"
 msgstr ""
 
-#: ../src/widgets/calligraphy-toolbar.cpp:511
-#: ../src/widgets/eraser-toolbar.cpp:248
+#: ../src/widgets/calligraphy-toolbar.cpp:482
+#: ../src/widgets/eraser-toolbar.cpp:258
 msgid "(maximum tremor)"
 msgstr ""
 
-#: ../src/widgets/calligraphy-toolbar.cpp:514
+#: ../src/widgets/calligraphy-toolbar.cpp:485
 msgid "Stroke Tremor"
 msgstr ""
 
-#: ../src/widgets/calligraphy-toolbar.cpp:514
-#: ../src/widgets/eraser-toolbar.cpp:251
+#: ../src/widgets/calligraphy-toolbar.cpp:485
+#: ../src/widgets/eraser-toolbar.cpp:261
 msgid "Tremor:"
 msgstr ""
 
-#: ../src/widgets/calligraphy-toolbar.cpp:515
-#: ../src/widgets/eraser-toolbar.cpp:252
+#: ../src/widgets/calligraphy-toolbar.cpp:486
+#: ../src/widgets/eraser-toolbar.cpp:262
 msgid "Increase to make strokes rugged and trembling"
 msgstr ""
 
 #. Wiggle
-#: ../src/widgets/calligraphy-toolbar.cpp:529
+#: ../src/widgets/calligraphy-toolbar.cpp:500
 msgid "(no wiggle)"
 msgstr ""
 
-#: ../src/widgets/calligraphy-toolbar.cpp:529
+#: ../src/widgets/calligraphy-toolbar.cpp:500
 msgid "(slight deviation)"
 msgstr ""
 
-#: ../src/widgets/calligraphy-toolbar.cpp:529
+#: ../src/widgets/calligraphy-toolbar.cpp:500
 msgid "(wild waves and curls)"
 msgstr ""
 
-#: ../src/widgets/calligraphy-toolbar.cpp:532
+#: ../src/widgets/calligraphy-toolbar.cpp:503
 msgid "Pen Wiggle"
 msgstr ""
 
-#: ../src/widgets/calligraphy-toolbar.cpp:532
+#: ../src/widgets/calligraphy-toolbar.cpp:503
 msgid "Wiggle:"
 msgstr ""
 
-#: ../src/widgets/calligraphy-toolbar.cpp:533
+#: ../src/widgets/calligraphy-toolbar.cpp:504
 msgid "Increase to make the pen waver and wiggle"
 msgstr ""
 
 #. Mass
-#: ../src/widgets/calligraphy-toolbar.cpp:546
-#: ../src/widgets/eraser-toolbar.cpp:266
+#: ../src/widgets/calligraphy-toolbar.cpp:517
+#: ../src/widgets/eraser-toolbar.cpp:278
 msgid "(no inertia)"
 msgstr ""
 
-#: ../src/widgets/calligraphy-toolbar.cpp:546
-#: ../src/widgets/eraser-toolbar.cpp:266
+#: ../src/widgets/calligraphy-toolbar.cpp:517
+#: ../src/widgets/eraser-toolbar.cpp:278
 msgid "(slight smoothing, default)"
 msgstr ""
 
-#: ../src/widgets/calligraphy-toolbar.cpp:546
-#: ../src/widgets/eraser-toolbar.cpp:266
+#: ../src/widgets/calligraphy-toolbar.cpp:517
+#: ../src/widgets/eraser-toolbar.cpp:278
 msgid "(noticeable lagging)"
 msgstr ""
 
-#: ../src/widgets/calligraphy-toolbar.cpp:546
-#: ../src/widgets/eraser-toolbar.cpp:266
+#: ../src/widgets/calligraphy-toolbar.cpp:517
+#: ../src/widgets/eraser-toolbar.cpp:278
 msgid "(maximum inertia)"
 msgstr ""
 
-#: ../src/widgets/calligraphy-toolbar.cpp:549
+#: ../src/widgets/calligraphy-toolbar.cpp:520
 msgid "Pen Mass"
 msgstr ""
 
-#: ../src/widgets/calligraphy-toolbar.cpp:549
-#: ../src/widgets/eraser-toolbar.cpp:269
+#: ../src/widgets/calligraphy-toolbar.cpp:520
+#: ../src/widgets/eraser-toolbar.cpp:281
 msgid "Mass:"
 msgstr ""
 
-#: ../src/widgets/calligraphy-toolbar.cpp:550
+#: ../src/widgets/calligraphy-toolbar.cpp:521
 msgid "Increase to make the pen drag behind, as if slowed by inertia"
 msgstr ""
 
-#: ../src/widgets/calligraphy-toolbar.cpp:565
+#: ../src/widgets/calligraphy-toolbar.cpp:536
 msgid "Trace Background"
 msgstr ""
 
-#: ../src/widgets/calligraphy-toolbar.cpp:566
+#: ../src/widgets/calligraphy-toolbar.cpp:537
 msgid ""
 "Trace the lightness of the background by the width of the pen (white - "
 "minimum width, black - maximum width)"
 msgstr ""
 
-#: ../src/widgets/calligraphy-toolbar.cpp:579
-#: ../src/widgets/eraser-toolbar.cpp:203
+#: ../src/widgets/calligraphy-toolbar.cpp:550
+#: ../src/widgets/eraser-toolbar.cpp:209
 msgid "Use the pressure of the input device to alter the width of the pen"
 msgstr ""
 
-#: ../src/widgets/calligraphy-toolbar.cpp:591
+#: ../src/widgets/calligraphy-toolbar.cpp:562
 msgid "Tilt"
 msgstr ""
 
-#: ../src/widgets/calligraphy-toolbar.cpp:592
+#: ../src/widgets/calligraphy-toolbar.cpp:563
 msgid "Use the tilt of the input device to alter the angle of the pen's nib"
 msgstr ""
 
-#: ../src/widgets/calligraphy-toolbar.cpp:607
+#. Name
+#. Label
+#: ../src/widgets/calligraphy-toolbar.cpp:584
 msgid "Choose a preset"
 msgstr ""
 
-#: ../src/widgets/calligraphy-toolbar.cpp:622
+#: ../src/widgets/calligraphy-toolbar.cpp:602
 msgid "Add/Edit Profile"
 msgstr ""
 
-#: ../src/widgets/calligraphy-toolbar.cpp:623
+#: ../src/widgets/calligraphy-toolbar.cpp:603
 msgid "Add or edit calligraphic profile"
 msgstr ""
 
@@ -28408,71 +28733,71 @@ msgstr ""
 msgid "Change connector spacing"
 msgstr ""
 
-#: ../src/widgets/connector-toolbar.cpp:306
+#: ../src/widgets/connector-toolbar.cpp:309
 msgid "Avoid"
 msgstr ""
 
-#: ../src/widgets/connector-toolbar.cpp:316
+#: ../src/widgets/connector-toolbar.cpp:319
 msgid "Ignore"
 msgstr ""
 
-#: ../src/widgets/connector-toolbar.cpp:327
+#: ../src/widgets/connector-toolbar.cpp:330
 msgid "Orthogonal"
 msgstr ""
 
-#: ../src/widgets/connector-toolbar.cpp:328
+#: ../src/widgets/connector-toolbar.cpp:331
 msgid "Make connector orthogonal or polyline"
 msgstr ""
 
-#: ../src/widgets/connector-toolbar.cpp:342
+#: ../src/widgets/connector-toolbar.cpp:345
 msgid "Connector Curvature"
 msgstr ""
 
-#: ../src/widgets/connector-toolbar.cpp:342
+#: ../src/widgets/connector-toolbar.cpp:345
 msgid "Curvature:"
 msgstr ""
 
-#: ../src/widgets/connector-toolbar.cpp:343
+#: ../src/widgets/connector-toolbar.cpp:346
 msgid "The amount of connectors curvature"
 msgstr ""
 
-#: ../src/widgets/connector-toolbar.cpp:353
+#: ../src/widgets/connector-toolbar.cpp:356
 msgid "Connector Spacing"
 msgstr ""
 
-#: ../src/widgets/connector-toolbar.cpp:353
+#: ../src/widgets/connector-toolbar.cpp:356
 msgid "Spacing:"
 msgstr ""
 
-#: ../src/widgets/connector-toolbar.cpp:354
+#: ../src/widgets/connector-toolbar.cpp:357
 msgid "The amount of space left around objects by auto-routing connectors"
 msgstr ""
 
-#: ../src/widgets/connector-toolbar.cpp:365
+#: ../src/widgets/connector-toolbar.cpp:368
 msgid "Graph"
 msgstr ""
 
-#: ../src/widgets/connector-toolbar.cpp:375
+#: ../src/widgets/connector-toolbar.cpp:378
 msgid "Connector Length"
 msgstr ""
 
-#: ../src/widgets/connector-toolbar.cpp:375
+#: ../src/widgets/connector-toolbar.cpp:378
 msgid "Length:"
 msgstr ""
 
-#: ../src/widgets/connector-toolbar.cpp:376
+#: ../src/widgets/connector-toolbar.cpp:379
 msgid "Ideal length for connectors when layout is applied"
 msgstr ""
 
-#: ../src/widgets/connector-toolbar.cpp:388
+#: ../src/widgets/connector-toolbar.cpp:391
 msgid "Downwards"
 msgstr ""
 
-#: ../src/widgets/connector-toolbar.cpp:389
+#: ../src/widgets/connector-toolbar.cpp:392
 msgid "Make connectors with end-markers (arrows) point downwards"
 msgstr ""
 
-#: ../src/widgets/connector-toolbar.cpp:405
+#: ../src/widgets/connector-toolbar.cpp:408
 msgid "Do not allow overlapping shapes"
 msgstr ""
 
@@ -28484,62 +28809,62 @@ msgstr ""
 msgid "Pattern offset"
 msgstr ""
 
-#: ../src/widgets/desktop-widget.cpp:422
+#: ../src/widgets/desktop-widget.cpp:437
 msgid "Zoom drawing if window size changes"
 msgstr ""
 
 #. Display the initial welcome message in the statusbar
-#: ../src/widgets/desktop-widget.cpp:566
+#: ../src/widgets/desktop-widget.cpp:580
 msgid ""
 "<b>Welcome to Inkscape!</b> Use shape or freehand tools to create objects; "
 "use selector (arrow) to move or transform them."
 msgstr ""
 
-#: ../src/widgets/desktop-widget.cpp:600
+#: ../src/widgets/desktop-widget.cpp:614
 msgid "Rotation. (Also Ctrl+Shift+Scroll)"
 msgstr ""
 
-#: ../src/widgets/desktop-widget.cpp:634
+#: ../src/widgets/desktop-widget.cpp:648
 msgid "Cursor coordinates"
 msgstr ""
 
-#: ../src/widgets/desktop-widget.cpp:646
+#: ../src/widgets/desktop-widget.cpp:660
 msgid "Z:"
 msgstr ""
 
-#: ../src/widgets/desktop-widget.cpp:786
+#: ../src/widgets/desktop-widget.cpp:799
 msgid "outline"
 msgstr ""
 
-#: ../src/widgets/desktop-widget.cpp:788
+#: ../src/widgets/desktop-widget.cpp:801
 msgid "no filters"
 msgstr ""
 
-#: ../src/widgets/desktop-widget.cpp:797
+#: ../src/widgets/desktop-widget.cpp:810
 msgid "grayscale"
 msgstr ""
 
-#: ../src/widgets/desktop-widget.cpp:799
+#: ../src/widgets/desktop-widget.cpp:812
 msgid "print colors preview"
 msgstr ""
 
-#: ../src/widgets/desktop-widget.cpp:999
+#: ../src/widgets/desktop-widget.cpp:1012
 msgid "Locked all guides"
 msgstr ""
 
-#: ../src/widgets/desktop-widget.cpp:1001
+#: ../src/widgets/desktop-widget.cpp:1014
 msgid "Unlocked all guides"
 msgstr ""
 
-#: ../src/widgets/desktop-widget.cpp:1018
+#: ../src/widgets/desktop-widget.cpp:1031
 msgid "Color-managed display is <b>enabled</b> in this window"
 msgstr ""
 
-#: ../src/widgets/desktop-widget.cpp:1020
+#: ../src/widgets/desktop-widget.cpp:1033
 msgid "Color-managed display is <b>disabled</b> in this window"
 msgstr ""
 
-#: ../src/widgets/desktop-widget.cpp:1075
+#: ../src/widgets/desktop-widget.cpp:1088
 #, c-format
 msgid ""
 "<span weight=\"bold\" size=\"larger\">Save changes to document \"%s\" before "
@@ -28548,12 +28873,12 @@ msgid ""
 "If you close without saving, your changes will be discarded."
 msgstr ""
 
-#: ../src/widgets/desktop-widget.cpp:1085
-#: ../src/widgets/desktop-widget.cpp:1144
+#: ../src/widgets/desktop-widget.cpp:1098
+#: ../src/widgets/desktop-widget.cpp:1157
 msgid "Close _without saving"
 msgstr ""
 
-#: ../src/widgets/desktop-widget.cpp:1134
+#: ../src/widgets/desktop-widget.cpp:1147
 #, c-format
 msgid ""
 "<span weight=\"bold\" size=\"larger\">The file \"%s\" was saved with a "
@@ -28562,11 +28887,11 @@ msgid ""
 "Do you want to save this file as Inkscape SVG?"
 msgstr ""
 
-#: ../src/widgets/desktop-widget.cpp:1146
+#: ../src/widgets/desktop-widget.cpp:1159
 msgid "_Save as Inkscape SVG"
 msgstr ""
 
-#: ../src/widgets/desktop-widget.cpp:1360
+#: ../src/widgets/desktop-widget.cpp:1373
 msgid "Note:"
 msgstr ""
 
@@ -28601,60 +28926,59 @@ msgstr ""
 msgid "remove"
 msgstr ""
 
-#: ../src/widgets/eraser-toolbar.cpp:146
-msgid "Delete objects touched by the eraser"
+#: ../src/widgets/eraser-toolbar.cpp:152
+msgid "Delete objects touched by eraser"
 msgstr ""
 
-#: ../src/widgets/eraser-toolbar.cpp:152
+#: ../src/widgets/eraser-toolbar.cpp:157
 msgid "Cut"
 msgstr ""
 
-#: ../src/widgets/eraser-toolbar.cpp:153
+#: ../src/widgets/eraser-toolbar.cpp:158
 msgid "Cut out from paths and shapes"
 msgstr ""
 
-#: ../src/widgets/eraser-toolbar.cpp:159
+#: ../src/widgets/eraser-toolbar.cpp:163
 msgid "Clip"
 msgstr ""
 
-#: ../src/widgets/eraser-toolbar.cpp:160
+#: ../src/widgets/eraser-toolbar.cpp:164
 msgid "Clip from objects"
 msgstr ""
 
-#. Width
-#: ../src/widgets/eraser-toolbar.cpp:184
+#: ../src/widgets/eraser-toolbar.cpp:188
 msgid "(no width)"
 msgstr ""
 
-#: ../src/widgets/eraser-toolbar.cpp:188
+#: ../src/widgets/eraser-toolbar.cpp:192
 msgid "The width of the eraser pen (relative to the visible canvas area)"
 msgstr ""
 
-#: ../src/widgets/eraser-toolbar.cpp:202
+#: ../src/widgets/eraser-toolbar.cpp:208
 msgid "Eraser Pressure"
 msgstr ""
 
-#: ../src/widgets/eraser-toolbar.cpp:217
+#: ../src/widgets/eraser-toolbar.cpp:224
 msgid "Eraser Stroke Thinning"
 msgstr ""
 
-#: ../src/widgets/eraser-toolbar.cpp:234
+#: ../src/widgets/eraser-toolbar.cpp:243
 msgid "Eraser Cap rounding"
 msgstr ""
 
-#: ../src/widgets/eraser-toolbar.cpp:251
+#: ../src/widgets/eraser-toolbar.cpp:261
 msgid "EraserStroke Tremor"
 msgstr ""
 
-#: ../src/widgets/eraser-toolbar.cpp:269
+#: ../src/widgets/eraser-toolbar.cpp:281
 msgid "Eraser Mass"
 msgstr ""
 
-#: ../src/widgets/eraser-toolbar.cpp:270
+#: ../src/widgets/eraser-toolbar.cpp:282
 msgid "Increase to make the eraser drag behind, as if slowed by inertia"
 msgstr ""
 
-#: ../src/widgets/eraser-toolbar.cpp:284 ../src/widgets/eraser-toolbar.cpp:285
+#: ../src/widgets/eraser-toolbar.cpp:298 ../src/widgets/eraser-toolbar.cpp:299
 msgid "Break apart cut items"
 msgstr ""
 
@@ -28694,66 +29018,66 @@ msgstr ""
 msgid "Set pattern on stroke"
 msgstr ""
 
-#: ../src/widgets/font-selector.cpp:103 ../src/widgets/text-toolbar.cpp:1366
-#: ../src/widgets/text-toolbar.cpp:1738
+#: ../src/widgets/font-selector.cpp:101 ../src/widgets/text-toolbar.cpp:1583
+#: ../src/widgets/text-toolbar.cpp:2040
 msgid "Font size"
 msgstr ""
 
 #. gtk_box_set_homogeneous(GTK_BOX(fsel), TRUE);
 #. gtk_box_set_spacing(GTK_BOX(fsel), 4);
 #. Family frame
-#: ../src/widgets/font-selector.cpp:117
+#: ../src/widgets/font-selector.cpp:115
 msgid "Font family"
 msgstr ""
 
 #. Style frame
-#: ../src/widgets/font-selector.cpp:166
+#: ../src/widgets/font-selector.cpp:164
 msgctxt "Font selector"
 msgid "Style"
 msgstr ""
 
-#: ../src/widgets/font-selector.cpp:194
+#: ../src/widgets/font-selector.cpp:192
 msgid "Face"
 msgstr ""
 
-#: ../src/widgets/font-selector.cpp:219 ../share/extensions/dots.inx.h:3
+#: ../src/widgets/font-selector.cpp:217 ../share/extensions/dots.inx.h:3
 #: ../share/extensions/nicechart.inx.h:17
 msgid "Font size:"
 msgstr ""
 
-#: ../src/widgets/gimp/ruler.cpp:185
+#: ../src/widgets/gimp/ruler.cpp:188
 msgid "The orientation of the ruler"
 msgstr ""
 
-#: ../src/widgets/gimp/ruler.cpp:195
+#: ../src/widgets/gimp/ruler.cpp:198
 msgid "Unit of the ruler"
 msgstr ""
 
-#: ../src/widgets/gimp/ruler.cpp:202
+#: ../src/widgets/gimp/ruler.cpp:205
 msgid "Lower"
 msgstr ""
 
-#: ../src/widgets/gimp/ruler.cpp:203
+#: ../src/widgets/gimp/ruler.cpp:206
 msgid "Lower limit of ruler"
 msgstr ""
 
-#: ../src/widgets/gimp/ruler.cpp:212
+#: ../src/widgets/gimp/ruler.cpp:215
 msgid "Upper"
 msgstr ""
 
-#: ../src/widgets/gimp/ruler.cpp:213
+#: ../src/widgets/gimp/ruler.cpp:216
 msgid "Upper limit of ruler"
 msgstr ""
 
-#: ../src/widgets/gimp/ruler.cpp:223
+#: ../src/widgets/gimp/ruler.cpp:226
 msgid "Position of mark on the ruler"
 msgstr ""
 
-#: ../src/widgets/gimp/ruler.cpp:232
+#: ../src/widgets/gimp/ruler.cpp:235
 msgid "Max Size"
 msgstr ""
 
-#: ../src/widgets/gimp/ruler.cpp:233
+#: ../src/widgets/gimp/ruler.cpp:236
 msgid "Maximum size of the ruler"
 msgstr ""
 
@@ -28766,7 +29090,7 @@ msgid "Edit gradient"
 msgstr ""
 
 #: ../src/widgets/gradient-selector.cpp:266
-#: ../src/widgets/paint-selector.cpp:221
+#: ../src/widgets/paint-selector.cpp:223
 msgid "Swatch"
 msgstr ""
 
@@ -28774,110 +29098,101 @@ msgstr ""
 msgid "Rename gradient"
 msgstr ""
 
-#: ../src/widgets/gradient-toolbar.cpp:157
-#: ../src/widgets/gradient-toolbar.cpp:170
-#: ../src/widgets/gradient-toolbar.cpp:759
-#: ../src/widgets/gradient-toolbar.cpp:1098
+#: ../src/widgets/gradient-toolbar.cpp:139
+#: ../src/widgets/gradient-toolbar.cpp:159
+#: ../src/widgets/gradient-toolbar.cpp:535
+#: ../src/widgets/gradient-toolbar.cpp:938
 msgid "No gradient"
 msgstr ""
 
-#: ../src/widgets/gradient-toolbar.cpp:177
+#: ../src/widgets/gradient-toolbar.cpp:149
+msgid "Nothing Selected"
+msgstr ""
+
+#: ../src/widgets/gradient-toolbar.cpp:168
 msgid "Multiple gradients"
 msgstr ""
 
-#: ../src/widgets/gradient-toolbar.cpp:679
-msgid "Multiple stops"
-msgstr ""
-
-#: ../src/widgets/gradient-toolbar.cpp:777
-#: ../src/widgets/gradient-vector.cpp:578
+#: ../src/widgets/gradient-toolbar.cpp:545
+#: ../src/widgets/gradient-vector.cpp:562
 msgid "No stops in gradient"
 msgstr ""
 
-#: ../src/widgets/gradient-toolbar.cpp:931
+#: ../src/widgets/gradient-toolbar.cpp:659
+msgid "Multiple stops"
+msgstr ""
+
+#: ../src/widgets/gradient-toolbar.cpp:742
 msgid "Assign gradient to object"
 msgstr ""
 
-#: ../src/widgets/gradient-toolbar.cpp:953
+#: ../src/widgets/gradient-toolbar.cpp:770
 msgid "Set gradient repeat"
 msgstr ""
 
-#: ../src/widgets/gradient-toolbar.cpp:991
-#: ../src/widgets/gradient-vector.cpp:691
+#: ../src/widgets/gradient-toolbar.cpp:833
+#: ../src/widgets/gradient-vector.cpp:670
 msgid "Change gradient stop offset"
 msgstr ""
 
-#: ../src/widgets/gradient-toolbar.cpp:1038
+#: ../src/widgets/gradient-toolbar.cpp:862
 msgid "linear"
 msgstr ""
 
-#: ../src/widgets/gradient-toolbar.cpp:1038
+#: ../src/widgets/gradient-toolbar.cpp:863
 msgid "Create linear gradient"
 msgstr ""
 
-#: ../src/widgets/gradient-toolbar.cpp:1042
+#: ../src/widgets/gradient-toolbar.cpp:868
 msgid "radial"
 msgstr ""
 
-#: ../src/widgets/gradient-toolbar.cpp:1042
+#: ../src/widgets/gradient-toolbar.cpp:869
 msgid "Create radial (elliptic or circular) gradient"
 msgstr ""
 
-#: ../src/widgets/gradient-toolbar.cpp:1045 ../src/widgets/mesh-toolbar.cpp:396
-msgid "New:"
-msgstr ""
-
-#: ../src/widgets/gradient-toolbar.cpp:1068 ../src/widgets/mesh-toolbar.cpp:419
+#: ../src/widgets/gradient-toolbar.cpp:900 ../src/widgets/mesh-toolbar.cpp:423
 msgid "fill"
 msgstr ""
 
-#: ../src/widgets/gradient-toolbar.cpp:1068 ../src/widgets/mesh-toolbar.cpp:419
+#: ../src/widgets/gradient-toolbar.cpp:901 ../src/widgets/mesh-toolbar.cpp:424
 msgid "Create gradient in the fill"
 msgstr ""
 
-#: ../src/widgets/gradient-toolbar.cpp:1072 ../src/widgets/mesh-toolbar.cpp:423
+#: ../src/widgets/gradient-toolbar.cpp:906 ../src/widgets/mesh-toolbar.cpp:429
 msgid "stroke"
 msgstr ""
 
-#: ../src/widgets/gradient-toolbar.cpp:1072 ../src/widgets/mesh-toolbar.cpp:423
+#: ../src/widgets/gradient-toolbar.cpp:907 ../src/widgets/mesh-toolbar.cpp:430
 msgid "Create gradient in the stroke"
 msgstr ""
 
-#: ../src/widgets/gradient-toolbar.cpp:1075 ../src/widgets/mesh-toolbar.cpp:426
-msgid "on:"
-msgstr ""
-
-#: ../src/widgets/gradient-toolbar.cpp:1100
+#. Name
+#: ../src/widgets/gradient-toolbar.cpp:945
 msgid "Select"
 msgstr ""
 
-#: ../src/widgets/gradient-toolbar.cpp:1100
-msgid "Choose a gradient"
-msgstr ""
-
-#: ../src/widgets/gradient-toolbar.cpp:1101
-msgid "Select:"
-msgstr ""
-
-#: ../src/widgets/gradient-toolbar.cpp:1116
+#: ../src/widgets/gradient-toolbar.cpp:972
 msgctxt "Gradient repeat type"
 msgid "None"
 msgstr ""
 
-#: ../src/widgets/gradient-toolbar.cpp:1119
+#: ../src/widgets/gradient-toolbar.cpp:978
 msgid "Reflected"
 msgstr ""
 
-#: ../src/widgets/gradient-toolbar.cpp:1122
+#: ../src/widgets/gradient-toolbar.cpp:984
 msgid "Direct"
 msgstr ""
 
-#: ../src/widgets/gradient-toolbar.cpp:1124
+#. Name
+#: ../src/widgets/gradient-toolbar.cpp:991
 msgid "Repeat"
 msgstr ""
 
+#. Label
 #. TRANSLATORS: for info, see http://www.w3.org/TR/2000/CR-SVG-20000802/pservers.html#LinearGradientSpreadMethodAttribute
-#: ../src/widgets/gradient-toolbar.cpp:1126
+#: ../src/widgets/gradient-toolbar.cpp:993
 msgid ""
 "Whether to fill with flat color beyond the ends of the gradient vector "
 "(spreadMethod=\"pad\"), or repeat the gradient in the same direction "
@@ -28885,97 +29200,86 @@ msgid ""
 "directions (spreadMethod=\"reflect\")"
 msgstr ""
 
-#: ../src/widgets/gradient-toolbar.cpp:1131
-msgid "Repeat:"
-msgstr ""
-
-#: ../src/widgets/gradient-toolbar.cpp:1145
+#: ../src/widgets/gradient-toolbar.cpp:1020
 msgid "No stops"
 msgstr ""
 
-#: ../src/widgets/gradient-toolbar.cpp:1147
+#. Name
+#: ../src/widgets/gradient-toolbar.cpp:1027
 msgid "Stops"
 msgstr ""
 
-#: ../src/widgets/gradient-toolbar.cpp:1147
-msgid "Select a stop for the current gradient"
-msgstr ""
-
-#: ../src/widgets/gradient-toolbar.cpp:1148
-msgid "Stops:"
-msgstr ""
-
 #. Label
-#: ../src/widgets/gradient-toolbar.cpp:1160
-#: ../src/widgets/gradient-vector.cpp:868
+#: ../src/widgets/gradient-toolbar.cpp:1049
+#: ../src/widgets/gradient-vector.cpp:847
 msgctxt "Gradient"
 msgid "Offset:"
 msgstr ""
 
-#: ../src/widgets/gradient-toolbar.cpp:1160
+#: ../src/widgets/gradient-toolbar.cpp:1049
 msgid "Offset of selected stop"
 msgstr ""
 
-#: ../src/widgets/gradient-toolbar.cpp:1178
-#: ../src/widgets/gradient-toolbar.cpp:1179
+#: ../src/widgets/gradient-toolbar.cpp:1067
+#: ../src/widgets/gradient-toolbar.cpp:1068
 msgid "Insert new stop"
 msgstr ""
 
-#: ../src/widgets/gradient-toolbar.cpp:1192
-#: ../src/widgets/gradient-toolbar.cpp:1193
-#: ../src/widgets/gradient-vector.cpp:854
+#: ../src/widgets/gradient-toolbar.cpp:1081
+#: ../src/widgets/gradient-toolbar.cpp:1082
+#: ../src/widgets/gradient-vector.cpp:833
 msgid "Delete stop"
 msgstr ""
 
-#: ../src/widgets/gradient-toolbar.cpp:1207
+#: ../src/widgets/gradient-toolbar.cpp:1096
 msgid "Reverse the direction of the gradient"
 msgstr ""
 
-#: ../src/widgets/gradient-toolbar.cpp:1221
+#: ../src/widgets/gradient-toolbar.cpp:1110
 msgid "Link gradients"
 msgstr ""
 
-#: ../src/widgets/gradient-toolbar.cpp:1222
+#: ../src/widgets/gradient-toolbar.cpp:1111
 msgid "Link gradients to change all related gradients"
 msgstr ""
 
-#: ../src/widgets/gradient-vector.cpp:289 ../src/widgets/paint-selector.cpp:917
-#: ../src/widgets/paint-selector.cpp:1269
-#: ../src/widgets/stroke-marker-selector.cpp:149
+#: ../src/widgets/gradient-vector.cpp:288 ../src/widgets/paint-selector.cpp:904
+#: ../src/widgets/paint-selector.cpp:1240
+#: ../src/widgets/stroke-marker-selector.cpp:148
 msgid "No document selected"
 msgstr ""
 
-#: ../src/widgets/gradient-vector.cpp:293
+#: ../src/widgets/gradient-vector.cpp:292
 msgid "No gradients in document"
 msgstr ""
 
-#: ../src/widgets/gradient-vector.cpp:297
+#: ../src/widgets/gradient-vector.cpp:296
 msgid "No gradient selected"
 msgstr ""
 
 #. TRANSLATORS: "Stop" means: a "phase" of a gradient
-#: ../src/widgets/gradient-vector.cpp:849
+#: ../src/widgets/gradient-vector.cpp:828
 msgid "Add stop"
 msgstr ""
 
-#: ../src/widgets/gradient-vector.cpp:852
+#: ../src/widgets/gradient-vector.cpp:831
 msgid "Add another control stop to gradient"
 msgstr ""
 
-#: ../src/widgets/gradient-vector.cpp:857
+#: ../src/widgets/gradient-vector.cpp:836
 msgid "Delete current control stop from gradient"
 msgstr ""
 
 #. TRANSLATORS: "Stop" means: a "phase" of a gradient
-#: ../src/widgets/gradient-vector.cpp:918
+#: ../src/widgets/gradient-vector.cpp:897
 msgid "Stop Color"
 msgstr ""
 
-#: ../src/widgets/gradient-vector.cpp:957
+#: ../src/widgets/gradient-vector.cpp:936
 msgid "Gradient editor"
 msgstr ""
 
-#: ../src/widgets/gradient-vector.cpp:1301
+#: ../src/widgets/gradient-vector.cpp:1280
 msgid "Change gradient stop color"
 msgstr ""
 
@@ -29033,14 +29337,6 @@ msgstr ""
 msgid "Display measuring info for selected items"
 msgstr ""
 
-#. Add the units menu.
-#: ../src/widgets/lpe-toolbar.cpp:380 ../src/widgets/node-toolbar.cpp:611
-#: ../src/widgets/paintbucket-toolbar.cpp:166
-#: ../src/widgets/rect-toolbar.cpp:374 ../src/widgets/select-toolbar.cpp:520
-#: ../src/widgets/text-toolbar.cpp:2020
-msgid "Units"
-msgstr ""
-
 #: ../src/widgets/lpe-toolbar.cpp:390
 msgid "Open LPE dialog"
 msgstr ""
@@ -29058,116 +29354,133 @@ msgid "Start and end measures active."
 msgstr ""
 
 #: ../src/widgets/measure-toolbar.cpp:175
-msgid "Show all crossings."
+msgid "Measures only selected."
 msgstr ""
 
 #: ../src/widgets/measure-toolbar.cpp:177
-msgid "Show visible crossings."
+msgid "Measure all."
 msgstr ""
 
 #: ../src/widgets/measure-toolbar.cpp:193
-msgid "Use all layers in the measure."
+msgid "Show all crossings."
 msgstr ""
 
 #: ../src/widgets/measure-toolbar.cpp:195
-msgid "Use current layer in the measure."
+msgid "Show visible crossings."
 msgstr ""
 
 #: ../src/widgets/measure-toolbar.cpp:211
-msgid "Compute all elements."
+msgid "Use all layers in the measure."
 msgstr ""
 
 #: ../src/widgets/measure-toolbar.cpp:213
+msgid "Use current layer in the measure."
+msgstr ""
+
+#: ../src/widgets/measure-toolbar.cpp:229
+msgid "Compute all elements."
+msgstr ""
+
+#: ../src/widgets/measure-toolbar.cpp:231
 msgid "Compute max length."
 msgstr ""
 
-#: ../src/widgets/measure-toolbar.cpp:274 ../src/widgets/text-toolbar.cpp:1741
+#: ../src/widgets/measure-toolbar.cpp:292 ../src/widgets/text-toolbar.cpp:2043
 msgid "Font Size"
 msgstr ""
 
-#: ../src/widgets/measure-toolbar.cpp:274
+#: ../src/widgets/measure-toolbar.cpp:292
 msgid "Font Size:"
 msgstr ""
 
-#: ../src/widgets/measure-toolbar.cpp:275
+#: ../src/widgets/measure-toolbar.cpp:293
 msgid "The font size to be used in the measurement labels"
 msgstr ""
 
-#: ../src/widgets/measure-toolbar.cpp:286
-#: ../src/widgets/measure-toolbar.cpp:294
+#: ../src/widgets/measure-toolbar.cpp:304
+#: ../src/widgets/measure-toolbar.cpp:312
 msgid "The units to be used for the measurements"
 msgstr ""
 
-#: ../src/widgets/measure-toolbar.cpp:302 ../share/extensions/measure.inx.h:14
+#: ../src/widgets/measure-toolbar.cpp:320 ../share/extensions/measure.inx.h:14
 msgid "Precision:"
 msgstr ""
 
-#: ../src/widgets/measure-toolbar.cpp:303
+#: ../src/widgets/measure-toolbar.cpp:321
 msgid "Decimal precision of measure"
 msgstr ""
 
-#: ../src/widgets/measure-toolbar.cpp:315
+#: ../src/widgets/measure-toolbar.cpp:333
+msgid "Scale %"
+msgstr ""
+
+#: ../src/widgets/measure-toolbar.cpp:333
 msgid "Scale %:"
 msgstr ""
 
-#: ../src/widgets/measure-toolbar.cpp:316
+#: ../src/widgets/measure-toolbar.cpp:334
 msgid "Scale the results"
 msgstr ""
 
-#: ../src/widgets/measure-toolbar.cpp:329
+#: ../src/widgets/measure-toolbar.cpp:347
 msgid "Mark dimension offset"
 msgstr ""
 
-#: ../src/widgets/measure-toolbar.cpp:341
-#: ../src/widgets/measure-toolbar.cpp:342
+#: ../src/widgets/measure-toolbar.cpp:359
+#: ../src/widgets/measure-toolbar.cpp:360
+msgid "Measure only selected"
+msgstr ""
+
+#: ../src/widgets/measure-toolbar.cpp:371
+#: ../src/widgets/measure-toolbar.cpp:372
 msgid "Ignore first and last"
 msgstr ""
 
-#: ../src/widgets/measure-toolbar.cpp:352
-#: ../src/widgets/measure-toolbar.cpp:353
+#: ../src/widgets/measure-toolbar.cpp:382
+#: ../src/widgets/measure-toolbar.cpp:383
 msgid "Show hidden intersections"
 msgstr ""
 
-#: ../src/widgets/measure-toolbar.cpp:363
-#: ../src/widgets/measure-toolbar.cpp:364
+#: ../src/widgets/measure-toolbar.cpp:393
+#: ../src/widgets/measure-toolbar.cpp:394
 msgid "Show measures between items"
 msgstr ""
 
-#: ../src/widgets/measure-toolbar.cpp:374
-#: ../src/widgets/measure-toolbar.cpp:375
-msgid "Measure all layers"
-msgstr ""
-
-#: ../src/widgets/measure-toolbar.cpp:385
-#: ../src/widgets/measure-toolbar.cpp:386
-msgid "Reverse measure"
-msgstr ""
-
-#: ../src/widgets/measure-toolbar.cpp:395
-#: ../src/widgets/measure-toolbar.cpp:396
-msgid "Phantom measure"
-msgstr ""
-
+#: ../src/widgets/measure-toolbar.cpp:404
 #: ../src/widgets/measure-toolbar.cpp:405
-#: ../src/widgets/measure-toolbar.cpp:406
-msgid "To guides"
+msgid "Measure all layers"
 msgstr ""
 
 #: ../src/widgets/measure-toolbar.cpp:415
 #: ../src/widgets/measure-toolbar.cpp:416
-msgid "Mark Dimension"
+msgid "Reverse measure"
 msgstr ""
 
 #: ../src/widgets/measure-toolbar.cpp:425
 #: ../src/widgets/measure-toolbar.cpp:426
+msgid "Phantom measure"
+msgstr ""
+
+#: ../src/widgets/measure-toolbar.cpp:435
+#: ../src/widgets/measure-toolbar.cpp:436
+msgid "To guides"
+msgstr ""
+
+#: ../src/widgets/measure-toolbar.cpp:445
+#: ../src/widgets/measure-toolbar.cpp:446
+msgid "Mark Dimension"
+msgstr ""
+
+#: ../src/widgets/measure-toolbar.cpp:455
+#: ../src/widgets/measure-toolbar.cpp:456
 msgid "Convert to item"
 msgstr ""
 
-#: ../src/widgets/mesh-toolbar.cpp:284
+#: ../src/widgets/mesh-toolbar.cpp:276
 msgid "Set mesh type"
 msgstr ""
 
-#: ../src/widgets/mesh-toolbar.cpp:357
+#: ../src/widgets/mesh-toolbar.cpp:349
 msgid ""
 "Mesh gradients are part of SVG 2:\n"
 "* Syntax may change.\n"
@@ -29177,142 +29490,144 @@ msgid ""
 "For print: export to PDF."
 msgstr ""
 
-#: ../src/widgets/mesh-toolbar.cpp:389
+#: ../src/widgets/mesh-toolbar.cpp:385
 msgid "normal"
 msgstr ""
 
-#: ../src/widgets/mesh-toolbar.cpp:389
+#: ../src/widgets/mesh-toolbar.cpp:386
 msgid "Create mesh gradient"
 msgstr ""
 
-#: ../src/widgets/mesh-toolbar.cpp:393
+#: ../src/widgets/mesh-toolbar.cpp:391
 msgid "conical"
 msgstr ""
 
-#: ../src/widgets/mesh-toolbar.cpp:393
+#: ../src/widgets/mesh-toolbar.cpp:392
 msgid "Create conical gradient"
 msgstr ""
 
-#: ../src/widgets/mesh-toolbar.cpp:448
+#. Name
+#: ../src/widgets/mesh-toolbar.cpp:398
+msgid "New:"
+msgstr ""
+
+#: ../src/widgets/mesh-toolbar.cpp:457
 msgid "Rows"
 msgstr ""
 
-#: ../src/widgets/mesh-toolbar.cpp:448
+#: ../src/widgets/mesh-toolbar.cpp:457
 #: ../share/extensions/guides_creator.inx.h:5
 #: ../share/extensions/layout_nup.inx.h:12
 msgid "Rows:"
 msgstr ""
 
-#: ../src/widgets/mesh-toolbar.cpp:448
+#: ../src/widgets/mesh-toolbar.cpp:457
 msgid "Number of rows in new mesh"
 msgstr ""
 
-#: ../src/widgets/mesh-toolbar.cpp:464
+#: ../src/widgets/mesh-toolbar.cpp:473
 msgid "Columns"
 msgstr ""
 
-#: ../src/widgets/mesh-toolbar.cpp:464
+#: ../src/widgets/mesh-toolbar.cpp:473
 #: ../share/extensions/guides_creator.inx.h:4
 msgid "Columns:"
 msgstr ""
 
-#: ../src/widgets/mesh-toolbar.cpp:464
+#: ../src/widgets/mesh-toolbar.cpp:473
 msgid "Number of columns in new mesh"
 msgstr ""
 
-#: ../src/widgets/mesh-toolbar.cpp:478
+#: ../src/widgets/mesh-toolbar.cpp:487
 msgid "Edit Fill"
 msgstr ""
 
-#: ../src/widgets/mesh-toolbar.cpp:479
+#: ../src/widgets/mesh-toolbar.cpp:488
 msgid "Edit fill mesh"
 msgstr ""
 
-#: ../src/widgets/mesh-toolbar.cpp:491
+#: ../src/widgets/mesh-toolbar.cpp:500
 msgid "Edit Stroke"
 msgstr ""
 
-#: ../src/widgets/mesh-toolbar.cpp:492
+#: ../src/widgets/mesh-toolbar.cpp:501
 msgid "Edit stroke mesh"
 msgstr ""
 
-#: ../src/widgets/mesh-toolbar.cpp:504 ../src/widgets/node-toolbar.cpp:519
+#: ../src/widgets/mesh-toolbar.cpp:513 ../src/widgets/node-toolbar.cpp:519
 msgid "Show Handles"
 msgstr ""
 
-#: ../src/widgets/mesh-toolbar.cpp:521 ../src/widgets/mesh-toolbar.cpp:522
+#: ../src/widgets/mesh-toolbar.cpp:530 ../src/widgets/mesh-toolbar.cpp:531
 msgid "WARNING: Mesh SVG Syntax Subject to Change"
 msgstr ""
 
-#: ../src/widgets/mesh-toolbar.cpp:536
+#: ../src/widgets/mesh-toolbar.cpp:548
 msgctxt "Type"
 msgid "Coons"
 msgstr ""
 
-#: ../src/widgets/mesh-toolbar.cpp:539
+#: ../src/widgets/mesh-toolbar.cpp:554
 msgid "Bicubic"
 msgstr ""
 
-#. TRANSLATORS: Type of Smoothing. See https://en.wikipedia.org/wiki/Coons_patch
-#: ../src/widgets/mesh-toolbar.cpp:542
-msgid "Coons"
+#. Name
+#: ../src/widgets/mesh-toolbar.cpp:562
+msgid "Smoothing"
 msgstr ""
 
-#: ../src/widgets/mesh-toolbar.cpp:543
-msgid "Coons: no smoothing. Bicubic: smoothing across patch boundaries."
+#. Label
+#: ../src/widgets/mesh-toolbar.cpp:563
+msgid "Coons: no smothing. Bicubic: smothing across patch boundaries."
 msgstr ""
 
-#: ../src/widgets/mesh-toolbar.cpp:545 ../src/widgets/pencil-toolbar.cpp:377
-msgid "Smoothing:"
-msgstr ""
-
-#: ../src/widgets/mesh-toolbar.cpp:555
+#: ../src/widgets/mesh-toolbar.cpp:582
 msgid "Toggle Sides"
 msgstr ""
 
-#: ../src/widgets/mesh-toolbar.cpp:556
+#: ../src/widgets/mesh-toolbar.cpp:583
 msgid "Toggle selected sides between Beziers and lines."
 msgstr ""
 
-#: ../src/widgets/mesh-toolbar.cpp:559
+#: ../src/widgets/mesh-toolbar.cpp:586
 msgid "Toggle side:"
 msgstr ""
 
-#: ../src/widgets/mesh-toolbar.cpp:566
+#: ../src/widgets/mesh-toolbar.cpp:593
 msgid "Make elliptical"
 msgstr ""
 
-#: ../src/widgets/mesh-toolbar.cpp:567
+#: ../src/widgets/mesh-toolbar.cpp:594
 msgid ""
 "Make selected sides elliptical by changing length of handles. Works best if "
 "handles already approximate ellipse."
 msgstr ""
 
-#: ../src/widgets/mesh-toolbar.cpp:570
+#: ../src/widgets/mesh-toolbar.cpp:597
 msgid "Make elliptical:"
 msgstr ""
 
-#: ../src/widgets/mesh-toolbar.cpp:577
+#: ../src/widgets/mesh-toolbar.cpp:604
 msgid "Pick colors:"
 msgstr ""
 
-#: ../src/widgets/mesh-toolbar.cpp:578
+#: ../src/widgets/mesh-toolbar.cpp:605
 msgid "Pick colors for selected corner nodes from underneath mesh."
 msgstr ""
 
-#: ../src/widgets/mesh-toolbar.cpp:581
+#: ../src/widgets/mesh-toolbar.cpp:608
 msgid "Pick Color"
 msgstr ""
 
-#: ../src/widgets/mesh-toolbar.cpp:589
+#: ../src/widgets/mesh-toolbar.cpp:616
 msgid "Scale mesh to bounding box:"
 msgstr ""
 
-#: ../src/widgets/mesh-toolbar.cpp:590
+#: ../src/widgets/mesh-toolbar.cpp:617
 msgid "Scale mesh to fit inside bounding box."
 msgstr ""
 
-#: ../src/widgets/mesh-toolbar.cpp:593
+#: ../src/widgets/mesh-toolbar.cpp:620
 msgid "Fit mesh"
 msgstr ""
 
@@ -29508,92 +29823,92 @@ msgstr ""
 msgid "Y coordinate of selected node(s)"
 msgstr ""
 
-#: ../src/widgets/paint-selector.cpp:207
+#: ../src/widgets/paint-selector.cpp:209
 msgid "No paint"
 msgstr ""
 
-#: ../src/widgets/paint-selector.cpp:209
+#: ../src/widgets/paint-selector.cpp:211
 msgid "Flat color"
 msgstr ""
 
-#: ../src/widgets/paint-selector.cpp:211
+#: ../src/widgets/paint-selector.cpp:213
 msgid "Linear gradient"
 msgstr ""
 
-#: ../src/widgets/paint-selector.cpp:213
+#: ../src/widgets/paint-selector.cpp:215
 msgid "Radial gradient"
 msgstr ""
 
-#: ../src/widgets/paint-selector.cpp:216
+#: ../src/widgets/paint-selector.cpp:218
 msgid "Mesh gradient"
 msgstr ""
 
-#: ../src/widgets/paint-selector.cpp:223
+#: ../src/widgets/paint-selector.cpp:225
 msgid "Unset paint (make it undefined so it can be inherited)"
 msgstr ""
 
 #. TRANSLATORS: for info, see http://www.w3.org/TR/2000/CR-SVG-20000802/painting.html#FillRuleProperty
-#: ../src/widgets/paint-selector.cpp:236
+#: ../src/widgets/paint-selector.cpp:238
 msgid ""
 "Any path self-intersections or subpaths create holes in the fill (fill-rule: "
 "evenodd)"
 msgstr ""
 
 #. TRANSLATORS: for info, see http://www.w3.org/TR/2000/CR-SVG-20000802/painting.html#FillRuleProperty
-#: ../src/widgets/paint-selector.cpp:247
+#: ../src/widgets/paint-selector.cpp:249
 msgid ""
 "Fill is solid unless a subpath is counterdirectional (fill-rule: nonzero)"
 msgstr ""
 
-#: ../src/widgets/paint-selector.cpp:589
+#: ../src/widgets/paint-selector.cpp:591
 msgid "<b>No objects</b>"
 msgstr ""
 
-#: ../src/widgets/paint-selector.cpp:600
+#: ../src/widgets/paint-selector.cpp:602
 msgid "<b>Multiple styles</b>"
 msgstr ""
 
-#: ../src/widgets/paint-selector.cpp:611
+#: ../src/widgets/paint-selector.cpp:613
 msgid "<b>Paint is undefined</b>"
 msgstr ""
 
-#: ../src/widgets/paint-selector.cpp:622
+#: ../src/widgets/paint-selector.cpp:624
 msgid "<b>No paint</b>"
 msgstr ""
 
-#: ../src/widgets/paint-selector.cpp:702
+#: ../src/widgets/paint-selector.cpp:704
 msgid "<b>Flat color</b>"
 msgstr ""
 
 #. sp_gradient_selector_set_mode(SP_GRADIENT_SELECTOR(gsel), SP_GRADIENT_SELECTOR_MODE_LINEAR);
-#: ../src/widgets/paint-selector.cpp:766
+#: ../src/widgets/paint-selector.cpp:768
 msgid "<b>Linear gradient</b>"
 msgstr ""
 
-#: ../src/widgets/paint-selector.cpp:769
+#: ../src/widgets/paint-selector.cpp:771
 msgid "<b>Radial gradient</b>"
 msgstr ""
 
-#: ../src/widgets/paint-selector.cpp:1038
+#: ../src/widgets/paint-selector.cpp:1025
 msgid "Use the <b>Mesh tool</b> to modify the mesh."
 msgstr ""
 
-#: ../src/widgets/paint-selector.cpp:1051
+#: ../src/widgets/paint-selector.cpp:1038
 msgid "<b>Mesh fill</b>"
 msgstr ""
 
-#: ../src/widgets/paint-selector.cpp:1390
+#: ../src/widgets/paint-selector.cpp:1361
 msgid ""
 "Use the <b>Node tool</b> to adjust position, scale, and rotation of the "
 "pattern on canvas. Use <b>Object &gt; Pattern &gt; Objects to Pattern</b> to "
 "create a new pattern from selection."
 msgstr ""
 
-#: ../src/widgets/paint-selector.cpp:1403
+#: ../src/widgets/paint-selector.cpp:1374
 msgid "<b>Pattern fill</b>"
 msgstr ""
 
-#: ../src/widgets/paint-selector.cpp:1497
+#: ../src/widgets/paint-selector.cpp:1468
 msgid "<b>Swatch fill</b>"
 msgstr ""
 
@@ -29637,8 +29952,8 @@ msgid "Close gaps:"
 msgstr ""
 
 #: ../src/widgets/paintbucket-toolbar.cpp:210
-#: ../src/widgets/pencil-toolbar.cpp:398 ../src/widgets/spiral-toolbar.cpp:282
-#: ../src/widgets/star-toolbar.cpp:562
+#: ../src/widgets/pencil-toolbar.cpp:556 ../src/widgets/spiral-toolbar.cpp:288
+#: ../src/widgets/star-toolbar.cpp:574
 msgid "Defaults"
 msgstr ""
 
@@ -29648,102 +29963,138 @@ msgid ""
 "to change defaults)"
 msgstr ""
 
-#: ../src/widgets/pencil-toolbar.cpp:102
+#: ../src/widgets/pencil-toolbar.cpp:124
 msgid "Bezier"
 msgstr ""
 
-#: ../src/widgets/pencil-toolbar.cpp:103
+#: ../src/widgets/pencil-toolbar.cpp:125
 msgid "Create regular Bezier path"
 msgstr ""
 
-#: ../src/widgets/pencil-toolbar.cpp:110
+#: ../src/widgets/pencil-toolbar.cpp:132
 msgid "Create Spiro path"
 msgstr ""
 
-#: ../src/widgets/pencil-toolbar.cpp:116
+#: ../src/widgets/pencil-toolbar.cpp:138
 msgid "Create BSpline path"
 msgstr ""
 
-#: ../src/widgets/pencil-toolbar.cpp:122
+#: ../src/widgets/pencil-toolbar.cpp:144
 msgid "Zigzag"
 msgstr ""
 
-#: ../src/widgets/pencil-toolbar.cpp:123
+#: ../src/widgets/pencil-toolbar.cpp:145
 msgid "Create a sequence of straight line segments"
 msgstr ""
 
-#: ../src/widgets/pencil-toolbar.cpp:129
+#: ../src/widgets/pencil-toolbar.cpp:151
 msgid "Paraxial"
 msgstr ""
 
-#: ../src/widgets/pencil-toolbar.cpp:130
+#: ../src/widgets/pencil-toolbar.cpp:152
 msgid "Create a sequence of paraxial line segments"
 msgstr ""
 
-#: ../src/widgets/pencil-toolbar.cpp:138
+#: ../src/widgets/pencil-toolbar.cpp:159
 msgid "Mode of new lines drawn by this tool"
 msgstr ""
 
-#: ../src/widgets/pencil-toolbar.cpp:173
+#: ../src/widgets/pencil-toolbar.cpp:176 ../src/widgets/pencil-toolbar.cpp:177
+msgid "LPE spiro or bspline flatten"
+msgstr ""
+
+#: ../src/widgets/pencil-toolbar.cpp:218
 msgctxt "Freehand shape"
 msgid "None"
 msgstr ""
 
-#: ../src/widgets/pencil-toolbar.cpp:174
+#: ../src/widgets/pencil-toolbar.cpp:219
 msgid "Triangle in"
 msgstr ""
 
-#: ../src/widgets/pencil-toolbar.cpp:175
+#: ../src/widgets/pencil-toolbar.cpp:220
 msgid "Triangle out"
 msgstr ""
 
-#: ../src/widgets/pencil-toolbar.cpp:177
+#: ../src/widgets/pencil-toolbar.cpp:222
 msgid "From clipboard"
 msgstr ""
 
-#: ../src/widgets/pencil-toolbar.cpp:178
+#: ../src/widgets/pencil-toolbar.cpp:223
 msgid "Bend from clipboard"
 msgstr ""
 
-#: ../src/widgets/pencil-toolbar.cpp:179
+#: ../src/widgets/pencil-toolbar.cpp:224
 msgid "Last applied"
 msgstr ""
 
-#: ../src/widgets/pencil-toolbar.cpp:204 ../src/widgets/pencil-toolbar.cpp:205
+#: ../src/widgets/pencil-toolbar.cpp:235 ../src/widgets/pencil-toolbar.cpp:236
 msgid "Shape:"
 msgstr ""
 
-#: ../src/widgets/pencil-toolbar.cpp:204
+#: ../src/widgets/pencil-toolbar.cpp:235
 msgid "Shape of new paths drawn by this tool"
 msgstr ""
 
-#: ../src/widgets/pencil-toolbar.cpp:374
+#: ../src/widgets/pencil-toolbar.cpp:479
+msgid "Min pressure"
+msgstr ""
+
+#: ../src/widgets/pencil-toolbar.cpp:479
+msgid "Min:"
+msgstr ""
+
+#: ../src/widgets/pencil-toolbar.cpp:479
+msgid "Min percent of pressure"
+msgstr ""
+
+#: ../src/widgets/pencil-toolbar.cpp:497
+msgid "Max pressure"
+msgstr ""
+
+#: ../src/widgets/pencil-toolbar.cpp:497
+msgid "Max:"
+msgstr ""
+
+#: ../src/widgets/pencil-toolbar.cpp:497
+msgid "Max percent of pressure"
+msgstr ""
+
+#: ../src/widgets/pencil-toolbar.cpp:514 ../src/widgets/pencil-toolbar.cpp:515
+msgid "Use pressure input"
+msgstr ""
+
+#: ../src/widgets/pencil-toolbar.cpp:532
 msgid "(many nodes, rough)"
 msgstr ""
 
-#: ../src/widgets/pencil-toolbar.cpp:374
+#: ../src/widgets/pencil-toolbar.cpp:532
 msgid "(few nodes, smooth)"
 msgstr ""
 
-#: ../src/widgets/pencil-toolbar.cpp:377
+#: ../src/widgets/pencil-toolbar.cpp:535
+msgid "Smoothing:"
+msgstr ""
+
+#: ../src/widgets/pencil-toolbar.cpp:535
 msgid "Smoothing: "
 msgstr ""
 
-#: ../src/widgets/pencil-toolbar.cpp:378
+#: ../src/widgets/pencil-toolbar.cpp:536
 msgid "How much smoothing (simplifying) is applied to the line"
 msgstr ""
 
-#: ../src/widgets/pencil-toolbar.cpp:399
+#: ../src/widgets/pencil-toolbar.cpp:557
 msgid ""
 "Reset pencil parameters to defaults (use Inkscape Preferences > Tools to "
 "change defaults)"
 msgstr ""
 
-#: ../src/widgets/pencil-toolbar.cpp:409 ../src/widgets/pencil-toolbar.cpp:410
+#: ../src/widgets/pencil-toolbar.cpp:566 ../src/widgets/pencil-toolbar.cpp:567
 msgid "LPE based interactive simplify"
 msgstr ""
 
-#: ../src/widgets/pencil-toolbar.cpp:420 ../src/widgets/pencil-toolbar.cpp:421
+#: ../src/widgets/pencil-toolbar.cpp:584 ../src/widgets/pencil-toolbar.cpp:585
 msgid "LPE simplify flatten"
 msgstr ""
 
@@ -29751,55 +30102,39 @@ msgstr ""
 msgid "Change rectangle"
 msgstr ""
 
-#: ../src/widgets/rect-toolbar.cpp:313
+#: ../src/widgets/rect-toolbar.cpp:319
 msgid "W:"
 msgstr ""
 
-#: ../src/widgets/rect-toolbar.cpp:313
+#: ../src/widgets/rect-toolbar.cpp:319
 msgid "Width of rectangle"
 msgstr ""
 
-#: ../src/widgets/rect-toolbar.cpp:330
+#: ../src/widgets/rect-toolbar.cpp:336
 msgid "H:"
 msgstr ""
 
-#: ../src/widgets/rect-toolbar.cpp:330
+#: ../src/widgets/rect-toolbar.cpp:336
 msgid "Height of rectangle"
 msgstr ""
 
-#: ../src/widgets/rect-toolbar.cpp:344 ../src/widgets/rect-toolbar.cpp:359
+#: ../src/widgets/rect-toolbar.cpp:350 ../src/widgets/rect-toolbar.cpp:365
 msgid "not rounded"
 msgstr ""
 
-#: ../src/widgets/rect-toolbar.cpp:347
-msgid "Horizontal radius"
-msgstr ""
-
-#: ../src/widgets/rect-toolbar.cpp:347
-msgid "Rx:"
-msgstr ""
-
-#: ../src/widgets/rect-toolbar.cpp:347
+#: ../src/widgets/rect-toolbar.cpp:353
 msgid "Horizontal radius of rounded corners"
 msgstr ""
 
-#: ../src/widgets/rect-toolbar.cpp:362
-msgid "Vertical radius"
-msgstr ""
-
-#: ../src/widgets/rect-toolbar.cpp:362
-msgid "Ry:"
-msgstr ""
-
-#: ../src/widgets/rect-toolbar.cpp:362
+#: ../src/widgets/rect-toolbar.cpp:368
 msgid "Vertical radius of rounded corners"
 msgstr ""
 
-#: ../src/widgets/rect-toolbar.cpp:381
+#: ../src/widgets/rect-toolbar.cpp:387
 msgid "Not rounded"
 msgstr ""
 
-#: ../src/widgets/rect-toolbar.cpp:382
+#: ../src/widgets/rect-toolbar.cpp:388
 msgid "Make corners sharp"
 msgstr ""
 
@@ -29951,10 +30286,6 @@ msgstr ""
 msgid "Unnamed"
 msgstr ""
 
-#: ../src/widgets/sp-xmlview-attr-list.cpp:55
-msgid "Value"
-msgstr ""
-
 #: ../src/widgets/sp-xmlview-content.cpp:134
 msgid "Type text in a text node"
 msgstr ""
@@ -29963,87 +30294,87 @@ msgstr ""
 msgid "Change spiral"
 msgstr ""
 
-#: ../src/widgets/spiral-toolbar.cpp:239
+#: ../src/widgets/spiral-toolbar.cpp:245
 msgid "just a curve"
 msgstr ""
 
-#: ../src/widgets/spiral-toolbar.cpp:239
+#: ../src/widgets/spiral-toolbar.cpp:245
 msgid "one full revolution"
 msgstr ""
 
-#: ../src/widgets/spiral-toolbar.cpp:242
+#: ../src/widgets/spiral-toolbar.cpp:248
 msgid "Number of turns"
 msgstr ""
 
-#: ../src/widgets/spiral-toolbar.cpp:242
+#: ../src/widgets/spiral-toolbar.cpp:248
 msgid "Turns:"
 msgstr ""
 
-#: ../src/widgets/spiral-toolbar.cpp:242
+#: ../src/widgets/spiral-toolbar.cpp:248
 msgid "Number of revolutions"
 msgstr ""
 
-#: ../src/widgets/spiral-toolbar.cpp:253
+#: ../src/widgets/spiral-toolbar.cpp:259
 msgid "circle"
 msgstr ""
 
-#: ../src/widgets/spiral-toolbar.cpp:253
+#: ../src/widgets/spiral-toolbar.cpp:259
 msgid "edge is much denser"
 msgstr ""
 
-#: ../src/widgets/spiral-toolbar.cpp:253
+#: ../src/widgets/spiral-toolbar.cpp:259
 msgid "edge is denser"
 msgstr ""
 
-#: ../src/widgets/spiral-toolbar.cpp:253
+#: ../src/widgets/spiral-toolbar.cpp:259
 msgid "even"
 msgstr ""
 
-#: ../src/widgets/spiral-toolbar.cpp:253
+#: ../src/widgets/spiral-toolbar.cpp:259
 msgid "center is denser"
 msgstr ""
 
-#: ../src/widgets/spiral-toolbar.cpp:253
+#: ../src/widgets/spiral-toolbar.cpp:259
 msgid "center is much denser"
 msgstr ""
 
-#: ../src/widgets/spiral-toolbar.cpp:256
+#: ../src/widgets/spiral-toolbar.cpp:262
 msgid "Divergence"
 msgstr ""
 
-#: ../src/widgets/spiral-toolbar.cpp:256
+#: ../src/widgets/spiral-toolbar.cpp:262
 msgid "Divergence:"
 msgstr ""
 
-#: ../src/widgets/spiral-toolbar.cpp:256
+#: ../src/widgets/spiral-toolbar.cpp:262
 msgid "How much denser/sparser are outer revolutions; 1 = uniform"
 msgstr ""
 
-#: ../src/widgets/spiral-toolbar.cpp:267
+#: ../src/widgets/spiral-toolbar.cpp:273
 msgid "starts from center"
 msgstr ""
 
-#: ../src/widgets/spiral-toolbar.cpp:267
+#: ../src/widgets/spiral-toolbar.cpp:273
 msgid "starts mid-way"
 msgstr ""
 
-#: ../src/widgets/spiral-toolbar.cpp:267
+#: ../src/widgets/spiral-toolbar.cpp:273
 msgid "starts near edge"
 msgstr ""
 
-#: ../src/widgets/spiral-toolbar.cpp:270
+#: ../src/widgets/spiral-toolbar.cpp:276
 msgid "Inner radius"
 msgstr ""
 
-#: ../src/widgets/spiral-toolbar.cpp:270
+#: ../src/widgets/spiral-toolbar.cpp:276
 msgid "Inner radius:"
 msgstr ""
 
-#: ../src/widgets/spiral-toolbar.cpp:270
+#: ../src/widgets/spiral-toolbar.cpp:276
 msgid "Radius of the innermost revolution (relative to the spiral size)"
 msgstr ""
 
-#: ../src/widgets/spiral-toolbar.cpp:283 ../src/widgets/star-toolbar.cpp:563
+#: ../src/widgets/spiral-toolbar.cpp:289 ../src/widgets/star-toolbar.cpp:575
 msgid ""
 "Reset shape parameters to defaults (use Inkscape Preferences > Tools to "
 "change defaults)"
@@ -30105,11 +30436,11 @@ msgstr ""
 msgid "Increase to scatter sprayed objects"
 msgstr ""
 
-#: ../src/widgets/spray-toolbar.cpp:361
+#: ../src/widgets/spray-toolbar.cpp:363
 msgid "Spray copies of the initial selection"
 msgstr ""
 
-#: ../src/widgets/spray-toolbar.cpp:368
+#: ../src/widgets/spray-toolbar.cpp:369
 msgid "Spray clones of the initial selection"
 msgstr ""
 
@@ -30121,135 +30452,135 @@ msgstr ""
 msgid "Spray objects in a single path"
 msgstr ""
 
-#: ../src/widgets/spray-toolbar.cpp:383
+#: ../src/widgets/spray-toolbar.cpp:382
 msgid "Delete sprayed items"
 msgstr ""
 
-#: ../src/widgets/spray-toolbar.cpp:384
+#: ../src/widgets/spray-toolbar.cpp:383
 msgid "Delete sprayed items from selection"
 msgstr ""
 
 #. Population
-#: ../src/widgets/spray-toolbar.cpp:408
+#: ../src/widgets/spray-toolbar.cpp:406
 msgid "(low population)"
 msgstr ""
 
-#: ../src/widgets/spray-toolbar.cpp:408
+#: ../src/widgets/spray-toolbar.cpp:406
 msgid "(high population)"
 msgstr ""
 
-#: ../src/widgets/spray-toolbar.cpp:411
+#: ../src/widgets/spray-toolbar.cpp:409
 msgid "Amount"
 msgstr ""
 
-#: ../src/widgets/spray-toolbar.cpp:412
+#: ../src/widgets/spray-toolbar.cpp:410
 msgid "Adjusts the number of items sprayed per click"
 msgstr ""
 
-#: ../src/widgets/spray-toolbar.cpp:428
+#: ../src/widgets/spray-toolbar.cpp:426
 msgid ""
 "Use the pressure of the input device to alter the amount of sprayed objects"
 msgstr ""
 
-#: ../src/widgets/spray-toolbar.cpp:438
+#: ../src/widgets/spray-toolbar.cpp:436
 msgid "(high rotation variation)"
 msgstr ""
 
-#: ../src/widgets/spray-toolbar.cpp:441
+#: ../src/widgets/spray-toolbar.cpp:439
 msgid "Rotation"
 msgstr ""
 
-#: ../src/widgets/spray-toolbar.cpp:441
+#: ../src/widgets/spray-toolbar.cpp:439
 msgid "Rotation:"
 msgstr ""
 
-#: ../src/widgets/spray-toolbar.cpp:443
+#: ../src/widgets/spray-toolbar.cpp:441
 #, no-c-format
 msgid ""
 "Variation of the rotation of the sprayed objects; 0% for the same rotation "
 "than the original object"
 msgstr ""
 
-#: ../src/widgets/spray-toolbar.cpp:456
+#: ../src/widgets/spray-toolbar.cpp:454
 msgid "(high scale variation)"
 msgstr ""
 
-#: ../src/widgets/spray-toolbar.cpp:459
+#: ../src/widgets/spray-toolbar.cpp:457
 msgctxt "Spray tool"
 msgid "Scale"
 msgstr ""
 
-#: ../src/widgets/spray-toolbar.cpp:459
+#: ../src/widgets/spray-toolbar.cpp:457
 msgctxt "Spray tool"
 msgid "Scale:"
 msgstr ""
 
-#: ../src/widgets/spray-toolbar.cpp:461
+#: ../src/widgets/spray-toolbar.cpp:459
 #, no-c-format
 msgid ""
 "Variation in the scale of the sprayed objects; 0% for the same scale than "
 "the original object"
 msgstr ""
 
-#: ../src/widgets/spray-toolbar.cpp:477
+#: ../src/widgets/spray-toolbar.cpp:475
 msgid "Use the pressure of the input device to alter the scale of new items"
 msgstr ""
 
-#: ../src/widgets/spray-toolbar.cpp:489 ../src/widgets/spray-toolbar.cpp:490
+#: ../src/widgets/spray-toolbar.cpp:487 ../src/widgets/spray-toolbar.cpp:488
 msgid ""
 "Pick color from the drawing. You can use clonetiler trace dialog for "
 "advanced effects. In clone mode original fill or stroke colors must be unset."
 msgstr ""
 
-#: ../src/widgets/spray-toolbar.cpp:502 ../src/widgets/spray-toolbar.cpp:503
+#: ../src/widgets/spray-toolbar.cpp:500 ../src/widgets/spray-toolbar.cpp:501
 msgid "Pick from center instead average area."
 msgstr ""
 
-#: ../src/widgets/spray-toolbar.cpp:515 ../src/widgets/spray-toolbar.cpp:516
+#: ../src/widgets/spray-toolbar.cpp:513 ../src/widgets/spray-toolbar.cpp:514
 msgid "Inverted pick value, retaining color in advanced trace mode"
 msgstr ""
 
-#: ../src/widgets/spray-toolbar.cpp:528 ../src/widgets/spray-toolbar.cpp:529
+#: ../src/widgets/spray-toolbar.cpp:526 ../src/widgets/spray-toolbar.cpp:527
 msgid "Apply picked color to fill"
 msgstr ""
 
-#: ../src/widgets/spray-toolbar.cpp:541 ../src/widgets/spray-toolbar.cpp:542
+#: ../src/widgets/spray-toolbar.cpp:539 ../src/widgets/spray-toolbar.cpp:540
 msgid "Apply picked color to stroke"
 msgstr ""
 
-#: ../src/widgets/spray-toolbar.cpp:554 ../src/widgets/spray-toolbar.cpp:555
+#: ../src/widgets/spray-toolbar.cpp:552 ../src/widgets/spray-toolbar.cpp:553
 msgid "No overlap between colors"
 msgstr ""
 
-#: ../src/widgets/spray-toolbar.cpp:567 ../src/widgets/spray-toolbar.cpp:568
+#: ../src/widgets/spray-toolbar.cpp:565 ../src/widgets/spray-toolbar.cpp:566
 msgid "Apply over transparent areas"
 msgstr ""
 
-#: ../src/widgets/spray-toolbar.cpp:580 ../src/widgets/spray-toolbar.cpp:581
+#: ../src/widgets/spray-toolbar.cpp:578 ../src/widgets/spray-toolbar.cpp:579
 msgid "Apply over no transparent areas"
 msgstr ""
 
-#: ../src/widgets/spray-toolbar.cpp:593 ../src/widgets/spray-toolbar.cpp:594
+#: ../src/widgets/spray-toolbar.cpp:591 ../src/widgets/spray-toolbar.cpp:592
 msgid "Prevent overlapping objects"
 msgstr ""
 
-#: ../src/widgets/spray-toolbar.cpp:605
+#: ../src/widgets/spray-toolbar.cpp:603
 msgid "(minimum offset)"
 msgstr ""
 
-#: ../src/widgets/spray-toolbar.cpp:605
+#: ../src/widgets/spray-toolbar.cpp:603
 msgid "(maximum offset)"
 msgstr ""
 
-#: ../src/widgets/spray-toolbar.cpp:608
+#: ../src/widgets/spray-toolbar.cpp:606
 msgid "Offset %"
 msgstr ""
 
-#: ../src/widgets/spray-toolbar.cpp:608
+#: ../src/widgets/spray-toolbar.cpp:606
 msgid "Offset %:"
 msgstr ""
 
-#: ../src/widgets/spray-toolbar.cpp:609
+#: ../src/widgets/spray-toolbar.cpp:607
 msgid "Increase to segregate objects more (value in percent)"
 msgstr ""
 
@@ -30277,153 +30608,153 @@ msgstr ""
 msgid "Star: Change randomization"
 msgstr ""
 
-#: ../src/widgets/star-toolbar.cpp:461
+#: ../src/widgets/star-toolbar.cpp:473
 msgid "Regular polygon (with one handle) instead of a star"
 msgstr ""
 
-#: ../src/widgets/star-toolbar.cpp:468
+#: ../src/widgets/star-toolbar.cpp:480
 msgid "Star instead of a regular polygon (with one handle)"
 msgstr ""
 
-#: ../src/widgets/star-toolbar.cpp:489
+#: ../src/widgets/star-toolbar.cpp:501
 msgid "triangle/tri-star"
 msgstr ""
 
-#: ../src/widgets/star-toolbar.cpp:489
+#: ../src/widgets/star-toolbar.cpp:501
 msgid "square/quad-star"
 msgstr ""
 
-#: ../src/widgets/star-toolbar.cpp:489
+#: ../src/widgets/star-toolbar.cpp:501
 msgid "pentagon/five-pointed star"
 msgstr ""
 
-#: ../src/widgets/star-toolbar.cpp:489
+#: ../src/widgets/star-toolbar.cpp:501
 msgid "hexagon/six-pointed star"
 msgstr ""
 
-#: ../src/widgets/star-toolbar.cpp:492
+#: ../src/widgets/star-toolbar.cpp:504
 msgid "Corners"
 msgstr ""
 
-#: ../src/widgets/star-toolbar.cpp:492
+#: ../src/widgets/star-toolbar.cpp:504
 msgid "Corners:"
 msgstr ""
 
-#: ../src/widgets/star-toolbar.cpp:492
+#: ../src/widgets/star-toolbar.cpp:504
 msgid "Number of corners of a polygon or star"
 msgstr ""
 
-#: ../src/widgets/star-toolbar.cpp:505
+#: ../src/widgets/star-toolbar.cpp:517
 msgid "thin-ray star"
 msgstr ""
 
-#: ../src/widgets/star-toolbar.cpp:505
+#: ../src/widgets/star-toolbar.cpp:517
 msgid "pentagram"
 msgstr ""
 
-#: ../src/widgets/star-toolbar.cpp:505
+#: ../src/widgets/star-toolbar.cpp:517
 msgid "hexagram"
 msgstr ""
 
-#: ../src/widgets/star-toolbar.cpp:505
+#: ../src/widgets/star-toolbar.cpp:517
 msgid "heptagram"
 msgstr ""
 
-#: ../src/widgets/star-toolbar.cpp:505
+#: ../src/widgets/star-toolbar.cpp:517
 msgid "octagram"
 msgstr ""
 
-#: ../src/widgets/star-toolbar.cpp:505
+#: ../src/widgets/star-toolbar.cpp:517
 msgid "regular polygon"
 msgstr ""
 
-#: ../src/widgets/star-toolbar.cpp:508
+#: ../src/widgets/star-toolbar.cpp:520
 msgid "Spoke ratio"
 msgstr ""
 
-#: ../src/widgets/star-toolbar.cpp:508
+#: ../src/widgets/star-toolbar.cpp:520
 msgid "Spoke ratio:"
 msgstr ""
 
 #. TRANSLATORS: Tip radius of a star is the distance from the center to the farthest handle.
 #. Base radius is the same for the closest handle.
-#: ../src/widgets/star-toolbar.cpp:511
+#: ../src/widgets/star-toolbar.cpp:523
 msgid "Base radius to tip radius ratio"
 msgstr ""
 
-#: ../src/widgets/star-toolbar.cpp:529
+#: ../src/widgets/star-toolbar.cpp:541
 msgid "stretched"
 msgstr ""
 
-#: ../src/widgets/star-toolbar.cpp:529
+#: ../src/widgets/star-toolbar.cpp:541
 msgid "twisted"
 msgstr ""
 
-#: ../src/widgets/star-toolbar.cpp:529
+#: ../src/widgets/star-toolbar.cpp:541
 msgid "slightly pinched"
 msgstr ""
 
-#: ../src/widgets/star-toolbar.cpp:529
+#: ../src/widgets/star-toolbar.cpp:541
 msgid "NOT rounded"
 msgstr ""
 
-#: ../src/widgets/star-toolbar.cpp:529
+#: ../src/widgets/star-toolbar.cpp:541
 msgid "slightly rounded"
 msgstr ""
 
-#: ../src/widgets/star-toolbar.cpp:529
+#: ../src/widgets/star-toolbar.cpp:541
 msgid "visibly rounded"
 msgstr ""
 
-#: ../src/widgets/star-toolbar.cpp:529
+#: ../src/widgets/star-toolbar.cpp:541
 msgid "well rounded"
 msgstr ""
 
-#: ../src/widgets/star-toolbar.cpp:529
+#: ../src/widgets/star-toolbar.cpp:541
 msgid "amply rounded"
 msgstr ""
 
-#: ../src/widgets/star-toolbar.cpp:529 ../src/widgets/star-toolbar.cpp:544
+#: ../src/widgets/star-toolbar.cpp:541 ../src/widgets/star-toolbar.cpp:556
 msgid "blown up"
 msgstr ""
 
-#: ../src/widgets/star-toolbar.cpp:532
+#: ../src/widgets/star-toolbar.cpp:544
 msgid "Rounded:"
 msgstr ""
 
-#: ../src/widgets/star-toolbar.cpp:532
+#: ../src/widgets/star-toolbar.cpp:544
 msgid "How much rounded are the corners (0 for sharp)"
 msgstr ""
 
-#: ../src/widgets/star-toolbar.cpp:544
+#: ../src/widgets/star-toolbar.cpp:556
 msgid "NOT randomized"
 msgstr ""
 
-#: ../src/widgets/star-toolbar.cpp:544
+#: ../src/widgets/star-toolbar.cpp:556
 msgid "slightly irregular"
 msgstr ""
 
-#: ../src/widgets/star-toolbar.cpp:544
+#: ../src/widgets/star-toolbar.cpp:556
 msgid "visibly randomized"
 msgstr ""
 
-#: ../src/widgets/star-toolbar.cpp:544
+#: ../src/widgets/star-toolbar.cpp:556
 msgid "strongly randomized"
 msgstr ""
 
-#: ../src/widgets/star-toolbar.cpp:547
+#: ../src/widgets/star-toolbar.cpp:559
 msgid "Randomized"
 msgstr ""
 
-#: ../src/widgets/star-toolbar.cpp:547
+#: ../src/widgets/star-toolbar.cpp:559
 msgid "Randomized:"
 msgstr ""
 
-#: ../src/widgets/star-toolbar.cpp:547
+#: ../src/widgets/star-toolbar.cpp:559
 msgid "Scatter randomly the corners and angles"
 msgstr ""
 
-#: ../src/widgets/stroke-marker-selector.cpp:383
+#: ../src/widgets/stroke-marker-selector.cpp:369
 msgctxt "Marker"
 msgid "None"
 msgstr ""
@@ -30549,343 +30880,395 @@ msgstr ""
 msgid "Change swatch color"
 msgstr ""
 
-#: ../src/widgets/text-toolbar.cpp:178
+#: ../src/widgets/text-toolbar.cpp:182
 msgid "Text: Change font family"
 msgstr ""
 
-#: ../src/widgets/text-toolbar.cpp:272
+#: ../src/widgets/text-toolbar.cpp:276
 msgid "Text: Change font size"
 msgstr ""
 
-#: ../src/widgets/text-toolbar.cpp:317
+#: ../src/widgets/text-toolbar.cpp:321
 msgid "Text: Change font style"
 msgstr ""
 
-#: ../src/widgets/text-toolbar.cpp:356
+#: ../src/widgets/text-toolbar.cpp:360
 msgid "Text: Unset line height."
 msgstr ""
 
-#: ../src/widgets/text-toolbar.cpp:433
+#: ../src/widgets/text-toolbar.cpp:437
 msgid "Text: Change superscript or subscript"
 msgstr ""
 
-#: ../src/widgets/text-toolbar.cpp:574
+#: ../src/widgets/text-toolbar.cpp:578
 msgid "Text: Change alignment"
 msgstr ""
 
-#: ../src/widgets/text-toolbar.cpp:677
+#: ../src/widgets/text-toolbar.cpp:711
 msgid "Text: Change line-height"
 msgstr ""
 
-#: ../src/widgets/text-toolbar.cpp:832
+#: ../src/widgets/text-toolbar.cpp:875
 msgid "Text: Change line-height unit"
 msgstr ""
 
-#: ../src/widgets/text-toolbar.cpp:881
+#: ../src/widgets/text-toolbar.cpp:1055
+msgid "Text: Change line spacing mode"
+msgstr ""
+
+#: ../src/widgets/text-toolbar.cpp:1092
 msgid "Text: Change word-spacing"
 msgstr ""
 
-#: ../src/widgets/text-toolbar.cpp:921
+#: ../src/widgets/text-toolbar.cpp:1132
 msgid "Text: Change letter-spacing"
 msgstr ""
 
-#: ../src/widgets/text-toolbar.cpp:959
+#: ../src/widgets/text-toolbar.cpp:1170
 msgid "Text: Change dx (kern)"
 msgstr ""
 
-#: ../src/widgets/text-toolbar.cpp:993
+#: ../src/widgets/text-toolbar.cpp:1204
 msgid "Text: Change dy"
 msgstr ""
 
-#: ../src/widgets/text-toolbar.cpp:1028
+#: ../src/widgets/text-toolbar.cpp:1239
 msgid "Text: Change rotate"
 msgstr ""
 
-#: ../src/widgets/text-toolbar.cpp:1079
+#: ../src/widgets/text-toolbar.cpp:1290
 msgid "Text: Change writing mode"
 msgstr ""
 
-#: ../src/widgets/text-toolbar.cpp:1131
+#: ../src/widgets/text-toolbar.cpp:1344
 msgid "Text: Change orientation"
 msgstr ""
 
-#: ../src/widgets/text-toolbar.cpp:1177
+#: ../src/widgets/text-toolbar.cpp:1392
 msgid "Text: Change direction"
 msgstr ""
 
-#: ../src/widgets/text-toolbar.cpp:1690
+#: ../src/widgets/text-toolbar.cpp:1992
 msgid "Font Family"
 msgstr ""
 
-#: ../src/widgets/text-toolbar.cpp:1691
+#: ../src/widgets/text-toolbar.cpp:1993
 msgid "Select Font Family (Alt-X to access)"
 msgstr ""
 
 #. Focus widget
 #. Enable entry completion
-#: ../src/widgets/text-toolbar.cpp:1701
+#: ../src/widgets/text-toolbar.cpp:2003
 msgid "Select all text with this font-family"
 msgstr ""
 
-#: ../src/widgets/text-toolbar.cpp:1705
+#: ../src/widgets/text-toolbar.cpp:2007
 msgid "Font not found on system"
 msgstr ""
 
-#: ../src/widgets/text-toolbar.cpp:1763
+#: ../src/widgets/text-toolbar.cpp:2065
 msgid "Font Style"
 msgstr ""
 
-#: ../src/widgets/text-toolbar.cpp:1764
+#: ../src/widgets/text-toolbar.cpp:2066
 msgid "Font style"
 msgstr ""
 
 #. Name
-#: ../src/widgets/text-toolbar.cpp:1781
+#: ../src/widgets/text-toolbar.cpp:2083
 msgid "Toggle Superscript"
 msgstr ""
 
 #. Label
-#: ../src/widgets/text-toolbar.cpp:1782
+#: ../src/widgets/text-toolbar.cpp:2084
 msgid "Toggle superscript"
 msgstr ""
 
 #. Name
-#: ../src/widgets/text-toolbar.cpp:1794
+#: ../src/widgets/text-toolbar.cpp:2096
 msgid "Toggle Subscript"
 msgstr ""
 
 #. Label
-#: ../src/widgets/text-toolbar.cpp:1795
+#: ../src/widgets/text-toolbar.cpp:2097
 msgid "Toggle subscript"
 msgstr ""
 
-#: ../src/widgets/text-toolbar.cpp:1831
+#: ../src/widgets/text-toolbar.cpp:2133
 msgid "Justify"
 msgstr ""
 
 #. Name
-#: ../src/widgets/text-toolbar.cpp:1838
+#: ../src/widgets/text-toolbar.cpp:2140
 msgid "Alignment"
 msgstr ""
 
 #. Label
-#: ../src/widgets/text-toolbar.cpp:1839
+#: ../src/widgets/text-toolbar.cpp:2141
 msgid "Text alignment"
 msgstr ""
 
-#: ../src/widgets/text-toolbar.cpp:1868
+#: ../src/widgets/text-toolbar.cpp:2170
 msgid "Vertical — RL"
 msgstr ""
 
-#: ../src/widgets/text-toolbar.cpp:1869
+#: ../src/widgets/text-toolbar.cpp:2171
 msgid "Vertical text — lines: right to left"
 msgstr ""
 
-#: ../src/widgets/text-toolbar.cpp:1874
+#: ../src/widgets/text-toolbar.cpp:2176
 msgid "Vertical — LR"
 msgstr ""
 
-#: ../src/widgets/text-toolbar.cpp:1875
+#: ../src/widgets/text-toolbar.cpp:2177
 msgid "Vertical text — lines: left to right"
 msgstr ""
 
 #. Name
-#: ../src/widgets/text-toolbar.cpp:1881
+#: ../src/widgets/text-toolbar.cpp:2183
 msgid "Writing mode"
 msgstr ""
 
 #. Label
-#: ../src/widgets/text-toolbar.cpp:1882
+#: ../src/widgets/text-toolbar.cpp:2184
 msgid "Block progression"
 msgstr ""
 
-#: ../src/widgets/text-toolbar.cpp:1906
+#: ../src/widgets/text-toolbar.cpp:2208
 msgid "Auto glyph orientation"
 msgstr ""
 
-#: ../src/widgets/text-toolbar.cpp:1911
+#: ../src/widgets/text-toolbar.cpp:2213
 msgid "Upright"
 msgstr ""
 
-#: ../src/widgets/text-toolbar.cpp:1912
+#: ../src/widgets/text-toolbar.cpp:2214
 msgid "Upright glyph orientation"
 msgstr ""
 
-#: ../src/widgets/text-toolbar.cpp:1917
+#: ../src/widgets/text-toolbar.cpp:2219
 msgid "Sideways"
 msgstr ""
 
-#: ../src/widgets/text-toolbar.cpp:1918
+#: ../src/widgets/text-toolbar.cpp:2220
 msgid "Sideways glyph orientation"
 msgstr ""
 
 #. Name
-#: ../src/widgets/text-toolbar.cpp:1924
+#: ../src/widgets/text-toolbar.cpp:2226
 msgid "Text orientation"
 msgstr ""
 
 #. Label
-#: ../src/widgets/text-toolbar.cpp:1925
+#: ../src/widgets/text-toolbar.cpp:2227
 msgid "Text (glyph) orientation in vertical text."
 msgstr ""
 
-#: ../src/widgets/text-toolbar.cpp:1949
+#: ../src/widgets/text-toolbar.cpp:2251
 msgid "LTR"
 msgstr ""
 
-#: ../src/widgets/text-toolbar.cpp:1950
+#: ../src/widgets/text-toolbar.cpp:2252
 msgid "Left to right text"
 msgstr ""
 
-#: ../src/widgets/text-toolbar.cpp:1955
+#: ../src/widgets/text-toolbar.cpp:2257
 msgid "RTL"
 msgstr ""
 
-#: ../src/widgets/text-toolbar.cpp:1956
+#: ../src/widgets/text-toolbar.cpp:2258
 msgid "Right to left text"
 msgstr ""
 
 #. Name
-#: ../src/widgets/text-toolbar.cpp:1962
+#: ../src/widgets/text-toolbar.cpp:2264
 msgid "Text direction"
 msgstr ""
 
 #. Label
-#: ../src/widgets/text-toolbar.cpp:1963
+#: ../src/widgets/text-toolbar.cpp:2265
 msgid "Text direction for normally horizontal text."
 msgstr ""
 
 #. Drop down menu
-#: ../src/widgets/text-toolbar.cpp:1989
+#: ../src/widgets/text-toolbar.cpp:2291
 msgid "Smaller spacing"
 msgstr ""
 
-#: ../src/widgets/text-toolbar.cpp:1989 ../src/widgets/text-toolbar.cpp:2028
-#: ../src/widgets/text-toolbar.cpp:2059
+#: ../src/widgets/text-toolbar.cpp:2291 ../src/widgets/text-toolbar.cpp:2379
+#: ../src/widgets/text-toolbar.cpp:2410
 msgctxt "Text tool"
 msgid "Normal"
 msgstr ""
 
-#: ../src/widgets/text-toolbar.cpp:1989
+#: ../src/widgets/text-toolbar.cpp:2291
 msgid "Larger spacing"
 msgstr ""
 
 #. name
-#: ../src/widgets/text-toolbar.cpp:1994
+#: ../src/widgets/text-toolbar.cpp:2296
 msgid "Line Height"
 msgstr ""
 
 #. label
-#: ../src/widgets/text-toolbar.cpp:1995
+#: ../src/widgets/text-toolbar.cpp:2297
 msgid "Line:"
 msgstr ""
 
 #. short label
-#: ../src/widgets/text-toolbar.cpp:1996
+#: ../src/widgets/text-toolbar.cpp:2298
 msgid "Spacing between baselines"
 msgstr ""
 
+#: ../src/widgets/text-toolbar.cpp:2337
+msgid "Adaptive"
+msgstr ""
+
+#: ../src/widgets/text-toolbar.cpp:2338
+msgid "Line spacing adapts to font size."
+msgstr ""
+
+#: ../src/widgets/text-toolbar.cpp:2343
+#: ../share/extensions/polyhedron_3d.inx.h:54
+msgid "Minimum"
+msgstr ""
+
+#: ../src/widgets/text-toolbar.cpp:2344
+msgid "Line spacing adapts to fonts size with set minimum spacing."
+msgstr ""
+
+#: ../src/widgets/text-toolbar.cpp:2348
+msgid "Even"
+msgstr ""
+
+#: ../src/widgets/text-toolbar.cpp:2349
+msgid "Lines evenly spaced."
+msgstr ""
+
+#: ../src/widgets/text-toolbar.cpp:2354
+msgid "Adjustable ☠"
+msgstr ""
+
+#: ../src/widgets/text-toolbar.cpp:2355
+msgid "Line spacing fully adjustable"
+msgstr ""
+
+#. Name
+#: ../src/widgets/text-toolbar.cpp:2361
+msgid "Line Spacing Mode"
+msgstr ""
+
+#. Label
+#: ../src/widgets/text-toolbar.cpp:2362
+msgid ""
+"How should multiple baselines be spaced?\n"
+" Adaptive: Line spacing adapts to font size.\n"
+" Minimum: Like Adaptive, but with a set minimum.\n"
+" Even: Evenly spaced.\n"
+" Adjustable: No restrictions."
+msgstr ""
+
 #. Drop down menu
-#: ../src/widgets/text-toolbar.cpp:2028 ../src/widgets/text-toolbar.cpp:2059
+#: ../src/widgets/text-toolbar.cpp:2379 ../src/widgets/text-toolbar.cpp:2410
 msgid "Negative spacing"
 msgstr ""
 
-#: ../src/widgets/text-toolbar.cpp:2028 ../src/widgets/text-toolbar.cpp:2059
+#: ../src/widgets/text-toolbar.cpp:2379 ../src/widgets/text-toolbar.cpp:2410
 msgid "Positive spacing"
 msgstr ""
 
 #. name
-#: ../src/widgets/text-toolbar.cpp:2033
+#: ../src/widgets/text-toolbar.cpp:2384
 msgid "Word spacing"
 msgstr ""
 
 #. label
-#: ../src/widgets/text-toolbar.cpp:2034
+#: ../src/widgets/text-toolbar.cpp:2385
 msgid "Word:"
 msgstr ""
 
 #. short label
-#: ../src/widgets/text-toolbar.cpp:2035
+#: ../src/widgets/text-toolbar.cpp:2386
 msgid "Spacing between words (px)"
 msgstr ""
 
 #. name
-#: ../src/widgets/text-toolbar.cpp:2064
+#: ../src/widgets/text-toolbar.cpp:2415
 msgid "Letter spacing"
 msgstr ""
 
 #. label
-#: ../src/widgets/text-toolbar.cpp:2065
+#: ../src/widgets/text-toolbar.cpp:2416
 msgid "Letter:"
 msgstr ""
 
 #. short label
-#: ../src/widgets/text-toolbar.cpp:2066
+#: ../src/widgets/text-toolbar.cpp:2417
 msgid "Spacing between letters (px)"
 msgstr ""
 
 #. name
-#: ../src/widgets/text-toolbar.cpp:2095
+#: ../src/widgets/text-toolbar.cpp:2446
 msgid "Kerning"
 msgstr ""
 
 #. label
-#: ../src/widgets/text-toolbar.cpp:2096
+#: ../src/widgets/text-toolbar.cpp:2447
 msgid "Kern:"
 msgstr ""
 
 #. short label
-#: ../src/widgets/text-toolbar.cpp:2097
+#: ../src/widgets/text-toolbar.cpp:2448
 msgid "Horizontal kerning (px)"
 msgstr ""
 
 #. name
-#: ../src/widgets/text-toolbar.cpp:2126
+#: ../src/widgets/text-toolbar.cpp:2477
 msgid "Vertical Shift"
 msgstr ""
 
 #. label
-#: ../src/widgets/text-toolbar.cpp:2127
+#: ../src/widgets/text-toolbar.cpp:2478
 msgid "Vert:"
 msgstr ""
 
 #. short label
-#: ../src/widgets/text-toolbar.cpp:2128
+#: ../src/widgets/text-toolbar.cpp:2479
 msgid "Vertical shift (px)"
 msgstr ""
 
 #. name
-#: ../src/widgets/text-toolbar.cpp:2157
+#: ../src/widgets/text-toolbar.cpp:2508
 msgid "Letter rotation"
 msgstr ""
 
 #. label
-#: ../src/widgets/text-toolbar.cpp:2158
+#: ../src/widgets/text-toolbar.cpp:2509
 msgid "Rot:"
 msgstr ""
 
 #. short label
-#: ../src/widgets/text-toolbar.cpp:2159
+#: ../src/widgets/text-toolbar.cpp:2510
 msgid "Character rotation (degrees)"
 msgstr ""
 
 #. Name
-#: ../src/widgets/text-toolbar.cpp:2183
+#: ../src/widgets/text-toolbar.cpp:2534
 msgid "Unset line height"
 msgstr ""
 
 #. Label
-#: ../src/widgets/text-toolbar.cpp:2184
+#: ../src/widgets/text-toolbar.cpp:2535
 msgid "If enabled, line height is set on part of selection. Click to unset."
 msgstr ""
 
 #. Name
-#: ../src/widgets/text-toolbar.cpp:2196
+#: ../src/widgets/text-toolbar.cpp:2547
 msgid "Show outer style"
 msgstr ""
 
 #. Label
-#: ../src/widgets/text-toolbar.cpp:2197
+#: ../src/widgets/text-toolbar.cpp:2548
 msgid ""
 "Show style of outermost text element. The 'font-size' and 'line-height' "
 "values of the outermost text element determine the minimum line spacing in "
@@ -30936,131 +31319,131 @@ msgstr ""
 msgid "Style of Paint Bucket fill objects"
 msgstr ""
 
-#: ../src/widgets/toolbox.cpp:1245
+#: ../src/widgets/toolbox.cpp:1248
 msgid "Bounding box"
 msgstr ""
 
-#: ../src/widgets/toolbox.cpp:1245
+#: ../src/widgets/toolbox.cpp:1248
 msgid "Snap bounding boxes"
 msgstr ""
 
-#: ../src/widgets/toolbox.cpp:1254
+#: ../src/widgets/toolbox.cpp:1257
 msgid "Bounding box edges"
 msgstr ""
 
-#: ../src/widgets/toolbox.cpp:1254
+#: ../src/widgets/toolbox.cpp:1257
 msgid "Snap to edges of a bounding box"
 msgstr ""
 
-#: ../src/widgets/toolbox.cpp:1263
+#: ../src/widgets/toolbox.cpp:1266
 msgid "Bounding box corners"
 msgstr ""
 
-#: ../src/widgets/toolbox.cpp:1263
+#: ../src/widgets/toolbox.cpp:1266
 msgid "Snap bounding box corners"
 msgstr ""
 
-#: ../src/widgets/toolbox.cpp:1272
+#: ../src/widgets/toolbox.cpp:1275
 msgid "BBox Edge Midpoints"
 msgstr ""
 
-#: ../src/widgets/toolbox.cpp:1272
+#: ../src/widgets/toolbox.cpp:1275
 msgid "Snap midpoints of bounding box edges"
 msgstr ""
 
-#: ../src/widgets/toolbox.cpp:1282
+#: ../src/widgets/toolbox.cpp:1285
 msgid "BBox Centers"
 msgstr ""
 
-#: ../src/widgets/toolbox.cpp:1282
+#: ../src/widgets/toolbox.cpp:1285
 msgid "Snapping centers of bounding boxes"
 msgstr ""
 
-#: ../src/widgets/toolbox.cpp:1291
+#: ../src/widgets/toolbox.cpp:1294
 msgid "Snap nodes, paths, and handles"
 msgstr ""
 
-#: ../src/widgets/toolbox.cpp:1299
+#: ../src/widgets/toolbox.cpp:1302
 msgid "Snap to paths"
 msgstr ""
 
-#: ../src/widgets/toolbox.cpp:1308
+#: ../src/widgets/toolbox.cpp:1311
 msgid "Path intersections"
 msgstr ""
 
-#: ../src/widgets/toolbox.cpp:1308
+#: ../src/widgets/toolbox.cpp:1311
 msgid "Snap to path intersections"
 msgstr ""
 
-#: ../src/widgets/toolbox.cpp:1317
+#: ../src/widgets/toolbox.cpp:1320
 msgid "To nodes"
 msgstr ""
 
-#: ../src/widgets/toolbox.cpp:1317
+#: ../src/widgets/toolbox.cpp:1320
 msgid "Snap cusp nodes, incl. rectangle corners"
 msgstr ""
 
-#: ../src/widgets/toolbox.cpp:1326
+#: ../src/widgets/toolbox.cpp:1329
 msgid "Smooth nodes"
 msgstr ""
 
-#: ../src/widgets/toolbox.cpp:1326
+#: ../src/widgets/toolbox.cpp:1329
 msgid "Snap smooth nodes, incl. quadrant points of ellipses"
 msgstr ""
 
-#: ../src/widgets/toolbox.cpp:1335
+#: ../src/widgets/toolbox.cpp:1338
 msgid "Line Midpoints"
 msgstr ""
 
-#: ../src/widgets/toolbox.cpp:1335
+#: ../src/widgets/toolbox.cpp:1338
 msgid "Snap midpoints of line segments"
 msgstr ""
 
-#: ../src/widgets/toolbox.cpp:1344
+#: ../src/widgets/toolbox.cpp:1347
 msgid "Others"
 msgstr ""
 
-#: ../src/widgets/toolbox.cpp:1344
+#: ../src/widgets/toolbox.cpp:1347
 msgid "Snap other points (centers, guide origins, gradient handles, etc.)"
 msgstr ""
 
-#: ../src/widgets/toolbox.cpp:1352
+#: ../src/widgets/toolbox.cpp:1355
 msgid "Object Centers"
 msgstr ""
 
-#: ../src/widgets/toolbox.cpp:1352
+#: ../src/widgets/toolbox.cpp:1355
 msgid "Snap centers of objects"
 msgstr ""
 
-#: ../src/widgets/toolbox.cpp:1361
+#: ../src/widgets/toolbox.cpp:1364
 msgid "Rotation Centers"
 msgstr ""
 
-#: ../src/widgets/toolbox.cpp:1361
+#: ../src/widgets/toolbox.cpp:1364
 msgid "Snap an item's rotation center"
 msgstr ""
 
-#: ../src/widgets/toolbox.cpp:1370
+#: ../src/widgets/toolbox.cpp:1373
 msgid "Text baseline"
 msgstr ""
 
-#: ../src/widgets/toolbox.cpp:1370
+#: ../src/widgets/toolbox.cpp:1373
 msgid "Snap text anchors and baselines"
 msgstr ""
 
-#: ../src/widgets/toolbox.cpp:1380
+#: ../src/widgets/toolbox.cpp:1383
 msgid "Page border"
 msgstr ""
 
-#: ../src/widgets/toolbox.cpp:1380
+#: ../src/widgets/toolbox.cpp:1383
 msgid "Snap to the page border"
 msgstr ""
 
-#: ../src/widgets/toolbox.cpp:1389
+#: ../src/widgets/toolbox.cpp:1392
 msgid "Snap to grids"
 msgstr ""
 
-#: ../src/widgets/toolbox.cpp:1398
+#: ../src/widgets/toolbox.cpp:1401
 msgid "Snap guides"
 msgstr ""
 
@@ -31619,19 +32002,23 @@ msgstr ""
 msgid "Please select an object"
 msgstr ""
 
-#: ../share/extensions/gimp_xcf.py:37
+#: ../share/extensions/gimp_xcf.py:38
 msgid "Inkscape must be installed and set in your path variable."
 msgstr ""
 
-#: ../share/extensions/gimp_xcf.py:41
+#: ../share/extensions/gimp_xcf.py:42
 msgid "Gimp must be installed and set in your path variable."
 msgstr ""
 
-#: ../share/extensions/gimp_xcf.py:45
+#: ../share/extensions/gimp_xcf.py:46
 msgid "An error occurred while processing the XCF file."
 msgstr ""
 
-#: ../share/extensions/gimp_xcf.py:183
+#: ../share/extensions/gimp_xcf.py:92 ../share/extensions/inkex.py:358
+msgid "SVG Width not set correctly! Assuming width = 100"
+msgstr ""
+
+#: ../share/extensions/gimp_xcf.py:228
 msgid "This extension requires at least one non empty layer."
 msgstr ""
 
@@ -31659,7 +32046,7 @@ msgid ""
 msgstr ""
 
 #. issue error if no paths found
-#: ../share/extensions/hpgl_output.py:57
+#: ../share/extensions/hpgl_output.py:58
 msgid ""
 "No paths where found. Please convert all objects you want to save into paths."
 msgstr ""
@@ -31691,11 +32078,11 @@ msgstr ""
 msgid "No matching node for expression: %s"
 msgstr ""
 
-#: ../share/extensions/inkex.py:358
-msgid "SVG Width not set correctly! Assuming width = 100"
+#: ../share/extensions/interp_att_g.py:146
+msgid "You selected 'Other'. Please enter an attribute to interpolate."
 msgstr ""
 
-#: ../share/extensions/interp_att_g.py:175
+#: ../share/extensions/interp_att_g.py:182
 msgid "There is no selection to interpolate"
 msgstr ""
 
@@ -31926,66 +32313,69 @@ msgid ""
 "numpy."
 msgstr ""
 
-#: ../share/extensions/perspective.py:60 ../share/extensions/summersnight.py:49
+#: ../share/extensions/perspective.py:69 ../share/extensions/summersnight.py:58
 #, python-format
 msgid ""
 "The first selected object is of type '%s'.\n"
 "Try using the procedure Path->Object to Path."
 msgstr ""
 
-#: ../share/extensions/perspective.py:67 ../share/extensions/summersnight.py:57
+#: ../share/extensions/perspective.py:76 ../share/extensions/summersnight.py:66
 msgid ""
 "This extension requires that the second selected path be four nodes long."
 msgstr ""
 
-#: ../share/extensions/perspective.py:93 ../share/extensions/summersnight.py:90
+#: ../share/extensions/perspective.py:102
+#: ../share/extensions/summersnight.py:99
 msgid ""
 "The second selected object is a group, not a path.\n"
 "Try using the procedure Object->Ungroup."
 msgstr ""
 
-#: ../share/extensions/perspective.py:95 ../share/extensions/summersnight.py:92
+#: ../share/extensions/perspective.py:104
+#: ../share/extensions/summersnight.py:101
 msgid ""
 "The second selected object is not a path.\n"
 "Try using the procedure Path->Object to Path."
 msgstr ""
 
-#: ../share/extensions/perspective.py:98 ../share/extensions/summersnight.py:95
+#: ../share/extensions/perspective.py:107
+#: ../share/extensions/summersnight.py:104
 msgid ""
 "The first selected object is not a path.\n"
 "Try using the procedure Path->Object to Path."
 msgstr ""
 
 #. issue error if no paths found
-#: ../share/extensions/plotter.py:68
+#: ../share/extensions/plotter.py:69
 msgid ""
 "No paths where found. Please convert all objects you want to plot into paths."
 msgstr ""
 
-#: ../share/extensions/plotter.py:146
+#: ../share/extensions/plotter.py:147
 msgid "pySerial is not installed. Please follow these steps:"
 msgstr ""
 
-#: ../share/extensions/plotter.py:147
+#: ../share/extensions/plotter.py:148
 msgid "1. Download and extract (unzip) this file to your local harddisk:"
 msgstr ""
 
-#: ../share/extensions/plotter.py:149
+#: ../share/extensions/plotter.py:150
 msgid ""
 "2. Copy the \"serial\" folder (Can be found inside the just extracted folder)"
 msgstr ""
 
-#: ../share/extensions/plotter.py:150
+#: ../share/extensions/plotter.py:151
 msgid ""
 "   into the following Inkscape folder: C:\\[Program files]\\inkscape\\python"
 "\\Lib\\"
 msgstr ""
 
-#: ../share/extensions/plotter.py:151
+#: ../share/extensions/plotter.py:152
 msgid "3. Close and restart Inkscape."
 msgstr ""
 
-#: ../share/extensions/plotter.py:200
+#: ../share/extensions/plotter.py:201
 msgid ""
 "Could not open port. Please check that your plotter is running, connected "
 "and the settings are correct."
@@ -32212,7 +32602,7 @@ msgstr ""
 #: ../share/extensions/convert2dashes.inx.h:2
 #: ../share/extensions/edge3d.inx.h:9 ../share/extensions/flatten.inx.h:3
 #: ../share/extensions/fractalize.inx.h:4
-#: ../share/extensions/interp_att_g.inx.h:31
+#: ../share/extensions/interp_att_g.inx.h:34
 #: ../share/extensions/jitternodes.inx.h:14
 #: ../share/extensions/markers_strokepaint.inx.h:13
 #: ../share/extensions/perspective.inx.h:2
@@ -34638,7 +35028,7 @@ msgid "Check this to show movements between paths (Default: Unchecked)"
 msgstr ""
 
 #: ../share/extensions/hpgl_input.inx.h:9
-#: ../share/extensions/hpgl_output.inx.h:35
+#: ../share/extensions/hpgl_output.inx.h:37
 msgid "HP Graphics Language file (*.hpgl)"
 msgstr ""
 
@@ -34809,12 +35199,24 @@ msgstr ""
 
 #: ../share/extensions/hpgl_output.inx.h:34
 #: ../share/extensions/plotter.inx.h:64
+msgid "Convert objects to paths"
+msgstr ""
+
+#: ../share/extensions/hpgl_output.inx.h:35
+#: ../share/extensions/plotter.inx.h:65
+msgid ""
+"Check this to automatically (nondestructively) convert all objects to paths "
+"before plotting (Default: Checked)"
+msgstr ""
+
+#: ../share/extensions/hpgl_output.inx.h:36
+#: ../share/extensions/plotter.inx.h:66
 msgid ""
 "All these settings depend on the plotter you use, for more information "
 "please consult the manual or homepage for your plotter."
 msgstr ""
 
-#: ../share/extensions/hpgl_output.inx.h:36
+#: ../share/extensions/hpgl_output.inx.h:38
 msgid "Export an HP Graphics Language file"
 msgstr ""
 
@@ -34985,11 +35387,11 @@ msgstr ""
 msgid "Interpolate style"
 msgstr ""
 
-#: ../share/extensions/interp.inx.h:7 ../share/extensions/interp_att_g.inx.h:10
+#: ../share/extensions/interp.inx.h:7 ../share/extensions/interp_att_g.inx.h:12
 msgid "Use Z-order"
 msgstr ""
 
-#: ../share/extensions/interp.inx.h:8 ../share/extensions/interp_att_g.inx.h:11
+#: ../share/extensions/interp.inx.h:8 ../share/extensions/interp_att_g.inx.h:13
 msgid "Workaround for reversed selection order in Live Preview cycles"
 msgstr ""
 
@@ -35006,70 +35408,83 @@ msgid "Other Attribute:"
 msgstr ""
 
 #: ../share/extensions/interp_att_g.inx.h:5
-msgid "Other Attribute type:"
+msgid "Examples: r, width, inkscape:rounded, sodipodi:sides"
 msgstr ""
 
 #: ../share/extensions/interp_att_g.inx.h:6
-msgid "Apply to:"
+msgid "Other Attribute type:"
 msgstr ""
 
 #: ../share/extensions/interp_att_g.inx.h:7
-msgid "Start Value:"
+msgid "Apply to:"
 msgstr ""
 
 #: ../share/extensions/interp_att_g.inx.h:8
+msgid "Start Value:"
+msgstr ""
+
+#: ../share/extensions/interp_att_g.inx.h:9
+msgid "Examples: 0.5, 5, #rgb, #rrggbb or r, g, b"
+msgstr ""
+
+#: ../share/extensions/interp_att_g.inx.h:10
 msgid "End Value:"
 msgstr ""
 
-#: ../share/extensions/interp_att_g.inx.h:15
+#: ../share/extensions/interp_att_g.inx.h:17
 msgid "Translate X"
 msgstr ""
 
-#: ../share/extensions/interp_att_g.inx.h:16
+#: ../share/extensions/interp_att_g.inx.h:18
 msgid "Translate Y"
 msgstr ""
 
-#: ../share/extensions/interp_att_g.inx.h:17
+#: ../share/extensions/interp_att_g.inx.h:19
 #: ../share/extensions/markers_strokepaint.inx.h:9
 msgid "Fill"
 msgstr ""
 
-#: ../share/extensions/interp_att_g.inx.h:19
+#: ../share/extensions/interp_att_g.inx.h:21
 msgid "Other"
 msgstr ""
 
-#: ../share/extensions/interp_att_g.inx.h:20
-msgid ""
-"If you select \"Other\", you must know the SVG attributes to identify here "
-"this \"other\"."
-msgstr ""
-
 #: ../share/extensions/interp_att_g.inx.h:22
-msgid "Integer Number"
+msgid "Other Attribute"
 msgstr ""
 
 #: ../share/extensions/interp_att_g.inx.h:23
-msgid "Float Number"
+msgid ""
+"If you selected \"Other\" above, you must specify the details for this "
+"\"other\" here."
 msgstr ""
 
 #: ../share/extensions/interp_att_g.inx.h:25
+msgid "Integer Number"
+msgstr ""
+
+#: ../share/extensions/interp_att_g.inx.h:26
+msgid "Float Number"
+msgstr ""
+
+#: ../share/extensions/interp_att_g.inx.h:28
 #: ../share/extensions/polyhedron_3d.inx.h:33
 msgid "Style"
 msgstr ""
 
-#: ../share/extensions/interp_att_g.inx.h:26
+#: ../share/extensions/interp_att_g.inx.h:29
 msgid "Transformation"
 msgstr ""
 
-#: ../share/extensions/interp_att_g.inx.h:27
-msgid "••••••••••••••••••••••••••••••••••••••••••••••••"
+#: ../share/extensions/interp_att_g.inx.h:30
+#: ../share/extensions/nicechart.inx.h:38
+msgid "Values"
 msgstr ""
 
-#: ../share/extensions/interp_att_g.inx.h:28
+#: ../share/extensions/interp_att_g.inx.h:31
 msgid "No Unit"
 msgstr ""
 
-#: ../share/extensions/interp_att_g.inx.h:30
+#: ../share/extensions/interp_att_g.inx.h:33
 msgid ""
 "This effect applies a value for any interpolatable attribute for all "
 "elements inside the selected group or for all elements in a multiple "
@@ -35391,7 +35806,7 @@ msgstr ""
 
 #: ../share/extensions/jessyInk_keyBindings.inx.h:45
 msgid ""
-"This extension allows you customise the key bindings JessyInk uses. Please "
+"This extension allows you customize the key bindings JessyInk uses. Please "
 "see code.google.com/p/jessyink for more details."
 msgstr ""
 
@@ -35432,7 +35847,7 @@ msgstr ""
 
 #: ../share/extensions/jessyInk_mouseHandler.inx.h:7
 msgid ""
-"This extension allows you customise the mouse handler JessyInk uses. Please "
+"This extension allows you customize the mouse handler JessyInk uses. Please "
 "see code.google.com/p/jessyink for more details."
 msgstr ""
 
@@ -36100,10 +36515,6 @@ msgstr ""
 msgid "SAP"
 msgstr ""
 
-#: ../share/extensions/nicechart.inx.h:38
-msgid "Values"
-msgstr ""
-
 #: ../share/extensions/nicechart.inx.h:39
 msgid "Show values"
 msgstr ""
@@ -36721,10 +37132,6 @@ msgstr ""
 
 #: ../share/extensions/polyhedron_3d.inx.h:53
 msgid "Maximum"
-msgstr ""
-
-#: ../share/extensions/polyhedron_3d.inx.h:54
-msgid "Minimum"
 msgstr ""
 
 #: ../share/extensions/polyhedron_3d.inx.h:55
@@ -38407,45 +38814,49 @@ msgid "_Color display mode"
 msgstr ""
 
 #: ../share/ui/menus.xml.h:10
-msgid "Sh_ow/Hide"
+msgid "_Canvas orientation"
 msgstr ""
 
 #: ../share/ui/menus.xml.h:11
-msgid "_Layer"
+msgid "Sh_ow/Hide"
 msgstr ""
 
 #: ../share/ui/menus.xml.h:12
-msgid "_Object"
+msgid "_Layer"
 msgstr ""
 
 #: ../share/ui/menus.xml.h:13
-msgid "Cli_p"
+msgid "_Object"
 msgstr ""
 
 #: ../share/ui/menus.xml.h:14
-msgid "Mas_k"
+msgid "Cli_p"
 msgstr ""
 
 #: ../share/ui/menus.xml.h:15
-msgid "Patter_n"
+msgid "Mas_k"
 msgstr ""
 
 #: ../share/ui/menus.xml.h:16
+msgid "Patter_n"
+msgstr ""
+
+#: ../share/ui/menus.xml.h:17
 msgid "_Path"
 msgstr ""
 
-#: ../share/ui/menus.xml.h:18
+#: ../share/ui/menus.xml.h:19
 msgid "Filter_s"
 msgstr ""
 
-#: ../share/ui/menus.xml.h:19
+#: ../share/ui/menus.xml.h:20
 msgid "Exte_nsions"
 msgstr ""
 
-#: ../share/ui/menus.xml.h:20
+#: ../share/ui/menus.xml.h:21
 msgid "_Help"
 msgstr ""
 
-#: ../share/ui/menus.xml.h:21
+#: ../share/ui/menus.xml.h:22
 msgid "Tutorials"
 msgstr ""


### PR DESCRIPTION
Mmmh, irgendwas ist hier komisch, das diff, das mir hier angezeigt wird, scheint irgendwie zu einer veralteten Version zu gehören - master sieht anders aus.

Z.B. 
Zeile 349:
#: ../src/ui/dialog/inkscape-preferences.cpp:451
ist bereits in master so enthalten. Hier im diff sagt es, die Vorversion (also master) wäre hier 
#: ../src/ui/dialog/inkscape-preferences.cpp:433

Gibt es irgendwas, was ich da machen kann? Oder ist das ein github-Problem?...

